### PR TITLE
Feature: organization settings for out of office feature

### DIFF
--- a/api.docs/includes/_organizations.md
+++ b/api.docs/includes/_organizations.md
@@ -298,7 +298,7 @@ mutation updateOrganization($id: ID!, $input: OrganizationInput!) {
           "id": 7
         }
       ],
-      "endTime": "T10:00:00",
+      "endTime": "T19:00:00",
       "flowId": 1,
       "startTime": "T09:00:00"
     }
@@ -349,9 +349,9 @@ mutation updateOrganization($id: ID!, $input: OrganizationInput!) {
               "id": 7
             }
           ],
-          "endTime": "10:00:00",
+          "endTime": "19:00:00",
           "flowId": "1",
-          "startTime": "09:00:00"
+          "startTime": "9:00:00"
         }
       }
     }

--- a/api.docs/includes/_organizations.md
+++ b/api.docs/includes/_organizations.md
@@ -244,6 +244,21 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
       id
       name
       displayName
+      outOfOffice {
+        enabled
+        startTime
+        endTime
+        flowId
+        enabledDays {
+          monday
+          tuesday
+          wednesday
+          thursday
+          friday
+          saturday
+          sunday
+        }
+      }
     }
     errors {
       key
@@ -255,7 +270,22 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
 {
   "id": "1",
   "input": {
-    "display_name": "updated organization display name"
+    "displayName": "updated organization display name",
+    "outOfOffice": {
+      "enabled": true,
+      "enabledDays": {
+        "friday": true,
+        "monday": true,
+        "saturday": true,
+        "sunday": false,
+        "thursday": true,
+        "tuesday": true,
+        "wednesday": true
+      },
+      "endTime": "T10:00:00",
+      "flowId": 1,
+      "startTime": "T09:00:00"
+    }
   }
 }
 ```
@@ -270,7 +300,22 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
       "organization": {
         "displayName": "updated organization display name",
         "id": "1",
-        "name": "Default Organization"
+        "name": "Glific",
+        "outOfOffice": {
+          "enabled": true,
+          "enabledDays": {
+            "friday": true,
+            "monday": true,
+            "saturday": true,
+            "sunday": false,
+            "thursday": true,
+            "tuesday": true,
+            "wednesday": true
+          },
+          "endTime": "10:00:00",
+          "flowId": "1",
+          "startTime": "09:00:00"
+        }
       }
     }
   }
@@ -411,6 +456,11 @@ Type | Description
 <td valign="top"><a href="#string">String</a></td>
 <td></td>
 </tr>
+<tr>
+<td colspan="2" valign="top"><strong>outOfOffice</strong></td>
+<td valign="top"><a href="#outofoffice">OutOfOffice</a></td>
+<td></td>
+</tr>
 </tbody>
 </table>
 
@@ -438,6 +488,98 @@ Type | Description
 </tr>
 </tbody>
 </table>
+
+### OutOfOffice
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>enabled</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startTime</strong></td>
+<td valign="top"><a href="#time">Time</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endTime</strong></td>
+<td valign="top"><a href="#time">Time</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>enabledDays</strong></td>
+<td valign="top"><a href="#enableddays">EnabledDays</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>flow_id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### EnabledDays
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>monday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tuesday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wednesday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>thursday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>friday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saturday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sunday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+
 
 ## Organization Inputs ##
 
@@ -584,6 +726,103 @@ Unique
 <tr>
 <td colspan="2" valign="top"><strong>providerNumber</strong></td>
 <td valign="top"><a href="#string">String</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>outOfOfficeInput</strong></td>
+<td valign="top"><a href="#outofofficeinput">OutOfOfficeInput</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+
+
+### OutOfOfficeInput
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>enabled</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>startTime</strong></td>
+<td valign="top"><a href="#time">Time</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>endTime</strong></td>
+<td valign="top"><a href="#time">Time</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>enabledDaysInput</strong></td>
+<td valign="top"><a href="#enableddaysinput">EnabledDaysInput</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>flow_id</strong></td>
+<td valign="top"><a href="#id">ID</a></td>
+<td></td>
+</tr>
+</tbody>
+</table>
+
+### EnabledDaysInput
+
+<table>
+<thead>
+<tr>
+<th align="left">Field</th>
+<th align="right">Argument</th>
+<th align="left">Type</th>
+<th align="left">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2" valign="top"><strong>monday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>tuesday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>wednesday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>thursday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>friday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>saturday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
+<td></td>
+</tr>
+<tr>
+<td colspan="2" valign="top"><strong>sunday</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a></td>
 <td></td>
 </tr>
 </tbody>

--- a/api.docs/includes/_organizations.md
+++ b/api.docs/includes/_organizations.md
@@ -238,7 +238,7 @@ Type | Description
 ## Update an Organization
 
 ```graphql
-mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
+mutation updateOrganization($id: ID!, $input: OrganizationInput!) {
   updateOrganization(id: $id, input: $input) {
     organization {
       id
@@ -250,13 +250,8 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
         endTime
         flowId
         enabledDays {
-          monday
-          tuesday
-          wednesday
-          thursday
-          friday
-          saturday
-          sunday
+          id
+          enabled
         }
       }
     }
@@ -273,15 +268,36 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
     "displayName": "updated organization display name",
     "outOfOffice": {
       "enabled": true,
-      "enabledDays": {
-        "friday": true,
-        "monday": true,
-        "saturday": true,
-        "sunday": false,
-        "thursday": true,
-        "tuesday": true,
-        "wednesday": true
-      },
+      "enabledDays": [
+        {
+          "enabled": true,
+          "id": 1
+        },
+        {
+          "enabled": true,
+          "id": 2
+        },
+        {
+          "enabled": true,
+          "id": 3
+        },
+        {
+          "enabled": true,
+          "id": 4
+        },
+        {
+          "enabled": true,
+          "id": 5
+        },
+        {
+          "enabled": false,
+          "id": 6
+        },
+        {
+          "enabled": false,
+          "id": 7
+        }
+      ],
       "endTime": "T10:00:00",
       "flowId": 1,
       "startTime": "T09:00:00"
@@ -303,15 +319,36 @@ mutation updateOrganization($id: ID!, $input:OrganizationInput!) {
         "name": "Glific",
         "outOfOffice": {
           "enabled": true,
-          "enabledDays": {
-            "friday": true,
-            "monday": true,
-            "saturday": true,
-            "sunday": false,
-            "thursday": true,
-            "tuesday": true,
-            "wednesday": true
-          },
+          "enabledDays": [
+            {
+              "enabled": true,
+              "id": 1
+            },
+            {
+              "enabled": true,
+              "id": 2
+            },
+            {
+              "enabled": true,
+              "id": 3
+            },
+            {
+              "enabled": true,
+              "id": 4
+            },
+            {
+              "enabled": true,
+              "id": 5
+            },
+            {
+              "enabled": false,
+              "id": 6
+            },
+            {
+              "enabled": false,
+              "id": 7
+            }
+          ],
           "endTime": "10:00:00",
           "flowId": "1",
           "startTime": "09:00:00"
@@ -518,7 +555,7 @@ Type | Description
 </tr>
 <tr>
 <td colspan="2" valign="top"><strong>enabledDays</strong></td>
-<td valign="top"><a href="#enableddays">EnabledDays</a></td>
+<td valign="top">[<a href="#enabledday">EnabledDay</a>]</td>
 <td></td>
 </tr>
 <tr>
@@ -529,7 +566,7 @@ Type | Description
 </tbody>
 </table>
 
-### EnabledDays
+### EnabledDay
 
 <table>
 <thead>
@@ -542,37 +579,12 @@ Type | Description
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>monday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#integer">Integer</a></td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tuesday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>wednesday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>thursday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>friday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>saturday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>sunday</strong></td>
+<td colspan="2" valign="top"><strong>enabled</strong></td>
 <td valign="top"><a href="#boolean">Boolean</a></td>
 <td></td>
 </tr>
@@ -766,8 +778,8 @@ Unique
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>enabledDaysInput</strong></td>
-<td valign="top"><a href="#enableddaysinput">EnabledDaysInput</a></td>
+<td colspan="2" valign="top"><strong>enabledDays</strong></td>
+<td valign="top">[<a href="#enableddayinput">EnabledDayInput</a>]</td>
 <td></td>
 </tr>
 <tr>
@@ -778,7 +790,7 @@ Unique
 </tbody>
 </table>
 
-### EnabledDaysInput
+### EnabledDayInput
 
 <table>
 <thead>
@@ -791,38 +803,13 @@ Unique
 </thead>
 <tbody>
 <tr>
-<td colspan="2" valign="top"><strong>monday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
+<td colspan="2" valign="top"><strong>id</strong></td>
+<td valign="top"><a href="#integer">Integer</a>!</td>
 <td></td>
 </tr>
 <tr>
-<td colspan="2" valign="top"><strong>tuesday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>wednesday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>thursday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>friday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>saturday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
-<td></td>
-</tr>
-<tr>
-<td colspan="2" valign="top"><strong>sunday</strong></td>
-<td valign="top"><a href="#boolean">Boolean</a></td>
+<td colspan="2" valign="top"><strong>enabled</strong></td>
+<td valign="top"><a href="#boolean">Boolean</a>!</td>
 <td></td>
 </tr>
 </tbody>

--- a/api.docs/includes/_scalars.md
+++ b/api.docs/includes/_scalars.md
@@ -11,6 +11,10 @@ timezone. The DateTime appears in a JSON response as an ISO8601 formatted
 string, including UTC timezone ("Z"). The parsed date and time string will
 be converted to UTC if there is an offset.
 
+### Time
+
+The `Time` scalar type represents a time without microseconds precision. The Time appears in a JSON response as an ISO8601 formatted string.
+
 ### Gid
 
 The `gid` scalar appears in JSON as a String. The string appears to

--- a/assets/gql/organizations/fields.frag.gql
+++ b/assets/gql/organizations/fields.frag.gql
@@ -17,6 +17,17 @@ fragment OrganizationFields on OrganizationResult {
       url
       api_end_point   
     }
+
+    out_of_office {
+      enabled
+      start_time
+      end_time
+      flow_id
+      enabled_days {
+        id
+        enabled
+      }
+    }
   }
 }
 

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -72,6 +72,7 @@ defmodule Glific.Partners.Organization do
   def changeset(organization, attrs) do
     organization
     |> cast(attrs, @required_fields ++ @optional_fields)
+    |> add_out_of_office_if_missing()
     |> cast_embed(:out_of_office, with: &OutOfOffice.out_of_office_changeset/2)
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:contact_id)
@@ -79,5 +80,20 @@ defmodule Glific.Partners.Organization do
     |> unique_constraint(:email)
     |> unique_constraint(:provider_number)
     |> unique_constraint([:contact_id])
+  end
+
+  defp add_out_of_office_if_missing(%Ecto.Changeset{changes: %{out_of_office: _}} = changeset) do
+    changeset
+  end
+
+  defp add_out_of_office_if_missing(
+         %Ecto.Changeset{data: %Organization{out_of_office: nil}} = changeset
+       ) do
+    changeset
+    |> put_change(:out_of_office, %{enabled: false})
+  end
+
+  defp add_out_of_office_if_missing(changeset) do
+    changeset
   end
 end

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -44,7 +44,7 @@ defmodule Glific.Partners.Organization do
           provider_number: String.t() | nil,
           default_language_id: non_neg_integer | nil,
           default_language: Language.t() | Ecto.Association.NotLoaded.t() | nil,
-          out_of_office: map() | nil,
+          out_of_office: OutOfOffice.t() | nil,
           inserted_at: :utc_datetime | nil,
           updated_at: :utc_datetime | nil
         }

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -8,7 +8,7 @@ defmodule Glific.Partners.Organization do
   alias __MODULE__
 
   alias Glific.Contacts.Contact
-  alias Glific.Partners.OutOfOffice
+  alias Glific.Partners.OrganizationSettings.OutOfOffice
   alias Glific.Partners.Provider
   alias Glific.Settings.Language
 
@@ -44,6 +44,7 @@ defmodule Glific.Partners.Organization do
           provider_number: String.t() | nil,
           default_language_id: non_neg_integer | nil,
           default_language: Language.t() | Ecto.Association.NotLoaded.t() | nil,
+          out_of_office: map() | nil,
           inserted_at: :utc_datetime | nil,
           updated_at: :utc_datetime | nil
         }

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -8,6 +8,7 @@ defmodule Glific.Partners.Organization do
   alias __MODULE__
 
   alias Glific.Contacts.Contact
