### PR TITLE
(#161) send message to provider

### DIFF
--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -39,7 +39,7 @@ defmodule Glific.Communications.Message do
       apply(provider_module(), @type_to_token[message.type], [message])
       {:ok, Communications.publish_data(message, :sent_message)}
     else
-      Messages.update_message(message, %{status: :error, provider_status: nil})
+      Messages.update_message(message, %{status: :contact_opt_out, provider_status: nil})
       {:error, "Can not send the message to the contact."}
     end
   end
@@ -57,7 +57,7 @@ defmodule Glific.Communications.Message do
     |> Messages.update_message(%{
       provider_message_id: body["messageId"],
       provider_status: :enqueued,
-      status: :enqueued,
+      status: :sent,
       flow: :outbound,
       sent_at: DateTime.truncate(DateTime.utc_now(), :second)
     })
@@ -73,7 +73,11 @@ defmodule Glific.Communications.Message do
     message
     |> Poison.encode!()
     |> Poison.decode!(as: %Message{})
-    |> Messages.update_message(%{provider_status: :error, status: :error, flow: :outbound})
+    |> Messages.update_message(%{
+      provider_status: :error,
+      status: :sent,
+      flow: :outbound
+    })
 
     {:error, response.body}
   end

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -39,6 +39,7 @@ defmodule Glific.Communications.Message do
       apply(provider_module(), @type_to_token[message.type], [message])
       {:ok, Communications.publish_data(message, :sent_message)}
     else
+      Messages.update_message(message, %{status: :error, provider_status: nil})
       {:error, "Can not send the message to the contact."}
     end
   end
@@ -100,7 +101,8 @@ defmodule Glific.Communications.Message do
         type: type,
         sender_id: contact.id,
         receiver_id: organization_contact_id(),
-        flow: :inbound
+        flow: :inbound,
+        provider_status: :delivered
       })
 
     cond do

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -57,6 +57,7 @@ defmodule Glific.Communications.Message do
     |> Messages.update_message(%{
       provider_message_id: body["messageId"],
       provider_status: :enqueued,
+      status: :enqueued,
       flow: :outbound,
       sent_at: DateTime.truncate(DateTime.utc_now(), :second)
     })
@@ -72,7 +73,7 @@ defmodule Glific.Communications.Message do
     message
     |> Poison.encode!()
     |> Poison.decode!(as: %Message{})
-    |> Messages.update_message(%{provider_status: :error, flow: :outbound})
+    |> Messages.update_message(%{provider_status: :error, status: :error, flow: :outbound})
 
     {:error, response.body}
   end
@@ -102,7 +103,8 @@ defmodule Glific.Communications.Message do
         sender_id: contact.id,
         receiver_id: organization_contact_id(),
         flow: :inbound,
-        provider_status: :delivered
+        provider_status: :delivered,
+        status: :delivered
       })
 
     cond do

--- a/lib/glific/enums/constants/enums.ex
+++ b/lib/glific/enums/constants/enums.ex
@@ -17,7 +17,15 @@ defmodule Glific.Enums.Constants do
       @message_flow_const [:inbound, :outbound]
 
       # the status of the message as indicated by the provider
-      @message_status_const [:sent, :delivered, :enqueued, :error, :read, :received, :contact_opt_out]
+      @message_status_const [
+        :sent,
+        :delivered,
+        :enqueued,
+        :error,
+        :read,
+        :received,
+        :contact_opt_out
+      ]
 
       # the different possible types of message
       @message_types_const [:audio, :contact, :document, :hsm, :image, :location, :text, :video]

--- a/lib/glific/enums/constants/enums.ex
+++ b/lib/glific/enums/constants/enums.ex
@@ -17,7 +17,7 @@ defmodule Glific.Enums.Constants do
       @message_flow_const [:inbound, :outbound]
 
       # the status of the message as indicated by the provider
-      @message_status_const [:sent, :delivered, :enqueued, :error, :read, :received]
+      @message_status_const [:sent, :delivered, :enqueued, :error, :read, :received, :contact_opt_out]
 
       # the different possible types of message
       @message_types_const [:audio, :contact, :document, :hsm, :image, :location, :text, :video]

--- a/lib/glific/enums/enums.ex
+++ b/lib/glific/enums/enums.ex
@@ -23,7 +23,7 @@ defmodule Glific.Enums do
   [:inbound, :outbound]
 
   iex> Glific.Enums.message_status_const()
