### PR TITLE
CORS Proxy

### DIFF
--- a/lib/glific/cors_proxy.ex
+++ b/lib/glific/cors_proxy.ex
@@ -1,0 +1,70 @@
+defmodule Glific.CorsProxy do
+  @moduledoc """
+  CorsProxy keeps the contexts that define your domain
+  and business logic.
+
+  Contexts are also responsible for managing your data, regardless
+  if it comes from the database, an external API or others.
+  """
+  import Plug.Conn, only: [send_resp: 3, put_resp_header: 3]
+  require Logger
+
+  @request_blacklist ~w[host accept-language]
+  @response_whitelist ~w[Content-Encoding Content-Type]
+
+  def request(method, url, headers, body) when is_map(body) do
+    {:ok, body} = body |> Jason.encode()
+    request(method, url, headers, body)
+  end
+
+  def request(method, [protocol | path_info], headers, body) do
+    path =
+      path_info
+      |> Enum.join("/")
+
+    url = "#{protocol}//#{path}"
+
+    Logger.info("#{method} #{url}")
+    Logger.info("Headers: #{inspect(headers)}")
+    Logger.info("Body: #{body}")
+    HTTPoison.request(method, url, body, filter_request_headers(headers))
+  end
+
+  def write_response({:ok, response}, conn) do
+    response.headers
+    |> filter_response_headers
+    |> Enum.reduce(conn, fn {name, value}, acc ->
+      put_resp_header(acc, name, value)
+    end)
+    |> put_access_control_headers
+    |> send_resp(response.status_code, response.body)
+  end
+
+  def write_response({:error, data}, conn) do
+    Logger.error(inspect(data))
+    send_resp(conn, 400, "")
+  end
+
+  defp filter_request_headers(headers) do
+    Enum.filter(headers, fn {name, _value} ->
+      Enum.all?(@request_blacklist, fn x -> x != name end)
+    end)
+  end
+
+  defp filter_response_headers(headers) do
+    headers
+    |> Enum.filter(fn {name, _} ->
+      Enum.any?(@response_whitelist, fn x -> x == name end)
+    end)
+    |> Kernel.++([
+      {"Accept-Language", "en-US"}
+    ])
+  end
+
+  def put_access_control_headers(conn) do
+    conn
+    |> put_resp_header("Access-Control-Allow-Headers", "*")
+    |> put_resp_header("Access-Control-Allow-Methods", "*")
+    |> put_resp_header("Access-Control-Allow-Origin", "*")
+  end
+end

--- a/lib/glific/providers/gupshup/contacts.ex
+++ b/lib/glific/providers/gupshup/contacts.ex
@@ -59,12 +59,14 @@ defmodule Glific.Providers.GupshupContacts do
     case ApiClient.get(url, headers: [{"apikey", api_key}]) do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, response_data} = Jason.decode(body)
+
         if is_nil(response_data["users"]) do
           raise "Error updating opted-in contacts #{response_data["message"]}"
         else
           users = response_data["users"]
           update_contacts(users, organization)
         end
+
       {:ok, %Tesla.Env{status: status, body: body}} when status in 400..499 ->
         raise "Error updating opted-in contacts #{body}"
 

--- a/lib/glific_web/controllers/api/v1/cors_controller.ex
+++ b/lib/glific_web/controllers/api/v1/cors_controller.ex
@@ -1,8 +1,14 @@
 defmodule GlificWeb.API.V1.CorsController do
+  @moduledoc """
+   Controller to manage the CORS request from the frontend.
+  """
+
   use GlificWeb, :controller
   require Logger
-  import Glific.CorsProxy, only: [request: 4, write_response: 2, put_access_control_headers: 1]
+  import Glific.CorsProxy, only: [request: 4, write_response: 2]
 
+  @doc false
+  @spec get(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def get(conn, params) do
     :get
     |> request(params["url"], conn.req_headers, "")

--- a/lib/glific_web/controllers/api/v1/cors_controller.ex
+++ b/lib/glific_web/controllers/api/v1/cors_controller.ex
@@ -1,0 +1,11 @@
+defmodule GlificWeb.API.V1.CorsController do
+  use GlificWeb, :controller
+  require Logger
+  import Glific.CorsProxy, only: [request: 4, write_response: 2, put_access_control_headers: 1]
+
+  def get(conn, params) do
+    :get
+    |> request(params["url"], conn.req_headers, "")
+    |> write_response(conn)
+  end
+end

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -43,8 +43,6 @@ defmodule GlificWeb.Router do
     post "/registration/reset-password", RegistrationController, :reset_password
     resources "/session", SessionController, singleton: true, only: [:create, :delete]
     post "/session/renew", SessionController, :renew
-
-
   end
 
   scope "/", GlificWeb do
@@ -130,7 +128,7 @@ defmodule GlificWeb.Router do
   end
 
   scope "/cors-proxy", GlificWeb.API.V1 do
-    #https://github.com/bcentinaro/cors-proxy
+    # https://github.com/bcentinaro/cors-proxy
     get("/*url", CorsController, :get)
   end
 

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -43,6 +43,8 @@ defmodule GlificWeb.Router do
     post "/registration/reset-password", RegistrationController, :reset_password
     resources "/session", SessionController, singleton: true, only: [:create, :delete]
     post "/session/renew", SessionController, :renew
+
+
   end
 
   scope "/", GlificWeb do
@@ -125,6 +127,11 @@ defmodule GlificWeb.Router do
 
   scope "/webhook", GlificWeb.Flows do
     post "/stir/survey", WebhookController, :stir_survey
+  end
+
+  scope "/cors-proxy", GlificWeb.API.V1 do
+    #https://github.com/bcentinaro/cors-proxy
+    get("/*url", CorsController, :get)
   end
 
   # defp debug_response(conn, _) do


### PR DESCRIPTION

Currently, we are using a Heroku library to show all the previews in the messages. Because of the per-minute request limitations in the library sometimes preview does not show up. 

That's why I implemented a proxy server. 

I borrowed the idea from https://github.com/bcentinaro/cors-proxy
