### PR TITLE
Remove organization id in filter from resolvers and contexts

### DIFF
--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -49,7 +49,7 @@ defmodule Glific.Contacts do
   Include contacts only if have list of tags
   """
   @spec list_contacts(map()) :: [Contact.t()]
-  def list_contacts(%{filter: %{organization_id: _organization_id}} = args) do
+  def list_contacts(args) do
     args
     |> Repo.list_filter_query(Contact, &Repo.opts_with_name/2, &filter_with/2)
     |> Repo.add_permission(&Contacts.add_permission/2)
@@ -60,7 +60,7 @@ defmodule Glific.Contacts do
   Return the count of contacts, using the same filter as list_contacts
   """
   @spec count_contacts(map()) :: integer
-  def count_contacts(%{filter: %{organization_id: _organization_id}} = args) do
+  def count_contacts(args) do
     args
     |> Repo.list_filter_query(Contact, nil, &filter_with/2)
     |> Repo.add_permission(&Contacts.add_permission/2)

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -28,7 +28,7 @@ defmodule Glific.Flows do
 
   """
   @spec list_flows(map()) :: [Flow.t()]
-  def list_flows(%{filter: %{organization_id: _organization_id}} = args),
+  def list_flows(args),
     do: Repo.list_filter(args, Flow, &Repo.opts_with_name/2, &filter_with/2)
 
   @spec filter_with(Ecto.Queryable.t(), %{optional(atom()) => any}) :: Ecto.Queryable.t()
@@ -63,7 +63,7 @@ defmodule Glific.Flows do
   Return the count of tags, using the same filter as list_tags
   """
   @spec count_flows(map()) :: integer
-  def count_flows(%{filter: %{organization_id: _organization_id}} = args),
+  def count_flows(args),
     do: Repo.count_filter(args, Flow, &Repo.filter_with/2)
 
   @doc """

--- a/lib/glific/groups.ex
+++ b/lib/glific/groups.ex
@@ -61,7 +61,7 @@ defmodule Glific.Groups do
   Return the count of groups, using the same filter as list_groups
   """
   @spec count_groups(map()) :: integer
-  def count_groups(%{filter: %{organization_id: _organization_id}} = args) do
+  def count_groups(args) do
     args
     |> Repo.list_filter_query(Group, nil, &Repo.filter_with/2)
     |> Repo.add_permission(&Groups.add_permission/2)

--- a/lib/glific/jobs/bigquery/bigquery_worker.ex
+++ b/lib/glific/jobs/bigquery/bigquery_worker.ex
@@ -245,7 +245,6 @@ defmodule Glific.Jobs.BigQueryWorker do
     data
   end
 
-
   @spec make_job(list(), String.t(), non_neg_integer, non_neg_integer) :: :ok | nil
   defp make_job(data, "messages", organization_id, schedule_in) do
     __MODULE__.new(%{organization_id: organization_id, messages: data}, schedule_in: schedule_in)

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -32,7 +32,7 @@ defmodule Glific.Messages do
 
   """
   @spec list_messages(map()) :: [Message.t()]
-  def list_messages(%{filter: %{organization_id: _org_id}} = args),
+  def list_messages(args),
     do:
       Repo.list_filter(args, Message, &Repo.opts_with_body/2, &filter_with/2)
       |> Enum.map(&put_clean_body/1)
@@ -41,7 +41,7 @@ defmodule Glific.Messages do
   Return the count of messages, using the same filter as list_messages
   """
   @spec count_messages(map()) :: integer
-  def count_messages(%{filter: %{organization_id: _org_id}} = args),
+  def count_messages(args),
     do: Repo.count_filter(args, Message, &filter_with/2)
 
   # codebeat:disable[ABC, LOC]

