### PR TITLE
Feature/db cleanup cron

### DIFF
--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -1,0 +1,49 @@
+defmodule Glific.Erase do
+  @moduledoc """
+  A simple module to periodically delete old data to clean up db
+  """
+import Ecto.Query
+  alias Glific.{
+    Flows.WebhookLog,
+    Flows.FlowRevision,
+    Notifications,
+    Repo
+  }
+
+
+  @doc """
+  This is called from the cron job on a regular schedule and cleans database periodically
+  """
+  @spec clean_db(non_neg_integer) :: :ok
+  def clean_db(organization_id) do
+    clean_notifications(organization_id)
+    webhook_logs(organization_id)
+    flow_revision(organization_id)
+  end
+  @doc """
+  Deleting notification older than a month
+  """
+  @spec clean_notifications(non_neg_integer()) :: String.t()
+  def clean_notifications(organization_id) do
+    from n in Notification, where: n.inserted_at < ago(1, "month")
+    |> Repo.delete_all
+  end
+
+  @doc """
+  Deleting webhook_logs older than a month
+  """
+  @spec webhook_logs(non_neg_integer()) :: String.t()
+  def webhook_logs(organization_id) do
+    from w in WebhookLog, where: w.inserted_at < ago(1, "month")
+    |> Repo.delete_all
+  end
+
+  @doc """
+  Deleting flow_revision older than a month
+  """
+  @spec flow_revision(non_neg_integer()) :: String.t()
+  def flow_revision(organization_id) do
+    from w in FlowRevision, where: w.inserted_at < ago(1, "month")
+    |> Repo.delete_all
+  end
+end

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -15,6 +15,7 @@ defmodule Glific.Erase do
     clean_notifications()
     clean_webhook_logs()
     clean_flow_revision()
+    :ok
   end
 
   @doc """
@@ -44,10 +45,11 @@ defmodule Glific.Erase do
   @doc """
   Deleting flow_revision older than a month
   """
-  @spec clean_flow_revision() :: {integer(), nil | [term()]}
+  @spec clean_flow_revision() :: :ok
   def clean_flow_revision do
     clean_drafted_flow_revisions()
     clean_archived_flow_revisions()
+    :ok
   end
 
   defp clean_drafted_flow_revisions do

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -2,15 +2,14 @@ defmodule Glific.Erase do
   @moduledoc """
   A simple module to periodically delete old data to clean up db
   """
-import Ecto.Query
+  import Ecto.Query
+
   alias Glific.{
     Flows.WebhookLog,
-    Flows.FlowRevision,
     Notifications,
     Repo
   }
-
-
+  @max_age 1
   @doc """
   This is called from the cron job on a regular schedule and cleans database periodically
   """
@@ -20,13 +19,17 @@ import Ecto.Query
     webhook_logs(organization_id)
     flow_revision(organization_id)
   end
+
   @doc """
   Deleting notification older than a month
   """
   @spec clean_notifications(non_neg_integer()) :: String.t()
   def clean_notifications(organization_id) do
-    from n in Notification, where: n.inserted_at < ago(1, "month")
-    |> Repo.delete_all
+    from n in Notification,
+      where:
+        n.inserted_at <
+          ago(@max_age, "month")
+          |> Repo.delete_all()
   end
 
   @doc """
@@ -34,8 +37,11 @@ import Ecto.Query
   """
   @spec webhook_logs(non_neg_integer()) :: String.t()
   def webhook_logs(organization_id) do
-    from w in WebhookLog, where: w.inserted_at < ago(1, "month")
-    |> Repo.delete_all
+    from w in WebhookLog,
+      where:
+        w.inserted_at <
+          ago(@max_age, "month")
+          |> Repo.delete_all()
   end
 
   @doc """
