### PR TITLE
Example is not mandatory while fetching the HSM form BSP 

### DIFF
--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -338,10 +338,10 @@ defmodule Glific.Templates do
     example =
       case Jason.decode(template["meta"] || "{}") do
         {:ok, meta} ->
-          meta["example"]
+          meta["example"] || "NA"
 
         _ ->
-          nil
+          "NA"
       end
 
     if example,


### PR DESCRIPTION
- Set example as "NA" if it's not found. 