+  alias Glific.Partners.OutOfOffice
   alias Glific.Partners.Provider
   alias Glific.Settings.Language
 
@@ -58,16 +59,19 @@ defmodule Glific.Partners.Organization do
     belongs_to :contact, Contact
     belongs_to :default_language, Language
 
+    embeds_one :out_of_office, OutOfOffice, on_replace: :update
+
     timestamps(type: :utc_datetime)
   end
 
   @doc """
-  Standard changeset pattern we use for all datat types
+  Standard changeset pattern we use for all data types
   """
   @spec changeset(Organization.t(), map()) :: Ecto.Changeset.t()
   def changeset(organization, attrs) do
     organization
     |> cast(attrs, @required_fields ++ @optional_fields)
+    |> cast_embed(:out_of_office, with: &OutOfOffice.out_of_office_changeset/2)
     |> validate_required(@required_fields)
     |> foreign_key_constraint(:contact_id)
     |> unique_constraint(:name)

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -82,15 +82,24 @@ defmodule Glific.Partners.Organization do
     |> unique_constraint([:contact_id])
   end
 
-  defp add_out_of_office_if_missing(%Ecto.Changeset{changes: %{out_of_office: _}} = changeset) do
-    changeset
-  end
-
   defp add_out_of_office_if_missing(
          %Ecto.Changeset{data: %Organization{out_of_office: nil}} = changeset
        ) do
