### PR TITLE
glific updates

### DIFF
--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -166,6 +166,12 @@ defmodule Glific.Providers.Gupshup.Message do
       |> Map.put(:destination, message.receiver.phone)
       |> Map.put("message", Jason.encode!(payload))
 
+    ## gupshup does not allow null in the caption.
+    attrs =
+      if Map.has_key?(attrs, :caption) and is_nil(attrs[:caption]),
+        do: Map.put(attrs, :caption, ""),
+        else: attrs
+
     create_oban_job(message, request_body, attrs)
   end
 


### PR DESCRIPTION
Gupshup does not allow null values in the caption. So I converted it to an empty string.