### PR TITLE
Roles and Permission: Seeder Fixes

### DIFF
--- a/lib/glific/seeds/seeds_dev.ex
+++ b/lib/glific/seeds/seeds_dev.ex
@@ -753,21 +753,10 @@ if Code.ensure_loaded?(Faker) do
     def seed_user_roles(organization \\ nil) do
       organization = get_organization(organization)
 
-      [u1, u2, u3, u4, u5 | _] = Users.list_users(%{filter: %{organization_id: organization.id}})
+      [_u1, _u2, u3, u4, u5 | _] =
+        Users.list_users(%{filter: %{organization_id: organization.id}})
 
       [r1, r2, r3 | _] = AccessControl.list_roles(%{organization_id: organization.id})
-
-      Repo.insert!(%AccessControl.UserRole{
-        user_id: u1.id,
-        role_id: r1.id,
-        organization_id: organization.id
-      })
-
-      Repo.insert!(%AccessControl.UserRole{
-        user_id: u2.id,
-        role_id: r1.id,
-        organization_id: organization.id
-      })
 
       Repo.insert!(%AccessControl.UserRole{
         user_id: u3.id,
@@ -1498,8 +1487,6 @@ if Code.ensure_loaded?(Faker) do
       seed_interactives(organization)
 
       seed_contact_history(organization)
-
-      seed_roles(organization)
 
       seed_user_roles(organization)
     end

--- a/lib/glific/seeds/seeds_dev.ex
+++ b/lib/glific/seeds/seeds_dev.ex
@@ -753,10 +753,10 @@ if Code.ensure_loaded?(Faker) do
     def seed_user_roles(organization \\ nil) do
       organization = get_organization(organization)
 
-      [_u1, _u2, u3, u4, u5 | _] =
+      [_u1, _u2, u3, u4, u5, u6 | _] =
         Users.list_users(%{filter: %{organization_id: organization.id}})
 
-      [r1, r2, r3 | _] = AccessControl.list_roles(%{organization_id: organization.id})
+      [r1, r2, r3, r4 | _] = AccessControl.list_roles(%{organization_id: organization.id})
 
       Repo.insert!(%AccessControl.UserRole{
         user_id: u3.id,
@@ -773,6 +773,12 @@ if Code.ensure_loaded?(Faker) do
       Repo.insert!(%AccessControl.UserRole{
         user_id: u5.id,
         role_id: r1.id,
+        organization_id: organization.id
+      })
+
+      Repo.insert!(%AccessControl.UserRole{
+        user_id: u6.id,
+        role_id: r4.id,
         organization_id: organization.id
       })
     end

--- a/lib/glific/users.ex
+++ b/lib/glific/users.ex
@@ -255,12 +255,24 @@ defmodule Glific.Users do
   @spec maybe_promote_user(list(), User.t()) :: User.t()
   defp maybe_promote_user([], user) do
     # this is the first user, since the list of valid org users is empty
-    {:ok, user} = update_user(user, %{roles: [:admin], add_role_ids: get_role_id("Admin")})
+    {:ok, user} =
+      update_user(user, %{
+        roles: [:admin],
+        add_role_ids: get_role_id("Admin"),
+        organization_id: user.organization_id
+      })
+
     user
   end
 
   defp maybe_promote_user(_list, user) do
-    {:ok, user} = update_user(user, %{roles: [:none], add_role_ids: get_role_id("No access")})
+    {:ok, user} =
+      update_user(user, %{
+        roles: [:none],
+        add_role_ids: get_role_id("No access"),
+        organization_id: user.organization_id
+      })
+
     user
   end
 

--- a/priv/repo/seeds/20200723172939_add_glific_data.exs
+++ b/priv/repo/seeds/20200723172939_add_glific_data.exs
@@ -5,6 +5,7 @@ defmodule Glific.Repo.Seeds.AddGlificData do
   envs([:dev, :test, :prod])
 
   alias Glific.{
+    AccessControl,
     Contacts.Contact,
     Contacts.ContactsField,
     Flows.Flow,
@@ -17,6 +18,7 @@ defmodule Glific.Repo.Seeds.AddGlificData do
     Profiles.Profile,
     Repo,
     Searches.SavedSearch,
+    Seeds.SeedsDev,
     Seeds.SeedsFlows,
     Seeds.SeedsMigration,
     Settings.Language,
@@ -86,6 +88,10 @@ defmodule Glific.Repo.Seeds.AddGlificData do
     flow_labels(organization)
 
     flows(organization)
+
+    roles(organization)
+
+    user_roles(organization)
 
     contacts_field(organization)
 
@@ -585,6 +591,27 @@ defmodule Glific.Repo.Seeds.AddGlificData do
 
   def flows(organization),
     do: SeedsFlows.seed([organization])
+
+  def roles(organization),
+    do: SeedsDev.seed_roles([organization])
+
+  def user_roles(organization) do
+    [u1, u2] = Users.list_users(%{filter: %{organization_id: organization.id}})
+
+    [r1 | _] = AccessControl.list_roles(%{organization_id: organization.id})
+
+    Repo.insert!(%AccessControl.UserRole{
+      user_id: u1.id,
+      role_id: r1.id,
+      organization_id: organization.id
+    })
+
+    Repo.insert!(%AccessControl.UserRole{
+      user_id: u2.id,
+      role_id: r1.id,
+      organization_id: organization.id
+    })
+  end
 
   def contacts_field(organization) do
     data = [

--- a/priv/repo/seeds/20200723172939_add_glific_data.exs
+++ b/priv/repo/seeds/20200723172939_add_glific_data.exs
@@ -593,12 +593,12 @@ defmodule Glific.Repo.Seeds.AddGlificData do
     do: SeedsFlows.seed([organization])
 
   def roles(organization),
-    do: SeedsDev.seed_roles([organization])
+    do: SeedsDev.seed_roles(organization)
 
   def user_roles(organization) do
     [u1, u2] = Users.list_users(%{filter: %{organization_id: organization.id}})
 
-    [r1 | _] = AccessControl.list_roles(%{organization_id: organization.id})
+    {:ok, r1} = Repo.fetch_by(AccessControl.Role, %{label: "Admin"})
 
     Repo.insert!(%AccessControl.UserRole{
       user_id: u1.id,

--- a/test/glific/access_control_test.exs
+++ b/test/glific/access_control_test.exs
@@ -29,7 +29,6 @@ defmodule Glific.AccessControlTest do
         for_actor: %{organization_id: attrs.organization_id}
       )
 
-      SeedsDev.seed_roles()
       Fixtures.role_fixture(attrs)
 
       assert AccessControl.count_roles(%{filter: attrs, organization_id: attrs.organization_id}) ==
@@ -42,7 +41,12 @@ defmodule Glific.AccessControlTest do
       )
 
       role = Fixtures.role_fixture(attrs)
-      assert AccessControl.list_roles(%{organization_id: attrs.organization_id}) == [role]
+
+      assert Enum.filter(
+               AccessControl.list_roles(%{organization_id: attrs.organization_id}),
+               fn r -> r.label == role.label end
+             ) ==
+               [role]
     end
 
     test "list_roles/0 returns with filtered data", attrs do

--- a/test/glific_web/schema/role_test.exs
+++ b/test/glific_web/schema/role_test.exs
@@ -4,14 +4,8 @@ defmodule GlificWeb.Schema.RoleTest do
 
   alias Glific.{
     AccessControl.Role,
-    Repo,
-    Seeds.SeedsDev
+    Repo
   }
-
-  setup do
-    SeedsDev.seed_roles()
-    :ok
-  end
 
   load_gql(:list, GlificWeb.Schema, "assets/gql/roles/list.gql")
   load_gql(:by_id, GlificWeb.Schema, "assets/gql/roles/by_id.gql")

--- a/test/glific_web/schema/user_test.exs
+++ b/test/glific_web/schema/user_test.exs
@@ -17,8 +17,6 @@ defmodule GlificWeb.Schema.UserTest do
     SeedsDev.seed_organizations(default_provider)
     SeedsDev.seed_contacts()
     SeedsDev.seed_users()
-    SeedsDev.seed_roles()
-    SeedsDev.seed_user_roles()
     :ok
   end
 


### PR DESCRIPTION
There are 4 roles by default in the table Roles for each organization and then there is a user roles table where mapping is done for each role to each user
Right now these 4 roles are not populated in the new organization setup. 