+    out_of_office_default_data = %{
+      enabled: false,
+      enabled_days: [
+        %{enabled: false, id: 1},
+        %{enabled: false, id: 2},
+        %{enabled: false, id: 3},
+        %{enabled: false, id: 4},
+        %{enabled: false, id: 5},
+        %{enabled: false, id: 6},
+        %{enabled: false, id: 7}
+      ]
+    }
+
     changeset
-    |> put_change(:out_of_office, %{enabled: false})
+    |> put_change(:out_of_office, out_of_office_default_data)
   end
 
   defp add_out_of_office_if_missing(changeset) do

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -88,6 +88,11 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay do
     :enabled
   ]
 
+  @type t() :: %__MODULE__{
+    id: integer | nil,
+    enabled: boolean | nil
+  }
+
   @primary_key false
   embedded_schema do
     field :id, :integer, primary_key: true

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -1,0 +1,38 @@
+defmodule Glific.Partners.OutOfOffice do
+  @moduledoc """
+  The Glific Abstraction to represent the organization settings of out of office
+  """
+  alias __MODULE__
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Glific.Flows.Flow
+
+  @required_fields [
+    :enabled
+  ]
+
+  @optional_fields [
+    :start_time,
+    :end_time,
+    :enabled_days,
+    :flow_id
+  ]
+
+  @type t() :: %__MODULE__{
+        }
+
+  embedded_schema do
+    field :enabled, :boolean
+    field :start_time, :utc_datetime
+    field :end_time, :utc_datetime
+    field :enabled_days, :map
+    belongs_to :flow, Flow
+  end
+
+  def out_of_office_changeset(out_of_office, attrs) do
+    out_of_office
+    |> cast(attrs, @required_fields ++ @optional_fields)
+  end
+end

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -40,9 +40,39 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   """
   @spec out_of_office_changeset(OutOfOffice.t(), map()) :: Ecto.Changeset.t()
   def out_of_office_changeset(out_of_office, attrs) do
+    attrs =
+      if Map.has_key?(attrs, :enabled_days),
+        do: Map.put(attrs, :enabled_days, prepare_enabled_days_list(attrs.enabled_days)),
+        else: attrs
+
     out_of_office
     |> cast(attrs, @optional_fields)
     |> cast_embed(:enabled_days, with: &EnabledDay.enabled_day_changeset/2)
+  end
+
+  @spec prepare_enabled_days_list(map()) :: map()
+  defp prepare_enabled_days_list(enabled_days) do
+    enabled_days_default_list = [
+      %{enabled: false, id: 1},
+      %{enabled: false, id: 2},
+      %{enabled: false, id: 3},
+      %{enabled: false, id: 4},
+      %{enabled: false, id: 5},
+      %{enabled: false, id: 6},
+      %{enabled: false, id: 7}
+    ]
+
+    enabled_days
+    |> Enum.reduce(enabled_days_default_list, fn x, acc ->
+      acc
+      |> Enum.map(fn y ->
+        if y.id == x.id do
+          %{enabled: x.enabled, id: x.id}
+        else
+          %{enabled: y.enabled, id: y.id}
+        end
+      end)
+    end)
   end
 end
 

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -8,13 +8,13 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   import Ecto.Changeset
 
   alias Glific.Flows.Flow
-  alias Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay
 
   @optional_fields [
     :enabled,
     :start_time,
     :end_time,
-    :flow_id
+    :flow_id,
+    :enabled_days
   ]
 
   @type t() :: %__MODULE__{
@@ -27,12 +27,11 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
 
   @primary_key false
   embedded_schema do
-    field :enabled, :boolean
+    field :enabled, :boolean, default: false
     field :start_time, :time
     field :end_time, :time
     belongs_to :flow, Flow
-
-    embeds_many :enabled_days, EnabledDay, on_replace: :raise
+    field :enabled_days, {:array, :map}
   end
 
   @doc """
