### PR TITLE
Bigquery Added inserted at

### DIFF
--- a/lib/glific/clients/sol.ex
+++ b/lib/glific/clients/sol.ex
@@ -49,7 +49,7 @@ defmodule Glific.Clients.Sol do
     language_label = fields["language_label"]
     city = fields["city"]
     ## y-m-d
-    activity_date = Timex.today() |> Timex.format!("{YYYY}-{0M}-{D}")
+    activity_date = Timex.today() |> Timex.format!("{YYYY}-{0M}-{0D}")
     activity = get_activity_by_date(organization_id, activity_date, city)
     activity_data = get_activity_content(activity, language_label, organization_id)
 

--- a/lib/glific/third_party/bigquery/bigquery_schema.ex
+++ b/lib/glific/third_party/bigquery/bigquery_schema.ex
@@ -23,6 +23,12 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
+        mode: "NULLABLE"
+      },
+      %{
         description: "User name",
         name: "name",
         type: "STRING",
@@ -236,6 +242,12 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
+        mode: "NULLABLE"
+      },
+      %{
         description: "Uniquely generated message UUID, primarily needed for the flow editor",
         name: "uuid",
         type: "STRING",
@@ -446,6 +458,12 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
+        mode: "NULLABLE"
+      },
+      %{
         description: "caption we received with the message",
         name: "caption",
         type: "STRING",
@@ -500,6 +518,12 @@ defmodule Glific.BigQuery.Schema do
         description: "Unique UUID for the row (allows us to delete duplicates)",
         name: "bq_uuid",
         type: "STRING",
+        mode: "NULLABLE"
+      },
+      %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
         mode: "NULLABLE"
       },
       %{
@@ -563,6 +587,12 @@ defmodule Glific.BigQuery.Schema do
         description: "Unique UUID for the row (allows us to delete duplicates)",
         name: "bq_uuid",
         type: "STRING",
+        mode: "NULLABLE"
+      },
+      %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
         mode: "NULLABLE"
       },
       %{
@@ -696,6 +726,12 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
+        mode: "NULLABLE"
+      },
+      %{
         description: "Name of the workflow",
         name: "name",
         type: "STRING",
@@ -769,6 +805,12 @@ defmodule Glific.BigQuery.Schema do
         description: "Unique UUID for the row (allows us to delete duplicates)",
         name: "bq_uuid",
         type: "STRING",
+        mode: "NULLABLE"
+      },
+      %{
+        description: "Time when the record entry was made on bigquery",
+        name: "bq_inserted_at",
+        type: "DATETIME",
         mode: "NULLABLE"
       },
       %{


### PR DESCRIPTION
- Added bq inserted_at to make the selection of most recent rows in the storage. 
- We saw that there are a few cases where the updated_at and inserted_at are the same. So this field will help in case of those issues as well.