### PR TITLE
Conversation API issues with exclude tag filter

### DIFF
--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -507,7 +507,7 @@ defmodule Glific.Messages do
       {:exclude_tags, tag_ids}, query ->
         query
         |> join(:left, [m], mt in MessageTag, on: m.id == mt.message_id)
-        |> where([m, mt], mt.tag_id not in ^tag_ids)
+        |> where([m, mt], mt.tag_id not in ^tag_ids or is_nil(mt.tag_id))
     end)
   end
 


### PR DESCRIPTION
Currently, if we filter the conversation using exclude tag filter it did not return any results if there is no entry in the message_tag table. 