@@ -42,37 +41,39 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
     |> cast(attrs, @optional_fields)
-    |> cast_embed(:enabled_days, with: &EnabledDay.enabled_day_changeset/2)
-  end
-end
-
-defmodule Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay do
-  @moduledoc """
-  The Glific abstraction to represent the out of office enabled day schema
-  """
-  use Ecto.Schema
-  import Ecto.Changeset
-
-  @required_fields [
-    :id,
-    :enabled
-  ]
-
-  @primary_key false
-  embedded_schema do
-    field :id, :integer, primary_key: true
-    field :enabled, :boolean
+    |> cast_enabled_days(attrs)
   end
 
-  @doc """
-  Changeset pattern for embedded schema of enabled_day
-  """
-  @spec enabled_day_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
-  def enabled_day_changeset(enabled_day, attrs) do
-    enabled_day
-    |> cast(attrs, @required_fields)
-    |> validate_required(@required_fields)
-    |> validate_number(:id, less_than_or_equal_to: 7)
-    |> validate_number(:id, greater_than_or_equal_to: 1)
+  @spec cast_enabled_days(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
+  defp cast_enabled_days(changeset, %{enabled_days: enabled_days}) do
+    changeset
+    |> put_change(:enabled_days, prepare_enabled_days_list(enabled_days))
+  end
+
+  defp cast_enabled_days(changeset, _), do: changeset
+
+  @spec prepare_enabled_days_list(map()) :: map()
+  defp prepare_enabled_days_list(enabled_days) do
+    enabled_days_default_list = [
+      %{enabled: false, id: 1},
+      %{enabled: false, id: 2},
+      %{enabled: false, id: 3},
+      %{enabled: false, id: 4},
+      %{enabled: false, id: 5},
+      %{enabled: false, id: 6},
+      %{enabled: false, id: 7}
+    ]
+
+    enabled_days
+    |> Enum.reduce(enabled_days_default_list, fn x, acc ->
+      acc
+      |> Enum.map(fn y ->
+        if y.id == x.id do
+          %{enabled: x.enabled, id: x.id}
+        else
+          %{enabled: y.enabled, id: y.id}
+        end
+      end)
+    end)
   end
 end

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -8,13 +8,13 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   import Ecto.Changeset
 
   alias Glific.Flows.Flow
+  alias Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay
 
   @optional_fields [
     :enabled,
     :start_time,
     :end_time,
-    :flow_id,
-    :enabled_days
+    :flow_id
   ]
 
   @type t() :: %__MODULE__{
@@ -25,12 +25,14 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
           flow_id: non_neg_integer | nil
         }
 
+  @primary_key false
   embedded_schema do
     field :enabled, :boolean
     field :start_time, :time
     field :end_time, :time
     belongs_to :flow, Flow
-    field :enabled_days, {:array, :map}
+
+    embeds_many :enabled_days, EnabledDay, on_replace: :raise
   end
 
   @doc """
@@ -40,5 +42,37 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
     |> cast(attrs, @optional_fields)
+    |> cast_embed(:enabled_days, with: &EnabledDay.enabled_day_changeset/2)
+  end
+end
+
+defmodule Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay do
+  @moduledoc """
+  The Glific abstraction to represent the out of office enabled day schema
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @required_fields [
+    :id,
+    :enabled
+  ]
+
+  @primary_key false
+  embedded_schema do
+    field :id, :integer, primary_key: true
+    field :enabled, :boolean
+  end
+
+  @doc """
+  Changeset pattern for embedded schema of enabled_day
+  """
+  @spec enabled_day_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
+  def enabled_day_changeset(enabled_day, attrs) do
+    enabled_day
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:id, less_than_or_equal_to: 7)
+    |> validate_number(:id, greater_than_or_equal_to: 1)
   end
 end

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -1,6 +1,6 @@
-defmodule Glific.Partners.OutOfOffice do
+defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   @moduledoc """
-  The Glific Abstraction to represent the organization settings of out of office
+  The Glific abstraction to represent the organization settings of out of office
   """
   alias __MODULE__
 