@@ -43,7 +49,25 @@ import Ecto.Query
   """
   @spec flow_revision(non_neg_integer()) :: String.t()
   def flow_revision(organization_id) do
-    from w in FlowRevision, where: w.inserted_at < ago(1, "month")
-    |> Repo.delete_all
+    clean_drafted_flow_revisions()
+    clean_drafted_archived_revisions()
+  end
+
+  defp clean_drafted_flow_revisions do
+    """
+    DELETE FROM flow_revisions fr1
+    WHERE fr1.status = 'draft' AND id
+    NOT IN( SELECT fr2.id FROM flow_revisions fr2 WHERE fr2.flow_id = fr1.flow_id and fr2.status = 'draft' ORDER BY fr2.id DESC LIMIT 10);
+    """
+    |> Repo.query!([], timeout: 60_000, skip_organization_id: true)
+  end
+
+  defp clean_drafted_archived_revisions do
+    """
+    DELETE FROM flow_revisions fr1
+    WHERE fr1.status = 'archived' AND id
+    NOT IN( SELECT fr2.id FROM flow_revisions fr2 WHERE fr2.flow_id = fr1.flow_id  and fr2.status = 'archived' ORDER BY fr2.id DESC LIMIT 10);
+    """
+    |> Repo.query!([], timeout: 60_000, skip_organization_id: true)
   end
 end

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -6,10 +6,11 @@ defmodule Glific.Erase do
 
   alias Glific.{
     Flows.WebhookLog,
-    Notifications,
+    Notifications.Notification,
     Repo
   }
-  @max_age 1
+
+  @period "month"
   @doc """
   This is called from the cron job on a regular schedule and cleans database periodically
   """
@@ -25,11 +26,11 @@ defmodule Glific.Erase do
   """
   @spec clean_notifications(non_neg_integer()) :: String.t()
   def clean_notifications(organization_id) do
-    from n in Notification,
-      where:
-        n.inserted_at <
-          ago(@max_age, "month")
-          |> Repo.delete_all()
+    Repo.delete_all(
+      from(n in "notifications",
+        where: n.inserted_at < fragment("CURRENT_DATE - ('1' || ?)::interval", ^@period)
+      ), skip_organization_id: true
+    )
   end
 
   @doc """
@@ -37,11 +38,11 @@ defmodule Glific.Erase do
   """
   @spec webhook_logs(non_neg_integer()) :: String.t()
   def webhook_logs(organization_id) do
