### PR TITLE
Validate phone API

### DIFF
--- a/api.docs/includes/_auth.md
+++ b/api.docs/includes/_auth.md
@@ -7,6 +7,35 @@ include roles and permissions. User management will be done via GraphQL
 
 The main API endpoints are listed below
 
+# Send a request to validate a phone number
+
+It would respond with error message if phone number is invalid
+
+```shell
+curl -X POST -d \
+  "user[phone]=911234554321" \
+  http://YOUR_HOSTNAME_AND_PORT/api/v1/registration/validate_phone
+```
+```javascript
+If you are using axios or other libraries, send the following in the BODY of a POST request
+
+{
+    "user": {
+        "phone": "911234554321"
+    }
+}
+```
+> The above query returns JSON structured like this:
+
+```json
+{
+    "data": {
+        "is_valid": "false",
+        "message": "Phone number already exists"
+    }
+}
+```
+
 # Send an OTP request to verify a phone number
 
 The OTP will be sent via WhatsApp and the NGO's Glific Instance. The API will only send

--- a/api.docs/includes/_auth.md
+++ b/api.docs/includes/_auth.md
@@ -30,7 +30,7 @@ If you are using axios or other libraries, send the following in the BODY of a P
 ```json
 {
     "data": {
-        "is_valid": "false",
+        "is_valid": false,
         "message": "Phone number already exists"
     }
 }

--- a/api.docs/includes/_auth.md
+++ b/api.docs/includes/_auth.md
@@ -9,7 +9,7 @@ The main API endpoints are listed below
 
 # Send a request to validate a phone number
 
-It would respond with error message if phone number is invalid
+It would respond with error message if a user with phone number already exists
 
 ```shell
 curl -X POST -d \

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,7 +47,15 @@ config :glific, :pow,
   repo: Glific.Repo
 
 config :passwordless_auth,