--- a/lib/glific/searches.ex
+++ b/lib/glific/searches.ex
@@ -34,14 +34,14 @@ defmodule Glific.Searches do
 
   """
   @spec list_saved_searches(map()) :: [SavedSearch.t()]
-  def list_saved_searches(%{filter: %{organization_id: _organization_id}} = args),
+  def list_saved_searches(args),
     do: Repo.list_filter(args, SavedSearch, &Repo.opts_with_label/2, &Repo.filter_with/2)
 
   @doc """
   Returns the count of searches, using the same filter as list_saved_searches
   """
   @spec count_saved_searches(map()) :: integer
-  def count_saved_searches(%{filter: %{organization_id: _organization_id}} = args),
+  def count_saved_searches(args),
     do: Repo.count_filter(args, SavedSearch, &Repo.filter_with/2)
 
   @doc """

--- a/lib/glific/tags.ex
+++ b/lib/glific/tags.ex
@@ -28,14 +28,14 @@ defmodule Glific.Tags do
 
   """
   @spec list_tags(map()) :: [Tag.t()]
-  def list_tags(%{filter: %{organization_id: _organization_id}} = args),
+  def list_tags(args),
     do: Repo.list_filter(args, Tag, &Repo.opts_with_label/2, &Repo.filter_with/2)
 
   @doc """
   Return the count of tags, using the same filter as list_tags
   """
   @spec count_tags(map()) :: integer
-  def count_tags(%{filter: %{organization_id: _organization_id}} = args),
+  def count_tags(args),
     do: Repo.count_filter(args, Tag, &Repo.filter_with/2)
 
   @doc """

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -21,14 +21,14 @@ defmodule Glific.Templates do
 
   """
   @spec list_session_templates(map()) :: [SessionTemplate.t()]
-  def list_session_templates(%{filter: %{organization_id: _organization_id}} = args),
+  def list_session_templates(args),
     do: Repo.list_filter(args, SessionTemplate, &Repo.opts_with_label/2, &filter_with/2)
 
   @doc """
   Return the count of session_templates, using the same filter as list_session_templates
   """
   @spec count_session_templates(map()) :: integer
-  def count_session_templates(%{filter: %{organization_id: _organization_id}} = args),
+  def count_session_templates(args),
     do: Repo.count_filter(args, SessionTemplate, &filter_with/2)
 
   # codebeat:disable[ABC,LOC]

--- a/lib/glific/users.ex
+++ b/lib/glific/users.ex
@@ -23,7 +23,7 @@ defmodule Glific.Users do
 
   """
   @spec list_users(map()) :: [User.t()]
-  def list_users(%{filter: %{organization_id: _organization_id}} = args) do
+  def list_users(args) do
     Repo.list_filter(args, User, &Repo.opts_with_name/2, &Repo.filter_with/2)
   end
 
@@ -31,7 +31,7 @@ defmodule Glific.Users do
   Return the count of users, using the same filter as list_users
   """
   @spec count_users(map()) :: integer
-  def count_users(%{filter: %{organization_id: _organization_id}} = args),
+  def count_users(args),
     do: Repo.count_filter(args, User, &Repo.filter_with/2)
 
   @doc """

--- a/lib/glific_web/resolvers/contacts.ex
+++ b/lib/glific_web/resolvers/contacts.ex
@@ -5,7 +5,6 @@ defmodule GlificWeb.Resolvers.Contacts do
   """
 
   alias Glific.{Contacts, Contacts.Contact, Repo}
-  alias GlificWeb.Resolvers.Helper
 
   @doc false
   @spec contact(Absinthe.Resolution.t(), %{id: integer}, %{context: map()}) ::
@@ -19,16 +18,16 @@ defmodule GlificWeb.Resolvers.Contacts do
   @doc false
   @spec contacts(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, [any]}
-  def contacts(_, args, context) do
-    {:ok, Contacts.list_contacts(Helper.add_org_filter(args, context))}
+  def contacts(_, args, _) do
+    {:ok, Contacts.list_contacts(args)}
   end
 
   @doc """
   Get the count of contacts filtered by args
   """
   @spec count_contacts(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_contacts(_, args, context) do
-    {:ok, Contacts.count_contacts(Helper.add_org_filter(args, context))}
+  def count_contacts(_, args, _) do
+    {:ok, Contacts.count_contacts(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/flows.ex
+++ b/lib/glific_web/resolvers/flows.ex
@@ -12,8 +12,6 @@ defmodule GlificWeb.Resolvers.Flows do
     Repo
   }
 
-  alias GlificWeb.Resolvers.Helper
-
   @doc """
   Get a specific flow by id
   """
@@ -28,16 +26,16 @@ defmodule GlificWeb.Resolvers.Flows do
   Get the list of flows
   """
   @spec flows(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, [Flow]}