-    from w in WebhookLog,
-      where:
-        w.inserted_at <
-          ago(@max_age, "month")
-          |> Repo.delete_all()
+    Repo.delete_all(
+      from(w in "webhook_logs",
+        where: w.inserted_at < fragment("CURRENT_DATE - ('1' || ?)::interval", ^@period)
+      ), skip_organization_id: true
+    )
   end
 
   @doc """

--- a/lib/glific/jobs/minute_worker.ex
+++ b/lib/glific/jobs/minute_worker.ex
@@ -10,6 +10,7 @@ defmodule Glific.Jobs.MinuteWorker do
   alias Glific.{
     BigQuery.BigQueryWorker,
     Contacts,
+    Erase,
     Flags,
     Flows.FlowContext,
     GCS.GcsWorker,
@@ -88,6 +89,7 @@ defmodule Glific.Jobs.MinuteWorker do
     case job do
       "daily_tasks" ->
         Partners.perform_all(&Billing.update_usage/2, %{time: DateTime.utc_now()}, [])
+        Partners.perform_all(&Erase.clean_db/2, nil, [])
 
       "delete_tasks" ->
         # lets do this first, before we delete any records, so we have a better picture

--- a/lib/glific/jobs/minute_worker.ex
+++ b/lib/glific/jobs/minute_worker.ex
@@ -89,7 +89,7 @@ defmodule Glific.Jobs.MinuteWorker do
     case job do
       "daily_tasks" ->
         Partners.perform_all(&Billing.update_usage/2, %{time: DateTime.utc_now()}, [])
-        Partners.perform_all(&Erase.clean_db/1, nil, [])
+        Erase.perform_periodic()
 
       "delete_tasks" ->
         # lets do this first, before we delete any records, so we have a better picture

--- a/lib/glific/jobs/minute_worker.ex
+++ b/lib/glific/jobs/minute_worker.ex
@@ -89,7 +89,7 @@ defmodule Glific.Jobs.MinuteWorker do
     case job do
       "daily_tasks" ->
         Partners.perform_all(&Billing.update_usage/2, %{time: DateTime.utc_now()}, [])
-        Partners.perform_all(&Erase.clean_db/2, nil, [])
+        Partners.perform_all(&Erase.clean_db/1, nil, [])
 
       "delete_tasks" ->
         # lets do this first, before we delete any records, so we have a better picture

--- a/lib/glific/state/state.ex
+++ b/lib/glific/state/state.ex
@@ -193,7 +193,9 @@ defmodule Glific.State do
         if (user && user.id == id && user.fingerprint == fingerprint) ||
              DateTime.compare(time, expiry_time) == :lt do
           Logger.info(
-            "Releasing entity: #{entity} for user: #{user.name} of org_id: #{user.organization_id}."
+            "Releasing entity: #{inspect(entity)} for user: #{user.name} of org_id: #{
+              user.organization_id
+            }."
           )
 
           publish_data(entity.organization_id, id, entity_type)

--- a/test/glific/erase_test.exs
+++ b/test/glific/erase_test.exs
@@ -1,4 +1,48 @@
 defmodule Glific.EraseTest do
   use Glific.DataCase
 
+  alias Glific.{
+    Erase,
+    Fixtures,
+    Flows.WebhookLog,
+    Notifications.Notification,
+    Notifications,
+    Repo
+  }
+
+  test "perform_periodic with clears webhook log older than a month",
+       %{
+         organization_id: _organization_id
+       } = attrs do
+    Fixtures.webhook_log_fixture(attrs)
+    time = DateTime.truncate(DateTime.utc_now(), :second)
+
+    Repo.update_all(WebhookLog,
+      set: [
+        inserted_at: Timex.shift(time, months: -2)
+      ]
+    )
+
+    logs_count = WebhookLog.count_webhook_logs(%{filter: attrs})
+    Erase.perform_periodic()
+    assert WebhookLog.count_webhook_logs(%{filter: attrs}) == logs_count - 1
+  end
+
+  test "perform_periodic with clears notifications log older than a month",
+       %{
+         organization_id: _organization_id
+       } = attrs do
+    Fixtures.notification_fixture(attrs)
+    time = DateTime.truncate(DateTime.utc_now(), :second)
+
+    Repo.update_all(Notification,
+      set: [
+        inserted_at: Timex.shift(time, months: -2)
+      ]
+    )
+
+    notification_count = Notifications.count_notifications(%{filter: attrs})
+    Erase.perform_periodic()
+    assert Notifications.count_notifications(%{filter: attrs}) == notification_count - 1
+  end
 end

--- a/test/glific/erase_test.exs
+++ b/test/glific/erase_test.exs
@@ -5,15 +5,13 @@ defmodule Glific.EraseTest do
     Erase,
     Fixtures,
     Flows.WebhookLog,
+    Flows.FlowRevision,
     Notifications.Notification,
     Notifications,
     Repo
   }
 
-  test "perform_periodic with clears webhook log older than a month",
-       %{
-         organization_id: _organization_id
-       } = attrs do
+  test "perform_periodic clears webhook log older than a month", attrs do
     Fixtures.webhook_log_fixture(attrs)
     time = DateTime.truncate(DateTime.utc_now(), :second)
 
@@ -28,10 +26,7 @@ defmodule Glific.EraseTest do
     assert WebhookLog.count_webhook_logs(%{filter: attrs}) == logs_count - 1
   end
 
-  test "perform_periodic with clears notifications log older than a month",
-       %{
-         organization_id: _organization_id
-       } = attrs do
+  test "perform_periodic clears notifications log older than a month", attrs do
     Fixtures.notification_fixture(attrs)
     time = DateTime.truncate(DateTime.utc_now(), :second)
 
@@ -44,5 +39,22 @@ defmodule Glific.EraseTest do
     notification_count = Notifications.count_notifications(%{filter: attrs})
     Erase.perform_periodic()
     assert Notifications.count_notifications(%{filter: attrs}) == notification_count - 1
+  end
+
+  test "perform_periodic clears flow revisions with status as draft, and saving only recent 10",
+       attrs do
+    flow = Fixtures.flow_fixture(attrs)
+
+    Enum.each(1..15, fn _x ->
+      FlowRevision.create_flow_revision(%{
+        definition: FlowRevision.default_definition(flow),
+        flow_id: flow.id,
+        organization_id: flow.organization_id
+      })
+    end)
+
+    flow_revision_count = Repo.count_filter(%{}, FlowRevision, &Repo.filter_with/2)
+    Erase.perform_periodic()
+    assert Repo.count_filter(%{}, FlowRevision, &Repo.filter_with/2) == flow_revision_count - 6
   end
 end

--- a/test/glific/erase_test.exs
+++ b/test/glific/erase_test.exs
@@ -4,10 +4,10 @@ defmodule Glific.EraseTest do
   alias Glific.{
     Erase,
     Fixtures,
-    Flows.WebhookLog,
     Flows.FlowRevision,
-    Notifications.Notification,
+    Flows.WebhookLog,
     Notifications,
+    Notifications.Notification,
     Repo
   }
 

--- a/test/glific/erase_test.exs
+++ b/test/glific/erase_test.exs
@@ -1,0 +1,4 @@
+defmodule Glific.EraseTest do
+  use Glific.DataCase
+
+end


### PR DESCRIPTION
Automatic cleaning of data which become irrelevant after some time like:

Webhook logs: Clearing webhook logs older than a month
Notifications: Clearing notifications older than a month
Flow revisions(draft and archived): Clearing flow revision with revision number greater than 10