### PR TITLE
Hotfix/Stripe-consulting-hours

### DIFF
--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -559,7 +559,6 @@ defmodule Glific.Partners.Billing do
     %{
       stripe_current_period_start: period_start,
       stripe_current_period_end: period_end,
-      stripe_last_usage_recorded: nil
     }
   end
 
@@ -711,7 +710,7 @@ defmodule Glific.Partners.Billing do
     start_date =
       if is_nil(billing.stripe_last_usage_recorded),
         # if we dont have last_usage, set it from the subscription period date
-        do: Timex.beginning_of_month(end_date),
+        do: Timex.beginning_of_week(end_date),
         # We know the last time recorded usage, we bump the date
         # to the next day for this period
         else: billing.stripe_last_usage_recorded

--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -558,7 +558,7 @@ defmodule Glific.Partners.Billing do
 
     %{
       stripe_current_period_start: period_start,
-      stripe_current_period_end: period_end,
+      stripe_current_period_end: period_end
     }
   end
 
@@ -595,7 +595,7 @@ defmodule Glific.Partners.Billing do
   defp subscription_requires_auth?(subscription),
     do:
       !is_nil(subscription.pending_setup_intent) &&
-        subscription.pending_setup_intent.status == "requires_action"
+        Map.get(subscription.pending_setup_intent, :status, "") == "requires_action"
 
   @doc """
   Update subscription details. We will also use this method while updating the details form webhook.


### PR DESCRIPTION
Added fixes for stripe_last_usage_recorded getting null incase of webhook event 