### PR TITLE
Upgraded CI postgres image version from 11 to 12

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,7 +13,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:11 # postgres image for test database.
+        image: postgres:12 # postgres image for test database.
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
### Changes include:

- Upgraded Postgres image version from 11 to 12 in Github action for CI.