### PR TITLE
- Adding more information to the errors can help us in debugging while publishing the flow.

### DIFF
--- a/lib/glific_web/resolvers/flows.ex
+++ b/lib/glific_web/resolvers/flows.ex
@@ -118,8 +118,8 @@ defmodule GlificWeb.Resolvers.Flows do
       {:error, errors} ->
         {:ok, %{success: true, errors: %{key: hd(errors), message: hd(tl(errors))}}}
 
-      _ ->
-        {:error, dgettext("errors", "Something went wrong.")}
+      errors ->
+        {:error, dgettext("errors", "Something went wrong. Errors: #{inspect(errors)}")}
     end
   end
 


### PR DESCRIPTION
- Adding more information to the errors can help us in debugging while publishing the flow.
- 