@@ -9,30 +9,48 @@ defmodule Glific.Partners.OutOfOffice do
 
   alias Glific.Flows.Flow
 
-  @required_fields [
-    :enabled
-  ]
-
   @optional_fields [
+    :enabled,
     :start_time,
     :end_time,
-    :enabled_days,
     :flow_id
   ]
 
-  @type t() :: %__MODULE__{
-        }
+  @enabled_days_optional_fields [
+    :monday,
+    :tuesday,
+    :wednesday,
+    :thursday,
+    :friday,
+    :saturday,
+    :sunday
+  ]
 
   embedded_schema do
     field :enabled, :boolean
     field :start_time, :utc_datetime
     field :end_time, :utc_datetime
-    field :enabled_days, :map
     belongs_to :flow, Flow
+
+    embeds_one :enabled_days, EnabledDays, on_replace: :update do
+      field :monday, :boolean
+      field :tuesday, :boolean
+      field :wednesday, :boolean
+      field :thursday, :boolean
+      field :friday, :boolean
+      field :saturday, :boolean
+      field :sunday, :boolean
+    end
   end
 
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
-    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> cast(attrs, @optional_fields)
+    |> cast_embed(:enabled_days, with: &enabled_days_changeset/2)
+  end
+
+  def enabled_days_changeset(enabled_days, attrs) do
+    enabled_days
+    |> cast(attrs, @enabled_days_optional_fields)
   end
 end

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -26,6 +26,14 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     :sunday
   ]
 
+  @type t() :: %__MODULE__{
+          enabled: boolean | nil,
+          start_time: :utc_datetime | nil,
+          end_time: :utc_datetime | nil,
+          enabled_days: map() | nil,
+          flow_id: non_neg_integer | nil
+        }
+
   embedded_schema do
     field :enabled, :boolean
     field :start_time, :utc_datetime
@@ -43,12 +51,14 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     end
   end
 
+  @spec out_of_office_changeset(OutOfOffice.t(), map()) :: Ecto.Changeset.t()
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
     |> cast(attrs, @optional_fields)
     |> cast_embed(:enabled_days, with: &enabled_days_changeset/2)
   end
 
+  @spec enabled_days_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
   def enabled_days_changeset(enabled_days, attrs) do
     enabled_days
     |> cast(attrs, @enabled_days_optional_fields)

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -28,8 +28,8 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
 
   @type t() :: %__MODULE__{
           enabled: boolean | nil,
-          start_time: :utc_datetime | nil,
-          end_time: :utc_datetime | nil,
+          start_time: :time | nil,
+          end_time: :time | nil,
           enabled_days: map() | nil,
           flow_id: non_neg_integer | nil,
           flow: Flow.t() | Ecto.Association.NotLoaded.t() | nil
@@ -37,8 +37,8 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
 
   embedded_schema do
     field :enabled, :boolean
-    field :start_time, :utc_datetime
-    field :end_time, :utc_datetime
+    field :start_time, :time
+    field :end_time, :time
     belongs_to :flow, Flow
 
     embeds_one :enabled_days, EnabledDays, on_replace: :update do
@@ -52,6 +52,9 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     end
   end
 
+  @doc """
+  Standard changeset pattern for embedded schema
+  """
   @spec out_of_office_changeset(OutOfOffice.t(), map()) :: Ecto.Changeset.t()
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
@@ -59,6 +62,9 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     |> cast_embed(:enabled_days, with: &enabled_days_changeset/2)
   end
 
+  @doc """
+  Standard changeset pattern for embedded schema
+  """
   @spec enabled_days_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
   def enabled_days_changeset(enabled_days, attrs) do
     enabled_days

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -31,7 +31,8 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
           start_time: :utc_datetime | nil,
           end_time: :utc_datetime | nil,
           enabled_days: map() | nil,
-          flow_id: non_neg_integer | nil
+          flow_id: non_neg_integer | nil,
+          flow: Flow.t() | Ecto.Association.NotLoaded.t() | nil
         }
 
   embedded_schema do

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -13,17 +13,8 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     :enabled,
     :start_time,
     :end_time,
