### PR TITLE
added check for validating billing in webhook

### DIFF
--- a/test/glific/partners/invoice_test.exs
+++ b/test/glific/partners/invoice_test.exs
@@ -177,7 +177,12 @@ defmodule Glific.InvoiceTest do
        %{
          organization_id: organization_id
        } do
-    billing = Fixtures.billing_fixture(%{organization_id: organization_id})
+    billing =
+      Fixtures.billing_fixture(%{
+        organization_id: organization_id,
+        stripe_subscription_id: "test_sub_ID",
+        stripe_payment_method_id: "test_pm_ID"
+      })
 
     with_mocks([
       {


### PR DESCRIPTION
- added check for validating billing in webhook in case of organization that have not put card details or have removed it but are in Stripe portal