### PR TITLE
Feature/receive message workflow

### DIFF
--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -86,7 +86,7 @@ defmodule Glific.Communications.Message do
   end
 
   @doc """
-  Callback when we receive a message form whats app
+  Callback when we receive a message from whats app
   """
   @spec receive_message(map(), atom()) :: {:ok} | {:error, String.t()}
   def receive_message(message_params, type \\ :text) do

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -88,7 +88,7 @@ defmodule Glific.Communications.Message do
   @doc """
   Callback when we receive a message form whats app
   """
-  @spec receive_message(map(), atom()) :: {:ok}
+  @spec receive_message(map(), atom()) :: {:ok} | {:error, String.t()}
   def receive_message(message_params, type \\ :text) do
     {:ok, contact} =
       Contacts.upsert(message_params.sender)
@@ -107,7 +107,7 @@ defmodule Glific.Communications.Message do
       type in [:video, :audio, :image, :document] -> receive_media(message_params)
       type == :text -> receive_text(message_params)
       # For location and address messages, will add that when there will be a use case
-      true -> {:ok}
+      true -> {:error, "Message type not supported"}
     end
   end
 

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -88,13 +88,14 @@ defmodule Glific.Communications.Message do
   @doc """
   Callback when we receive a message form whats app
   """
-  @spec receive_message(map(), atom()) :: {:ok }
+  @spec receive_message(map(), atom()) :: {:ok}
   def receive_message(message_params, type \\ :text) do
     {:ok, contact} =
       Contacts.upsert(message_params.sender)
       |> Contacts.update_contact(%{last_message_at: DateTime.utc_now()})
 
-      message_params = message_params
+    message_params =
+      message_params
       |> Map.merge(%{
         type: type,
         sender_id: contact.id,
@@ -102,36 +103,36 @@ defmodule Glific.Communications.Message do
         flow: :inbound
       })
 
-      cond do
-        type in [:video, :audio, :image, :document] -> receive_media(message_params)
-        type == :text -> receive_text(message_params)
-        # For location and address messages, will add that when there will be a use case
-        true  -> {:ok }
-      end
+    cond do
+      type in [:video, :audio, :image, :document] -> receive_media(message_params)
+      type == :text -> receive_text(message_params)
+      # For location and address messages, will add that when there will be a use case
+      true -> {:ok}
+    end
   end
 
-
-  #handler for receiving the text message
-  @spec receive_text(map()) :: {:ok }
+  # handler for receiving the text message
+  @spec receive_text(map()) :: {:ok}
   defp receive_text(message_params) do
     message_params
     |> Messages.create_message()
     |> Communications.publish_data(:received_message)
     |> Producer.add()
 
-    {:ok }
+    {:ok}
   end
 
-
-  #handler for receiving the media (image|video|audio|document)  message
-  @spec receive_media(map()) :: {:ok }
+  # handler for receiving the media (image|video|audio|document)  message
+  @spec receive_media(map()) :: {:ok}
   defp receive_media(message_params) do
     {:ok, message_media} = Messages.create_message_media(message_params)
+
     message_params
     |> Map.put(:media_id, message_media.id)
     |> Messages.create_message()
     |> Communications.publish_data(:received_message)
-    {:ok }
+
+    {:ok}
   end
 
   @doc false

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -123,7 +123,7 @@ defmodule Glific.Communications.Message do
   end
 
 
-  #handler for receiving the media (image|video|audio)  message
+  #handler for receiving the media (image|video|audio|document)  message
   @spec receive_media(map()) :: {:ok }
   defp receive_media(message_params) do
     {:ok, message_media} = Messages.create_message_media(message_params)

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -194,10 +194,7 @@ defmodule Glific.Templates do
       Glific.Messages.get_message!(message_id)
       |> Repo.preload([:contact])
 
-    Map.merge(
-      %{body: message.body, type: message.type, language_id: message.contact.language_id},
-      input
-    )
+    Map.merge(%{body: message.body, type: message.type}, input)
     |> create_session_template()
   end
 end

--- a/lib/glific_web/providers/gupshup/controllers/message_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_controller.ex
@@ -51,7 +51,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
 
   @doc false
   # Handle Gupshup media message and convert them into Glific Message struct
-  @spec media(Plug.Conn.t(), map(), map()) :: Plug.Conn.t()
+  @spec media(Plug.Conn.t(), map(), atom()) :: Plug.Conn.t()
   defp media(conn, params, type) do
     GupshupMessage.receive_media(params)
     |> Communications.receive_message(type)

--- a/lib/glific_web/providers/gupshup/controllers/message_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_controller.ex
@@ -20,7 +20,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   @spec text(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def text(conn, params) do
     GupshupMessage.receive_text(params)
-    |> Communications.receive_text()
+    |> Communications.receive_message()
 
     handler(conn, params, "text handler")
   end
@@ -29,33 +29,32 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   Callback for gupshup image images
   """
   @spec image(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def image(conn, params), do: media(conn, params, %{type: :image})
+  def image(conn, params), do: media(conn, params, :image)
 
   @doc """
   Callback file gupshup image images
   """
   @spec file(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def file(conn, params), do: media(conn, params, %{type: :document})
+  def file(conn, params), do: media(conn, params, :document)
 
   @doc """
   Callback audio gupshup image images
   """
   @spec audio(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def audio(conn, params), do: media(conn, params, %{type: :audio})
+  def audio(conn, params), do: media(conn, params, :audio)
 
   @doc """
   Callback video gupshup image images
   """
   @spec video(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def video(conn, params), do: media(conn, params, %{type: :video})
+  def video(conn, params), do: media(conn, params, :video)
 
   @doc false
   # Handle Gupshup media message and convert them into Glific Message struct
   @spec media(Plug.Conn.t(), map(), map()) :: Plug.Conn.t()
   defp media(conn, params, type) do
     GupshupMessage.receive_media(params)
-    |> Map.merge(type)
-    |> Communications.receive_media()
+    |> Communications.receive_message(type)
 
     handler(conn, params, "media handler")
   end

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -72,7 +72,6 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :body, :string
     field :type, :message_types_enum
     field :shortcode, :string
-    field :is_reserved, :boolean
     field :is_active, :boolean
     field :is_source, :boolean
     field :language_id, :id


### PR DESCRIPTION
Remove contact language id from the session template
Remove is_reserved field from the session template
Setup a single function for receiving the message. All other helper functions to receive the message will be called form a single place. 
