### PR TITLE
sending error message when duplicate contact field is created

### DIFF
--- a/lib/glific_web/flows/flow_editor_controller.ex
+++ b/lib/glific_web/flows/flow_editor_controller.ex
@@ -80,20 +80,28 @@ defmodule GlificWeb.Flows.FlowEditorController do
   def fields_post(conn, params) do
     # need to store this into DB, the value_type will default to text in this case
     # the shortcode is the name, lower cased, and camelized
-    {:ok, contact_field} =
-      ContactField.create_contact_field(%{
-        name: params["label"],
-        shortcode: String.downcase(params["label"]) |> String.replace(" ", "_"),
-        organization_id: conn.assigns[:organization_id]
-      })
-
-    conn
-    |> json(%{
-      key: contact_field.shortcode,
-      name: contact_field.name,
-      label: contact_field.name,
-      value_type: contact_field.value_type
+    ContactField.create_contact_field(%{
+      name: params["label"],
+      shortcode: String.downcase(params["label"]) |> String.replace(" ", "_"),
+      organization_id: conn.assigns[:organization_id]
     })
+    |> case do
+      {:ok, contact_field} ->
+        conn
+        |> json(%{
+          key: contact_field.shortcode,
+          name: contact_field.name,
+          label: contact_field.name,
+          value_type: contact_field.value_type
+        })
+
+      {:error, _} ->
+        conn
+        |> put_status(400)
+        |> json(%{
+          error: %{status: 400, message: "Cannot create new field with label #{params["label"]}"}
+        })
+    end
   end
 
   @doc """

--- a/test/glific_web/flows/flow_editor_controller_test.exs
+++ b/test/glific_web/flows/flow_editor_controller_test.exs
@@ -107,6 +107,22 @@ defmodule GlificWeb.Flows.FlowEditorControllerTest do
              }
     end
 
+    test "creating a field with duplicate name in fields_post should return error", %{
+      conn: conn,
+      access_token: token
+    } do
+      conn =
+        get_auth_token(conn, token)
+        |> post("/flow-editor/fields", %{"label" => "Name"})
+
+      assert json_response(conn, 400) == %{
+               "error" => %{
+                 "message" => "Cannot create new field with label Name",
+                 "status" => 400
+               }
+             }
+    end
+
     test "labels", %{conn: conn, access_token: token} do
       flows = FlowLabel.get_all_flowlabel(conn.assigns[:organization_id])
 


### PR DESCRIPTION
Creating duplicate returns an error message along with an error generated in appsignal
 
<img width="652" alt="Screenshot 2021-06-02 at 4 35 18 PM" src="https://user-images.githubusercontent.com/40158831/120469902-92dc9980-c3c0-11eb-8584-097318beb530.png">