-  def flows(_, args, context) do
-    {:ok, Flows.list_flows(Helper.add_org_filter(args, context))}
+  def flows(_, args, _) do
+    {:ok, Flows.list_flows(args)}
   end
 
   @doc """
   Get the count of flows filtered by args
   """
   @spec count_flows(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_flows(_, args, context) do
-    {:ok, Flows.count_flows(Helper.add_org_filter(args, context))}
+  def count_flows(_, args, _) do
+    {:ok, Flows.count_flows(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/groups.ex
+++ b/lib/glific_web/resolvers/groups.ex
@@ -6,7 +6,6 @@ defmodule GlificWeb.Resolvers.Groups do
 
   alias Glific.{Groups, Groups.Group, Repo}
   alias Glific.{Groups.ContactGroups, Groups.UserGroups}
-  alias GlificWeb.Resolvers.Helper
 
   @doc """
   Get a specific group by id
@@ -22,16 +21,16 @@ defmodule GlificWeb.Resolvers.Groups do
   Get the list of groups filtered by args
   """
   @spec groups(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, [Group]}
-  def groups(_, args, context) do
-    {:ok, Groups.list_groups(Helper.add_org_filter(args, context))}
+  def groups(_, args, _) do
+    {:ok, Groups.list_groups(args)}
   end
 
   @doc """
   Get the count of groups filtered by args
   """
   @spec count_groups(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_groups(_, args, context) do
-    {:ok, Groups.count_groups(Helper.add_org_filter(args, context))}
+  def count_groups(_, args, _) do
+    {:ok, Groups.count_groups(args)}
   end
 
   @doc """

--- a/lib/glific_web/resolvers/messages.ex
+++ b/lib/glific_web/resolvers/messages.ex
@@ -13,8 +13,6 @@ defmodule GlificWeb.Resolvers.Messages do
     Repo
   }
 
-  alias GlificWeb.Resolvers.Helper
-
   @doc """
   Get a specific message by id
   """
@@ -31,16 +29,16 @@ defmodule GlificWeb.Resolvers.Messages do
   """
   @spec messages(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, any} | {:error, any}
-  def messages(_, args, context) do
-    {:ok, Messages.list_messages(Helper.add_org_filter(args, context))}
+  def messages(_, args, _) do
+    {:ok, Messages.list_messages(args)}
   end
 
   @doc """
   Get the count of messages filtered by args
   """
   @spec count_messages(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_messages(_, args, context) do
-    {:ok, Messages.count_messages(Helper.add_org_filter(args, context))}
+  def count_messages(_, args, _) do
+    {:ok, Messages.count_messages(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/searches.ex
+++ b/lib/glific_web/resolvers/searches.ex
@@ -29,16 +29,16 @@ defmodule GlificWeb.Resolvers.Searches do
   Get the list of saved_searches
   """
   @spec saved_searches(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, [SavedSearch]}
-  def saved_searches(_, args, context) do
-    {:ok, Searches.list_saved_searches(Helper.add_org_filter(args, context))}
+  def saved_searches(_, args, _) do
+    {:ok, Searches.list_saved_searches(args)}
   end
 
   @doc """
   Get the count of saved_searches
   """
   @spec count_saved_searches(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_saved_searches(_, args, context) do
-    {:ok, Searches.count_saved_searches(Helper.add_org_filter(args, context))}
+  def count_saved_searches(_, args, _) do
+    {:ok, Searches.count_saved_searches(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/tags.ex
+++ b/lib/glific_web/resolvers/tags.ex
@@ -5,7 +5,6 @@ defmodule GlificWeb.Resolvers.Tags do
   """
 
   alias Glific.{Repo, Tags, Tags.Tag}
-  alias GlificWeb.Resolvers.Helper
 
   @doc """
   Get a specific tag by id
@@ -21,16 +20,16 @@ defmodule GlificWeb.Resolvers.Tags do
   Get the list of tags filtered by args
   """
   @spec tags(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, [Tag]}
-  def tags(_, args, context) do
-    {:ok, Tags.list_tags(Helper.add_org_filter(args, context))}
+  def tags(_, args, _) do
+    {:ok, Tags.list_tags(args)}
   end
 
   @doc """
   Get the count of tags filtered by args
   """
   @spec count_tags(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_tags(_, args, context) do
-    {:ok, Tags.count_tags(Helper.add_org_filter(args, context))}
+  def count_tags(_, args, _) do
+    {:ok, Tags.count_tags(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/templates.ex
+++ b/lib/glific_web/resolvers/templates.ex
@@ -5,7 +5,6 @@ defmodule GlificWeb.Resolvers.Templates do
   """
 
   alias Glific.{Messages, Repo, Templates, Templates.SessionTemplate}
-  alias GlificWeb.Resolvers.Helper
 
   @doc """
   Get a specific session template by id
@@ -23,8 +22,8 @@ defmodule GlificWeb.Resolvers.Templates do
   """
   @spec session_templates(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, any} | {:error, any}
-  def session_templates(_, args, context) do
-    {:ok, Templates.list_session_templates(Helper.add_org_filter(args, context))}
+  def session_templates(_, args, _) do
+    {:ok, Templates.list_session_templates(args)}
   end
 
   @doc """
@@ -32,8 +31,8 @@ defmodule GlificWeb.Resolvers.Templates do
   """
   @spec count_session_templates(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, integer}
-  def count_session_templates(_, args, context) do
-    {:ok, Templates.count_session_templates(Helper.add_org_filter(args, context))}
+  def count_session_templates(_, args, _) do
+    {:ok, Templates.count_session_templates(args)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -6,7 +6,6 @@ defmodule GlificWeb.Resolvers.Users do
 
   alias Glific.Repo
   alias Glific.{Groups, Users, Users.User}
-  alias GlificWeb.Resolvers.Helper
 
   @doc false
   @spec user(Absinthe.Resolution.t(), %{id: integer}, %{context: map()}) ::
@@ -19,16 +18,16 @@ defmodule GlificWeb.Resolvers.Users do
   @doc false
   @spec users(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, [any]}
-  def users(_, args, context) do
-    {:ok, Users.list_users(Helper.add_org_filter(args, context))}
+  def users(_, args, _) do
+    {:ok, Users.list_users(args)}
   end
 
   @doc """
   Get the count of users filtered by args
   """
   @spec count_users(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, integer}
-  def count_users(_, args, context) do
-    {:ok, Users.count_users(Helper.add_org_filter(args, context))}
+  def count_users(_, args, _) do
+    {:ok, Users.count_users(args)}
   end
 
   @doc false

--- a/lib/glific_web/schema/middleware/add_organization.ex
+++ b/lib/glific_web/schema/middleware/add_organization.ex
@@ -28,9 +28,9 @@ defmodule GlificWeb.Schema.Middleware.AddOrganization do
     put_in(arguments, [:input, :organization_id], current_user.organization_id)
   end
 
-  defp put_organization_id(%{filter: _filter} = arguments, current_user) do
-    put_in(arguments, [:filter, :organization_id], current_user.organization_id)
-  end
+  # defp put_organization_id(%{filter: _filter} = arguments, current_user) do
+  #   put_in(arguments, [:filter, :organization_id], current_user.organization_id)
+  # end
 
   defp put_organization_id(arguments, current_user) do
     Map.put_new(arguments, :organization_id, current_user.organization_id)


### PR DESCRIPTION
1. Removing helper for get_org_filter in resolvers,
2. Removing the signature of filter of organization id in context's list and count functions.
3. Removing put_organization_id in middleware