### PR TITLE
Webhook Logs: using or in filters

### DIFF
--- a/lib/glific/flows/webhook_log.ex
+++ b/lib/glific/flows/webhook_log.ex
@@ -116,10 +116,10 @@ defmodule Glific.Flows.WebhookLog do
     # We might want to move them in the repo in the future.
     Enum.reduce(filter, query, fn
       {:url, url}, query ->
-        from q in query, where: ilike(q.url, ^"%#{url}%")
+        from q in query, or_where: ilike(q.url, ^"%#{url}%")
 
       {:status_code, status_code}, query ->
-        from q in query, where: q.status_code == ^status_code
+        from q in query, or_where: q.status_code == ^status_code
 
       {:contact_phone, contact_phone}, query ->
         sub_query =
@@ -128,7 +128,7 @@ defmodule Glific.Flows.WebhookLog do
           |> select([c], c.id)
 
         query
-        |> where([q], q.contact_id in subquery(sub_query))
+        |> or_where([q], q.contact_id in subquery(sub_query))
 
       _, query ->
         query

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -155,15 +155,13 @@ defmodule Glific.Flows.WebhookTest do
       webhook_log_2 = Fixtures.webhook_log_fixture(valid_attrs_2)
 
       assert [Map.merge(webhook_log_2, %{status: "Error"})] ==
-               WebhookLog.list_webhook_logs(%{filter: Map.merge(%{status_code: 500}, attrs)})
+               WebhookLog.list_webhook_logs(%{filter: %{status_code: 500}})
 
       assert [Map.merge(webhook_log_1, %{status: "Success"})] ==
-               WebhookLog.list_webhook_logs(%{
-                 filter: Map.merge(%{status_code: 200, status: "Success"}, attrs)
-               })
+               WebhookLog.list_webhook_logs(%{filter: %{status_code: 200, status: "Success"}})
 
       assert [Map.merge(webhook_log_1, %{status: "Success"})] ==
-               WebhookLog.list_webhook_logs(%{filter: Map.merge(%{url: @valid_attrs.url}, attrs)})
+               WebhookLog.list_webhook_logs(%{filter: %{url: @valid_attrs.url}})
 
       #  order by inserted at
       assert [
@@ -181,7 +179,7 @@ defmodule Glific.Flows.WebhookTest do
                Map.merge(webhook_log_1, %{status: "Success"})
              ] ==
                WebhookLog.list_webhook_logs(%{
-                 filter: Map.merge(attrs, %{contact_phone: phone})
+                 filter: %{contact_phone: phone}
                })
     end
 


### PR DESCRIPTION
Using `or` instead of `and` in the filter for webhook logs