### PR TITLE
Feature/listing fixes

### DIFF
--- a/lib/glific/conversations.ex
+++ b/lib/glific/conversations.ex
@@ -38,7 +38,6 @@ defmodule Glific.Conversations do
           m.contact_id in ^ids and
             m.message_number >= ^message_offset and
             m.message_number < ^(message_limit + message_offset),
-        order_by: [{:desc, :updated_at}],
         select: m.id
 
     Repo.all(query)

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -571,7 +571,7 @@ defmodule Glific.Messages do
         {:ids, ids}, query ->
           query
           |> where([m], m.id in ^ids)
-          |> order_by([m], desc: m.updated_at)
+          |> order_by([m], desc: m.inserted_at)
 
         {:filter, filter}, query ->
           query |> conversations_with(filter)

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -61,6 +61,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
         languages =
           Language
           |> where([l], l.id in ^organization.active_language_ids)
+          |> order_by([l], l.label)
           |> Repo.all()
 
         {:ok, languages}


### PR DESCRIPTION
1. Fix for listing organization's active languages ordered by label
2. List conversation's messages ordered by inserted at