### PR TITLE
Optin status 

### DIFF
--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -492,7 +492,7 @@ defmodule Glific.Flows.Action do
         ContactAction.optin(
           context,
           method: "WA",
-          message_id: get_in(context, [:last_message, :bsp_message_id]),
+          message_id: context.last_message.bsp_message_id,
           bsp_status: :session_and_hsm
         )
 


### PR DESCRIPTION
Since flow context is a struct and does not implement access behavior, we can not use get_in/2 to get the value.