### PR TITLE
Increasing the delete interval to handle streaming error on Bigquery

### DIFF
--- a/lib/glific/bigquery.ex
+++ b/lib/glific/bigquery.ex
@@ -575,13 +575,13 @@ defmodule Glific.Bigquery do
   @spec clean_delta_tables(String.t(), map(), non_neg_integer) :: :ok
   defp clean_delta_tables(table, credentials, organization_id) do
     timezone = Partners.organization(organization_id).timezone
-    ## remove all the data for last 90 minutes
+    ## remove all the data for last 3 hours
     sql = """
     DELETE FROM `#{credentials.dataset_id}.#{table}_delta` WHERE EXISTS(SELECT * FROM  ( SELECT updated_at,
     ROW_NUMBER() OVER(PARTITION BY delta.id ORDER BY delta.updated_at DESC) AS row_num FROM `#{
       credentials.dataset_id
     }.#{table}_delta` delta )
-    WHERE row_num > 0 AND updated_at <= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 MINUTE), '#{
+    WHERE row_num > 0 AND updated_at <= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR), '#{
       timezone
     }'))
     """


### PR DESCRIPTION
Increased the update/delete interval to 3 hours to take care of streaming buffer error