-    :flow_id
-  ]
-
-  @enabled_days_optional_fields [
-    :monday,
-    :tuesday,
-    :wednesday,
-    :thursday,
-    :friday,
-    :saturday,
-    :sunday
+    :flow_id,
+    :enabled_days
   ]
 
   @type t() :: %__MODULE__{
@@ -31,8 +22,7 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
           start_time: :time | nil,
           end_time: :time | nil,
           enabled_days: map() | nil,
-          flow_id: non_neg_integer | nil,
-          flow: Flow.t() | Ecto.Association.NotLoaded.t() | nil
+          flow_id: non_neg_integer | nil
         }
 
   embedded_schema do
@@ -40,16 +30,7 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
     field :start_time, :time
     field :end_time, :time
     belongs_to :flow, Flow
-
-    embeds_one :enabled_days, EnabledDays, on_replace: :update do
-      field :monday, :boolean
-      field :tuesday, :boolean
-      field :wednesday, :boolean
-      field :thursday, :boolean
-      field :friday, :boolean
-      field :saturday, :boolean
-      field :sunday, :boolean
-    end
+    field :enabled_days, {:array, :map}
   end
 
   @doc """
@@ -59,15 +40,5 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
     |> cast(attrs, @optional_fields)
-    |> cast_embed(:enabled_days, with: &enabled_days_changeset/2)
-  end
-
-  @doc """
-  Standard changeset pattern for embedded schema
-  """
-  @spec enabled_days_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
-  def enabled_days_changeset(enabled_days, attrs) do
-    enabled_days
-    |> cast(attrs, @enabled_days_optional_fields)
   end
 end

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -89,9 +89,9 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay do
   ]
 
   @type t() :: %__MODULE__{
-    id: integer | nil,
-    enabled: boolean | nil
-  }
+          id: integer | nil,
+          enabled: boolean | nil
+        }
 
   @primary_key false
   embedded_schema do

--- a/lib/glific/partners/out_of_office.ex
+++ b/lib/glific/partners/out_of_office.ex
@@ -8,13 +8,13 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   import Ecto.Changeset
 
   alias Glific.Flows.Flow
+  alias Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay
 
   @optional_fields [
     :enabled,
     :start_time,
     :end_time,
-    :flow_id,
-    :enabled_days
+    :flow_id
   ]
 
   @type t() :: %__MODULE__{
@@ -27,11 +27,12 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
 
   @primary_key false
   embedded_schema do
-    field :enabled, :boolean, default: false
+    field :enabled, :boolean
     field :start_time, :time
     field :end_time, :time
     belongs_to :flow, Flow
-    field :enabled_days, {:array, :map}
+
+    embeds_many :enabled_days, EnabledDay, on_replace: :raise
   end
 
   @doc """
@@ -41,39 +42,37 @@ defmodule Glific.Partners.OrganizationSettings.OutOfOffice do
   def out_of_office_changeset(out_of_office, attrs) do
     out_of_office
     |> cast(attrs, @optional_fields)
