### PR TITLE
Fix for order by in list flows API

### DIFF
--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -44,16 +44,14 @@ defmodule Glific.Flows do
 
       {:status, status}, query ->
         query
-        |> join(:left, [flow], flow_revision in FlowRevision,
-          as: :flow_revision,
-          on: flow_revision.flow_id == flow.id
-        )
         |> where(
-          [flow, flow_revision: flow_revision],
-          flow_revision.status == ^status
+          [f],
+          f.id in subquery(
+            FlowRevision
+            |> where([fr], fr.status == ^status)
+            |> select([fr], fr.flow_id)
+          )
         )
-        # this is a temporary fix,
-        # it won't work for flow statuses other than "done"
 
       _, query ->
         query

--- a/test/glific/messages_test.exs
+++ b/test/glific/messages_test.exs
@@ -145,7 +145,7 @@ defmodule Glific.MessagesTest do
         |> Messages.create_message()
 
       # this gets the session_uuid set by the trigger
-        message = Messages.get_message!(message.id)
+      message = Messages.get_message!(message.id)
 
       assert [message] ==
                Messages.list_messages(%{filter: Map.merge(attrs, %{sender: sender.name})})


### PR DESCRIPTION
1. Fix for order by.
2. Fix for listing a flow multiple times.
3. Getting filtered flows that have flow revision stored with the status at least once.