-  [:sent, :delivered, :enqueued, :error, :read, :received]
+  [:sent, :delivered, :enqueued, :error, :read, :received, :contact_opt_out]
 
   iex> Glific.Enums.message_types_const()
   [:audio, :contact, :document, :hsm, :image, :location, :text, :video]

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -143,7 +143,7 @@ defmodule Glific.Messages do
   @spec create_message(map()) :: {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
   def create_message(attrs) do
     attrs =
-      %{flow: :inbound, provider_status: :delivered}
+      %{flow: :inbound, status: :enqueued}
       |> Map.merge(attrs)
       |> put_contact_id()
 

--- a/lib/glific/messages/message.ex
+++ b/lib/glific/messages/message.ex
@@ -12,6 +12,7 @@ defmodule Glific.Messages.Message do
           id: non_neg_integer | nil,
           type: String.t() | nil,
           flow: String.t() | nil,
+          status: String.t() | nil,
           provider_status: String.t() | nil,
           message_number: integer(),
           sender: Contact.t() | Ecto.Association.NotLoaded.t() | nil,
@@ -34,6 +35,7 @@ defmodule Glific.Messages.Message do
   ]
   @optional_fields [
     :body,
+    :status,
     :provider_status,
     :provider_message_id,
     :media_id,
@@ -44,6 +46,8 @@ defmodule Glific.Messages.Message do
     field :body, :string
     field :flow, MessageFlow
     field :type, MessageTypes
+    field :status, MessageStatus
+
     field :provider_message_id, :string
     field :provider_status, MessageStatus
     field :sent_at, :utc_datetime

--- a/lib/glific_web/schema/message_type.ex
+++ b/lib/glific_web/schema/message_type.ex
@@ -71,9 +71,6 @@ defmodule GlificWeb.Schema.MessageTypes do
     field :body, :string
     field :type, :message_types_enum
     field :flow, :message_flow_enum
-    field :provider_message_id, :string
-
-    field :provider_status, :message_status_enum
 
     field :sender_id, :id
     field :receiver_id, :id

--- a/priv/repo/migrations/20200601193405_create_glific_tables.exs
+++ b/priv/repo/migrations/20200601193405_create_glific_tables.exs
@@ -222,6 +222,10 @@ defmodule Glific.Repo.Migrations.GlificTables do
       # Options are: inbound, outbound
       add :flow, :message_flow_enum
 
+      # this is our status, It will tell us that
+      # message got created but could not send because contact has optout
+      add :status, :message_status_enum, null: false, default: "enqueued"
+
       # whats app message id
       add :provider_message_id, :string, null: true
 

--- a/test/glific/communications_test.exs
+++ b/test/glific/communications_test.exs
@@ -187,7 +187,7 @@ defmodule Glific.CommunicationsTest do
       assert message.flow == :outbound
     end
 
-    test "sending message to contact having invalid status will return error" do
+    test "sending message to optout contact will return error" do
       {:ok, receiver} =
         @receiver_attrs
         |> Map.merge(%{status: :invalid, phone: Phone.EnUs.phone()})
@@ -195,6 +195,10 @@ defmodule Glific.CommunicationsTest do
 
       message = message_fixture(%{receiver_id: receiver.id})
       assert {:error, _msg} = Communications.send_message(message)
+
+      message = Messages.get_message!(message.id)
+      assert message.status == :contact_opt_out
+      assert message.provider_status == nil
     end
 
     test "sending message to contact having invalid provider status will return error" do

--- a/test/glific_web/schema/message_test.exs
+++ b/test/glific_web/schema/message_test.exs
@@ -122,8 +122,7 @@ defmodule GlificWeb.Schema.MessageTest do
   end
 
   test "create a message and test possible scenarios and errors" do
-    body = "Default message body"
-    {:ok, message} = Glific.Repo.fetch_by(Message, %{body: body})
+    [message | _ ] = Glific.Messages.list_messages()
 
     result =
       query_gql_by(:create,
@@ -134,7 +133,6 @@ defmodule GlificWeb.Schema.MessageTest do
             "receiverId" => message.receiver_id,
             "senderId" => message.sender_id,
             "type" => "TEXT",
-            "providerStatus" => "DELIVERED"
           }
         }
       )
@@ -149,8 +147,7 @@ defmodule GlificWeb.Schema.MessageTest do
           "input" => %{
             "body" => "Message body",
             "flow" => "OUTBOUND",
-            "type" => "TEXT",
-            "providerStatus" => "DELIVERED"
+            "type" => "TEXT"
           }
         }
       )
@@ -216,8 +213,7 @@ defmodule GlificWeb.Schema.MessageTest do
             "body" => "Message body",
             "flow" => "OUTBOUND",
             "type" => "TEXT",
-            "sender_id" => Glific.Communications.Message.organization_contact_id(),
-            "providerStatus" => "DELIVERED"
+            "sender_id" => Glific.Communications.Message.organization_contact_id()
           },
           "contact_ids" => [contact1.id, contact2.id]
         }

--- a/test/glific_web/schema/message_test.exs
+++ b/test/glific_web/schema/message_test.exs
@@ -122,7 +122,7 @@ defmodule GlificWeb.Schema.MessageTest do
   end
 
   test "create a message and test possible scenarios and errors" do
-    [message | _ ] = Glific.Messages.list_messages()
+    [message | _] = Glific.Messages.list_messages()
 
     result =
       query_gql_by(:create,
@@ -132,7 +132,7 @@ defmodule GlificWeb.Schema.MessageTest do
             "flow" => "OUTBOUND",
             "receiverId" => message.receiver_id,
             "senderId" => message.sender_id,
-            "type" => "TEXT",
+            "type" => "TEXT"
           }
         }
       )


### PR DESCRIPTION
#161 
- Added new enum for message status
- Added new field status in message schema
- Removed provider_id and provider_status from graphql message input and updated test cases for that
- Doctest update for message status enum
- Communication test while sending the message to the output contact