-    |> cast_enabled_days(attrs)
+    |> cast_embed(:enabled_days, with: &EnabledDay.enabled_day_changeset/2)
+  end
+end
+
+defmodule Glific.Partners.OrganizationSettings.OutOfOffice.EnabledDay do
+  @moduledoc """
+  The Glific abstraction to represent the out of office enabled day schema
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @required_fields [
+    :id,
+    :enabled
+  ]
+
+  @primary_key false
+  embedded_schema do
+    field :id, :integer, primary_key: true
+    field :enabled, :boolean
   end
 
-  @spec cast_enabled_days(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
-  defp cast_enabled_days(changeset, %{enabled_days: enabled_days}) do
-    changeset
-    |> put_change(:enabled_days, prepare_enabled_days_list(enabled_days))
-  end
-
-  defp cast_enabled_days(changeset, _), do: changeset
-
-  @spec prepare_enabled_days_list(map()) :: map()
-  defp prepare_enabled_days_list(enabled_days) do
-    enabled_days_default_list = [
-      %{enabled: false, id: 1},
-      %{enabled: false, id: 2},
-      %{enabled: false, id: 3},
-      %{enabled: false, id: 4},
-      %{enabled: false, id: 5},
-      %{enabled: false, id: 6},
-      %{enabled: false, id: 7}
-    ]
-
-    enabled_days
-    |> Enum.reduce(enabled_days_default_list, fn x, acc ->
-      acc
-      |> Enum.map(fn y ->
-        if y.id == x.id do
-          %{enabled: x.enabled, id: x.id}
-        else
-          %{enabled: y.enabled, id: y.id}
-        end
-      end)
-    end)
+  @doc """
+  Changeset pattern for embedded schema of enabled_day
+  """
+  @spec enabled_day_changeset(Ecto.Schema.t(), map()) :: Ecto.Changeset.t()
+  def enabled_day_changeset(enabled_day, attrs) do
+    enabled_day
+    |> cast(attrs, @required_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:id, less_than_or_equal_to: 7)
+    |> validate_number(:id, greater_than_or_equal_to: 1)
   end
 end

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -30,6 +30,10 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :end_time, :datetime
     field :enabled_days, :enabled_days
     field :flow_id, :id
+
+    field :flow, :flow do
+      resolve(dataloader(Repo))
+    end
   end
 
   object :organization do

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -14,6 +14,24 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :errors, list_of(:input_error)
   end
 
+  object :enabled_days do
+    field :monday, :boolean
+    field :tuesday, :boolean
+    field :wednesday, :boolean
+    field :thursday, :boolean
+    field :friday, :boolean
+    field :saturday, :boolean
+    field :sunday, :boolean
+  end
+
+  object :out_of_office do
+    field :enabled, :boolean
+    field :start_time, :datetime
+    field :end_time, :datetime
+    field :enabled_days, :enabled_days
+    field :flow_id, :id
+  end
+
   object :organization do
     field :id, :id
     field :name, :string
@@ -34,6 +52,8 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :default_language, :language do
       resolve(dataloader(Repo))
     end
+
+    field :out_of_office, :out_of_office
   end
 
   @desc "Filtering options for organizations"
@@ -60,6 +80,24 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :default_language, :string
   end
 
+  input_object :enabled_days_input do
+    field :monday, :boolean
+    field :tuesday, :boolean
+    field :wednesday, :boolean
+    field :thursday, :boolean
+    field :friday, :boolean
+    field :saturday, :boolean
+    field :sunday, :boolean
+  end
+
+  input_object :out_of_office_input do
+    field :enabled, :boolean
+    field :start_time, :datetime
+    field :end_time, :datetime
+    field :enabled_days, :enabled_days_input
+    field :flow_id, :id
+  end
+
   input_object :organization_input do
     field :name, :string
     field :display_name, :string
@@ -71,6 +109,8 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :provider_id, :id
     field :contact_id, :id
     field :default_language_id, :id
+
+    field :out_of_office, :out_of_office_input
   end
 
   object :organization_queries do

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -26,8 +26,8 @@ defmodule GlificWeb.Schema.OrganizationTypes do
 
   object :out_of_office do
     field :enabled, :boolean
-    field :start_time, :datetime
-    field :end_time, :datetime
+    field :start_time, :time
+    field :end_time, :time
     field :enabled_days, :enabled_days
     field :flow_id, :id
 
@@ -96,8 +96,8 @@ defmodule GlificWeb.Schema.OrganizationTypes do
 
   input_object :out_of_office_input do
     field :enabled, :boolean
-    field :start_time, :datetime
-    field :end_time, :datetime
+    field :start_time, :time
+    field :end_time, :time
     field :enabled_days, :enabled_days_input
     field :flow_id, :id
   end

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -25,10 +25,6 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :end_time, :time
     field :enabled_days, list_of(:enabled_day)
     field :flow_id, :id
-
-    field :flow, :flow do
-      resolve(dataloader(Repo))
-    end
   end
 
   object :organization do

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -14,21 +14,16 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :errors, list_of(:input_error)
   end
 
-  object :enabled_days do
-    field :monday, :boolean
-    field :tuesday, :boolean
-    field :wednesday, :boolean
-    field :thursday, :boolean
-    field :friday, :boolean
-    field :saturday, :boolean
-    field :sunday, :boolean
+  object :enabled_day do
+    field :id, :integer
+    field :enabled, :boolean
   end
 
   object :out_of_office do
     field :enabled, :boolean
     field :start_time, :time
     field :end_time, :time
-    field :enabled_days, :enabled_days
+    field :enabled_days, list_of(:enabled_day)
     field :flow_id, :id
 
     field :flow, :flow do
@@ -84,21 +79,16 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field :default_language, :string
   end
 
-  input_object :enabled_days_input do
-    field :monday, :boolean
-    field :tuesday, :boolean
-    field :wednesday, :boolean
-    field :thursday, :boolean
-    field :friday, :boolean
-    field :saturday, :boolean
-    field :sunday, :boolean
+  input_object :enabled_day_input do
+    field :id, non_null(:integer)
+    field :enabled, non_null(:boolean)
   end
 
   input_object :out_of_office_input do
     field :enabled, :boolean
     field :start_time, :time
     field :end_time, :time
-    field :enabled_days, :enabled_days_input
+    field :enabled_days, list_of(:enabled_day_input)
     field :flow_id, :id
   end
 

--- a/priv/repo/migrations/20200812122802_alter_glific_tables.exs
+++ b/priv/repo/migrations/20200812122802_alter_glific_tables.exs
@@ -23,7 +23,7 @@ defmodule Glific.Repo.Migrations.AlterGlificTables do
     create unique_index(:users, :contact_id)
 
     alter table(:organizations) do
-      add :out_of_office, :map
+      add :out_of_office, :map, default: %{enabled: false}
     end
 
     alter_flow_tables()

--- a/priv/repo/migrations/20200812122802_alter_glific_tables.exs
+++ b/priv/repo/migrations/20200812122802_alter_glific_tables.exs
@@ -1,6 +1,5 @@
 defmodule Glific.Repo.Migrations.AlterGlificTables do
   use Ecto.Migration
-
   @moduledoc """
   Alter Glific tables
   """
@@ -21,6 +20,10 @@ defmodule Glific.Repo.Migrations.AlterGlificTables do
     end
 
     create unique_index(:users, :contact_id)
+
+    alter table(:organizations) do
+      add :out_of_office, :map
+    end
 
     alter_flow_tables()
   end

--- a/priv/repo/migrations/20200812122802_alter_glific_tables.exs
+++ b/priv/repo/migrations/20200812122802_alter_glific_tables.exs
@@ -23,7 +23,7 @@ defmodule Glific.Repo.Migrations.AlterGlificTables do
     create unique_index(:users, :contact_id)
 
     alter table(:organizations) do
-      add :out_of_office, :map, default: %{enabled: false}
+      add :out_of_office, :map
     end
 
     alter_flow_tables()

--- a/priv/repo/migrations/20200812122802_alter_glific_tables.exs
+++ b/priv/repo/migrations/20200812122802_alter_glific_tables.exs
@@ -1,5 +1,6 @@
 defmodule Glific.Repo.Migrations.AlterGlificTables do
   use Ecto.Migration
+
   @moduledoc """
   Alter Glific tables
   """

--- a/test/glific/partners_test.exs
+++ b/test/glific/partners_test.exs
@@ -244,6 +244,18 @@ defmodule Glific.PartnersTest do
       assert {:error, %Ecto.Changeset{}} = Partners.create_organization(@invalid_org_attrs)
     end
 
+    test "create_organization/1 should add default values for organization settings" do
+      {:ok, %Organization{} = organization} =
+        @valid_org_attrs
+        |> Map.merge(%{provider_id: provider_fixture().id})
+        |> Map.merge(%{default_language_id: default_language_fixture().id})
+        |> Partners.create_organization()
+
+      assert organization.out_of_office.enabled == false
+      day1 = get_in(organization.out_of_office.enabled_days, [Access.at(0)])
+      assert day1.enabled == false
+    end
+
     test "update_organization/2 with valid data updates the organization" do
       organization = organization_fixture()
 

--- a/test/glific/partners_test.exs
+++ b/test/glific/partners_test.exs
@@ -263,6 +263,52 @@ defmodule Glific.PartnersTest do
       assert organization == Partners.get_organization!(organization.id)
     end
 
+    test "update_organization/2 with oraganization settings" do
+      organization = organization_fixture()
+
+      update_org_attrs =
+        @update_org_attrs
+        |> Map.merge(%{
+          out_of_office: %{
+            enabled: true,
+            start_time: ~T[10:00:00],
+            end_time: ~T[20:00:00],
+            enabled_days: [
+              %{
+                id: 1,
+                enabled: true
+              }
+            ],
+            flow_id: 1
+          }
+        })
+
+      assert {:ok, %Organization{} = organization} =
+               Partners.update_organization(organization, update_org_attrs)
+
+      assert organization.out_of_office.enabled == true
+      assert organization.out_of_office.start_time == ~T[10:00:00]
+      day1 = get_in(organization.out_of_office.enabled_days, [Access.at(0)])
+      assert day1.enabled == true
+      # Days in the input should be updated accordingly, other days should be disabled
+      day2 = get_in(organization.out_of_office.enabled_days, [Access.at(1)])
+      assert day2.enabled == false
+
+      # disable out_of_office setting
+      update_org_attrs =
+        @update_org_attrs
+        |> Map.merge(%{
+          out_of_office: %{
+            enabled: false
+          }
+        })
+
+      assert {:ok, %Organization{} = organization} =
+               Partners.update_organization(organization, update_org_attrs)
+
+      assert organization.out_of_office.enabled == false
+    end
+
     test "delete_organization/1 deletes the organization" do
       organization = organization_fixture()
       assert {:ok, %Organization{}} = Partners.delete_organization(organization)
@@ -323,6 +369,8 @@ defmodule Glific.PartnersTest do
                Partners.list_organizations(%{filter: %{name: "Organization Name"}})
 
       assert [] == Partners.list_organizations(%{filter: %{provider: "RandomString"}})
+
+      assert [] == Partners.list_organizations(%{filter: %{default_language: "Hindi"}})
     end
 
     test "ensure that creating organization with out provider give an error" do

--- a/test/glific_web/schema/organization_test.exs
+++ b/test/glific_web/schema/organization_test.exs
@@ -223,6 +223,40 @@ defmodule GlificWeb.Schema.OrganizationTest do
     assert message == "has already been taken"
   end
 
+  test "update an organization with organization settings" do
+    {:ok, organization} = Repo.fetch_by(Organization, %{name: "Glific"})
+
+    result =
+      query_gql_by(:update,
+        variables: %{
+          "id" => organization.id,
+          "input" => %{
+            "out_of_office" => %{
+              "enabled" => true,
+              "enabled_days" => [
+                %{
+                  "id" => 1,
+                  "enabled" => true
+                }
+              ],
+              "start_time" => "T10:00:00",
+              "end_time" => "T20:00:00",
+              "flow_id" => 1
+            }
+          }
+        }
+      )
+
+    assert {:ok, query_data} = result
+
+    out_of_office =
+      get_in(query_data, [:data, "updateOrganization", "organization", "out_of_office"])
+
+    assert out_of_office["enabled"] == true
+    assert get_in(out_of_office, ["enabled_days", Access.at(0), "enabled"]) == true
+    assert get_in(out_of_office, ["enabled_days", Access.at(1), "enabled"]) == false
+  end
+
   test "delete an organization" do
     {:ok, organization} = Repo.fetch_by(Organization, %{name: "Glific"})
 


### PR DESCRIPTION
1. Added schema for out of office and enabled days
2. Prepare enabled days list before inserting to the database, if data for all days is not provided
3. Default values for out_of_office settings
4. Tests and docs update