-  sms_adapter: Glific.Providers.Gupshup
+  sms_adapter: Glific.Providers.Gupshup,
+  # seconds; optional (defaults to 30 if not provided)
+  garbage_collector_frequency: 30,
+  # optional (defaults to 5 if not provided)
+  num_attempts_before_timeout: 5,
+  # seconds; optional (defaults to 60 if not provided)
+  rate_limit_timeout_length: 60,
+  # seconds, optional (defaults to 300 if not provided)
+  verification_code_ttl: 300
 
 # Sentry configuration
 

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -201,6 +201,7 @@ defmodule Glific.Contacts do
     upsert(%{
       phone: phone,
       optout_time: utc_time,
+      optin_time: nil,
       status: :invalid,
       provider_status: :invalid,
       updated_at: DateTime.utc_now()
@@ -226,10 +227,8 @@ defmodule Glific.Contacts do
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()
   def can_send_hsm_message_to?(contact) do
-    with true <- contact.status == :valid,
-         true <- contact.provider_status == :valid,
+    with [contact.status, contact.provider_status] == [:valid, :valid]
          true <- contact.optin_time != nil,
-         true <- contact.optout_time == nil,
          do: true
   end
 

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -226,8 +226,7 @@ defmodule Glific.Contacts do
   """
   @spec is_opted_in?(Contact.t()) :: boolean()
   def is_opted_in?(contact) do
-    with true <- contact.status == :valid,
-         true <- contact.provider_status == :valid,
+    with [:valid, :valid] <- [contact.status, contact.provider_status],
          true <- contact.optin_time != nil,
          true <- contact.optout_time == nil,
          do: true

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -222,6 +222,18 @@ defmodule Glific.Contacts do
   end
 
   @doc """
+  Check if contact has opted in
+  """
+  @spec is_opted_in?(Contact.t()) :: boolean()
+  def is_opted_in?(contact) do
+    with true <- contact.status == :valid,
+         true <- contact.provider_status == :valid,
+         true <- contact.optin_time != nil,
+         true <- contact.optout_time == nil,
+         do: true
+  end
+
+  @doc """
   Check if we can send a hsm message to the contact
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -184,6 +184,7 @@ defmodule Glific.Contacts do
     upsert(%{
       phone: phone,
       optin_time: utc_time,
+      last_message_at: utc_time,
       optout_time: nil,
       status: :valid,
       provider_status: :valid

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -227,10 +227,13 @@ defmodule Glific.Contacts do
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()
   def can_send_hsm_message_to?(contact) do
-    with true <- contact.status == :valid,
-         true <- contact.provider_status == :valid,
-         true <- contact.optin_time != nil,
-         do: true
+    with :valid <- contact.status,
+         :valid <- contact.provider_status,
+         true <- contact.optin_time != nil do
+      true
+    else
+      _ -> false
+    end
   end
 
   @doc """

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -227,7 +227,8 @@ defmodule Glific.Contacts do
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()
   def can_send_hsm_message_to?(contact) do
-    with [:valid, :valid] <- [contact.status, contact.provider_status],
+    with true <- contact.status == :valid,
+         true <- contact.provider_status == :valid,
          true <- contact.optin_time != nil,
          do: true
   end

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -216,10 +216,13 @@ defmodule Glific.Contacts do
   @spec can_send_message_to?(Contact.t()) :: boolean()
 
   def can_send_message_to?(contact) do
-    with true <- contact.status == :valid,
-         true <- contact.provider_status == :valid,
-         true <- Timex.diff(DateTime.utc_now(), contact.last_message_at, :hours) < 24,
-         do: true
+    with :valid <- contact.status,
+         :valid <- contact.provider_status,
+         true <- Timex.diff(DateTime.utc_now(), contact.last_message_at, :hours) < 24 do
+      true
+    else
+      _ -> false
+    end
   end
 
   @doc """

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -222,17 +222,6 @@ defmodule Glific.Contacts do
   end
 
   @doc """
-  Check if contact has opted in
-  """
-  @spec is_opted_in?(Contact.t()) :: boolean()
-  def is_opted_in?(contact) do
-    with [:valid, :valid] <- [contact.status, contact.provider_status],
-         true <- contact.optin_time != nil,
-         true <- contact.optout_time == nil,
-         do: true
-  end
-
-  @doc """
   Check if we can send a hsm message to the contact
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -227,7 +227,7 @@ defmodule Glific.Contacts do
   """
   @spec can_send_hsm_message_to?(Contact.t()) :: boolean()
   def can_send_hsm_message_to?(contact) do
-    with [contact.status, contact.provider_status] == [:valid, :valid]
+    with [:valid, :valid] <- [contact.status, contact.provider_status],
          true <- contact.optin_time != nil,
          do: true
   end

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -206,23 +206,24 @@ defmodule Glific.Messages do
   @spec create_and_send_verification_message(String.t(), String.t()) :: {:ok, Message.t()}
   def create_and_send_verification_message(phone, otp) do
     # fetch contact by phone number
-    {:ok, contact} = Repo.fetch_by(Contact, %{phone: phone})
+    {:ok, contact} = Glific.Repo.fetch_by(Contact, %{phone: phone})
 
     # fetch session template by shortcode "verification"
     {:ok, session_template} =
-      Repo.fetch_by(SessionTemplate, %{
-        shortcode: "verification"
+      Glific.Repo.fetch_by(SessionTemplate, %{
+        shortcode: "verification",
+        is_hsm: true
       })
 
-    # create and send verification message with OTP code
-    message_params = %{
-      body: session_template.body <> otp,
-      type: session_template.type,
-      sender_id: Communications.Message.organization_contact_id(),
-      receiver_id: contact.id
-    }
+    ttl_in_minutes = Application.get_env(:passwordless_auth, :verification_code_ttl) |> div(60)
 
-    create_and_send_message(message_params)
+    parameters = [
+      "Registration",
+      otp,
+      "#{ttl_in_minutes} minutes"
+    ]
+
+    create_and_send_hsm_message(session_template.id, contact.id, parameters)
   end
 
   @doc """
@@ -257,7 +258,7 @@ defmodule Glific.Messages do
   @doc """
   Send a hsm template message to the specific contact.
   """
-  @spec create_and_send_hsm_message(integer, integer, []) ::
+  @spec create_and_send_hsm_message(integer, integer, [String.t()]) ::
           {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_hsm_message(template_id, receiver_id, parameters) do
     {:ok, session_template} = Repo.fetch(SessionTemplate, template_id)
@@ -280,7 +281,7 @@ defmodule Glific.Messages do
   end
 
   @doc false
-  @spec prepare_hsm_template(SessionTemplate.t(), []) :: SessionTemplate.t()
+  @spec prepare_hsm_template(SessionTemplate.t(), [String.t()]) :: SessionTemplate.t()
   def prepare_hsm_template(session_template, parameters) do
     parameters_map =
       1..session_template.number_parameters

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -203,15 +203,15 @@ defmodule Glific.Messages do
   Create and send verifciation message
   Using session template of shortcode 'verification'
   """
-  @spec create_and_send_verification_message(String.t(), String.t()) :: {:ok, Message.t()}
-  def create_and_send_verification_message(phone, otp) do
+  @spec create_and_send_otp_verification_message(String.t(), String.t()) :: {:ok, Message.t()}
+  def create_and_send_otp_verification_message(phone, otp) do
     # fetch contact by phone number
     {:ok, contact} = Glific.Repo.fetch_by(Contact, %{phone: phone})
 
     # fetch session template by shortcode "verification"
     {:ok, session_template} =
       Glific.Repo.fetch_by(SessionTemplate, %{
-        shortcode: "verification",
+        shortcode: "otp_verification",
         is_hsm: true
       })
 

--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -163,7 +163,7 @@ defmodule Glific.Providers.Gupshup.Message do
   def create(request) do
     %{to: phone, code: otp} = request
 
-    Glific.Messages.create_and_send_verification_message(phone, otp)
+    Glific.Messages.create_and_send_otp_verification_message(phone, otp)
 
     {:ok, otp}
   end

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -62,7 +62,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
   @spec send_otp(Conn.t(), map()) :: Conn.t()
   def send_otp(conn, %{"user" => %{"phone" => phone}}) do
     with {:ok, contact} <- Glific.Repo.fetch_by(Glific.Contacts.Contact, %{phone: phone}),
-         true <- Glific.Contacts.is_opted_in?(contact),
+         true <- Glific.Contacts.can_send_hsm_message_to?(contact),
          {:ok, _otp} <- PasswordlessAuth.create_and_send_verification_code(phone) do
       json(conn, %{
         data: %{
@@ -90,7 +90,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
     # we can put more validations for phone number here
     with {:error, _user} <- Glific.Repo.fetch_by(Glific.Users.User, %{phone: phone}),
          {:ok, contact} <- Glific.Repo.fetch_by(Glific.Contacts.Contact, %{phone: phone}),
-         true <- Glific.Contacts.is_opted_in?(contact) do
+         true <- Glific.Contacts.can_send_hsm_message_to?(contact) do
       json(conn, %{
         data: %{
           is_valid: true,

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -81,4 +81,27 @@ defmodule GlificWeb.API.V1.RegistrationController do
         |> json(%{error: %{status: 200, message: "Contact is not opted in yet"}})
     end
   end
+
+  @doc false
+  @spec validate_phone(Conn.t(), map()) :: Conn.t()
+  def validate_phone(conn, %{"user" => %{"phone" => phone}}) do
+    # we can put more validations for phone number here
+    case Glific.Repo.fetch_by(Glific.Users.User, %{phone: phone}) do
+      {:error, _} ->
+        json(conn, %{
+          data: %{
+            is_valid: true,
+            message: "Phone number is successfully validated"
+          }
+        })
+
+      {:ok, _} ->
+        json(conn, %{
+          data: %{
+            is_valid: false,
+            message: "Phone number already exists"
+          }
+        })
+    end
+  end
 end

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -62,7 +62,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
   @spec send_otp(Conn.t(), map()) :: Conn.t()
   def send_otp(conn, %{"user" => %{"phone" => phone}}) do
     with {:ok, contact} <- Glific.Repo.fetch_by(Glific.Contacts.Contact, %{phone: phone}),
-         true <- Glific.Contacts.can_send_message_to?(contact),
+         true <- Glific.Contacts.is_opted_in?(contact),
          {:ok, _otp} <- PasswordlessAuth.create_and_send_verification_code(phone) do
       json(conn, %{
         data: %{
@@ -79,7 +79,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
       false ->
         conn
         |> json(%{
-          error: %{status: 200, message: "User needs to initiate conversation to receive an OTP"}
+          error: %{status: 200, message: "Contact is not opted in yet"}
         })
     end
   end
@@ -90,7 +90,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
     # we can put more validations for phone number here
     with {:error, _user} <- Glific.Repo.fetch_by(Glific.Users.User, %{phone: phone}),
          {:ok, contact} <- Glific.Repo.fetch_by(Glific.Contacts.Contact, %{phone: phone}),
-         true <- Glific.Contacts.can_send_message_to?(contact) do
+         true <- Glific.Contacts.is_opted_in?(contact) do
       json(conn, %{
         data: %{
           is_valid: true,
@@ -110,7 +110,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
         json(conn, %{
           data: %{
             is_valid: false,
-            message: "User needs to initiate conversation to receive an OTP"
+            message: "Contact is not opted in yet"
           }
         })
 

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -33,6 +33,7 @@ defmodule GlificWeb.Router do
 
     resources "/registration", RegistrationController, singleton: true, only: [:create]
     post "/registration/send_otp", RegistrationController, :send_otp
+    post "/registration/validate_phone", RegistrationController, :validate_phone
     resources "/session", SessionController, singleton: true, only: [:create, :delete]
     post "/session/renew", SessionController, :renew
   end

--- a/priv/repo/seeds_prod.exs
+++ b/priv/repo/seeds_prod.exs
@@ -495,7 +495,7 @@ Repo.insert!(%SessionTemplate{
 Repo.insert!(%SessionTemplate{
   label: "HSM14",
   type: :text,
-  shortcode: "verification",
+  shortcode: "otp_verification",
   is_hsm: true,
   number_parameters: 3,
   language_id: en_us.id,

--- a/priv/repo/seeds_prod.exs
+++ b/priv/repo/seeds_prod.exs
@@ -361,15 +361,6 @@ Repo.insert!(%SessionTemplate{
   """
 })
 
-Repo.insert!(%SessionTemplate{
-  label: "Verification OTP",
-  type: :text,
-  shortcode: "verification",
-  is_reserved: true,
-  language_id: en_us.id,
-  body: "Your verification OTP is: "
-})
-
 # seed hsm templates
 Repo.insert!(%SessionTemplate{
   label: "HSM1",
@@ -504,7 +495,7 @@ Repo.insert!(%SessionTemplate{
 Repo.insert!(%SessionTemplate{
   label: "HSM14",
   type: :text,
-  shortcode: "hsm",
+  shortcode: "verification",
   is_hsm: true,
   number_parameters: 3,
   language_id: en_us.id,

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -309,7 +309,7 @@ defmodule Glific.ContactsTest do
         contact_fixture(%{
           phone: Phone.EnUs.phone(),
           provider_status: :valid,
-          optin_time: Timex.shift(DateTime.utc_now(), seconds: -30),
+          optin_time: nil,
           optout_time: DateTime.utc_now()
         })
 

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -113,9 +113,11 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
     end
 
     test "validate phone", %{conn: conn} do
+      {:ok, receiver} = Glific.Repo.fetch_by(Glific.Contacts.Contact, %{name: "Default receiver"})
+
       valid_params = %{
         "user" => %{
-          "phone" => "911234567890"
+          "phone" => receiver.phone
         }
       }
 

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -105,4 +105,38 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       assert get_in(json, ["error", "message"]) == "Phone number is incorrect"
     end
   end
+
+  describe "validate_phone/2" do
+    setup do
+      Glific.SeedsDev.seed_users()
+      :ok
+    end
+
+    test "validate phone", %{conn: conn} do
+      valid_params = %{
+        "user" => %{
+          "phone" => "911234567890"
+        }
+      }
+
+      conn = post(conn, Routes.api_v1_registration_path(conn, :validate_phone, valid_params))
+      assert json = json_response(conn, 200)
+      assert get_in(json, ["data", "is_valid"]) == true
+    end
+
+    test "validate phone of already existing user", %{conn: conn} do
+      {:ok, user} = Glific.Repo.fetch_by(Glific.Users.User, %{name: "NGO Basic User 1"})
+
+      invalid_params = %{
+        "user" => %{
+          "phone" => user.phone
+        }
+      }
+
+      conn = post(conn, Routes.api_v1_registration_path(conn, :validate_phone, invalid_params))
+      assert json = json_response(conn, 200)
+      assert get_in(json, ["data", "is_valid"]) == false
+      assert get_in(json, ["data", "message"]) == "Phone number already exists"
+    end
+  end
 end

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -81,6 +81,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
   describe "send_otp/2" do
     test "send otp", %{conn: conn} do
       {:ok, receiver} = Glific.Repo.fetch_by(Glific.Contacts.Contact, %{name: "Default receiver"})
+      Glific.Contacts.update_contact(receiver, %{optin_time: DateTime.utc_now()})
 
       valid_params = %{
         "user" => %{
@@ -114,6 +115,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
 
     test "validate phone", %{conn: conn} do
       {:ok, receiver} = Glific.Repo.fetch_by(Glific.Contacts.Contact, %{name: "Default receiver"})
+      Glific.Contacts.update_contact(receiver, %{optin_time: DateTime.utc_now()})
 
       valid_params = %{
         "user" => %{


### PR DESCRIPTION
1. Now front end can validate phone number before calling send OTP API.
2. Using hsm template for OTP
3. Fix for contact optin
4. Check for contact opted in.
5. OTP expiry time from passwordless auth config