### PR TITLE
Stripe: update metered user usage

### DIFF
--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -788,10 +788,10 @@ defmodule Glific.Partners.Billing do
     )
 
     case Stats.usage(organization_id, dates.start_usage_date, dates.end_usage_date) do
-      %{messages: messages, users: users} ->
+      %{messages: _messages, users: users} ->
         record_subscription_item(
           subscription_items[stripe_ids()["users"]],
-          usage.users,
+          users,
           dates.time,
           "users: #{organization_id}, #{Date.to_string(dates.start_usage_date)}"
         )

--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -783,6 +783,10 @@ defmodule Glific.Partners.Billing do
     start_date = end_date |> Timex.beginning_of_month() |> Timex.beginning_of_day()
     dates = format_dates(start_date, end_date)
 
+    Logger.info(
+      "Updating metered user in billing for org_id: #{organization_id} between #{dates.start_usage_date} and #{dates.end_usage_date}"
+    )
+
     case Stats.usage(organization_id, dates.start_usage_date, dates.end_usage_date) do
       usage ->
         record_subscription_item(
@@ -791,9 +795,12 @@ defmodule Glific.Partners.Billing do
           dates.time,
           "users: #{organization_id}, #{Date.to_string(dates.start_usage_date)}"
         )
-    end
 
-    :ok
+        :ok
+
+      nil ->
+        :ok
+    end
   end
 
   # record the usage against a subscription item in stripe

--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -788,15 +788,13 @@ defmodule Glific.Partners.Billing do
     )
 
     case Stats.usage(organization_id, dates.start_usage_date, dates.end_usage_date) do
-      usage ->
+      %{messages: messages, users: users} ->
         record_subscription_item(
           subscription_items[stripe_ids()["users"]],
           usage.users,
           dates.time,
           "users: #{organization_id}, #{Date.to_string(dates.start_usage_date)}"
         )
-
-        :ok
 
       nil ->
         :ok


### PR DESCRIPTION
- Added log when updating metered usage in stripe billing
- return `:ok` when no stats available