### PR TITLE
Gupshup credentials fixes

### DIFF
--- a/lib/glific/repo.ex
+++ b/lib/glific/repo.ex
@@ -259,7 +259,7 @@ defmodule Glific.Repo do
         make_like(query, :body, body)
 
       {:shortcode, shortcode}, query ->
-        make_like(query, :shortcode, shortcode)
+        from q in query, where: q.shortcode == ^shortcode
 
       {:language, language}, query ->
         from q in query,


### PR DESCRIPTION
Fetching provider by shortcode was giving two results (gupshup  and gupshup enterprise)
Now we will match shortcode strictly. 