### PR TITLE
Profiles: storing profile level info across tables

### DIFF
--- a/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
+++ b/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
@@ -1,0 +1,27 @@
+defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
+  use Ecto.Migration
+
+  def change do
+    add_profile_to_flow_results()
+    add_profile_to_flow_contexts()
+    add_profile_to_contact_histories()
+  end
+
+  defp add_profile_to_flow_results() do
+    alter table(:flow_results) do
+      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+    end
+  end
+
+  defp add_profile_to_flow_contexts() do
+    alter table(:flow_contexts) do
+      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+    end
+  end
+
+  defp add_profile_to_contact_histories() do
+    alter table(:contact_histories) do
+      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
+++ b/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
@@ -6,6 +6,10 @@ defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
     add_profile_to_flow_contexts()
     add_profile_to_contact_histories()
     add_profile_to_messages()
+    add_profile_id_flow_results_trigger()
+    add_profile_id_flow_contexts_trigger()
+    add_profile_id_contact_histories_trigger()
+    add_profile_id_messages_trigger()
   end
 
   defp add_profile_to_flow_results() do
@@ -30,5 +34,101 @@ defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
     alter table(:messages) do
       add :profile_id, references(:profiles, on_delete: :nilify_all), null: true
     end
+  end
+
+  defp add_profile_id_flow_results_trigger() do
+    execute """
+    CREATE OR REPLACE FUNCTION update_profile_id_on_new_flow_result()
+      RETURNS trigger AS $$
+
+      BEGIN
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE flow_results set profile_id = (SELECT active_profile_id FROM contacts WHERE id = New.contact_id) where id = New.id;
+        END IF;
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER update_profile_id_on_new_flow_result
+    AFTER INSERT
+    ON flow_results
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_profile_id_on_new_flow_result();
+    """
+  end
+
+  defp add_profile_id_flow_contexts_trigger() do
+    execute """
+    CREATE OR REPLACE FUNCTION update_profile_id_on_new_flow_context()
+      RETURNS trigger AS $$
+
+      BEGIN
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE flow_contexts set profile_id = (SELECT active_profile_id FROM contacts WHERE id = New.contact_id) where id = New.id;
+        END IF;
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER update_profile_id_on_new_flow_context
+    AFTER INSERT
+    ON flow_contexts
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_profile_id_on_new_flow_context();
+    """
+  end
+
+  defp add_profile_id_contact_histories_trigger() do
+    execute """
+    CREATE OR REPLACE FUNCTION update_profile_id_on_new_contact_history()
+      RETURNS trigger AS $$
+
+      BEGIN
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE contact_histories set profile_id = (SELECT active_profile_id FROM contacts WHERE id = New.contact_id) where id = New.id;
+        END IF;
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER update_profile_id_on_new_contact_history
+    AFTER INSERT
+    ON contact_histories
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_profile_id_on_new_contact_history();
+    """
+  end
+
+  defp add_profile_id_messages_trigger() do
+    execute """
+    CREATE OR REPLACE FUNCTION update_profile_id_on_new_message()
+      RETURNS trigger AS $$
+
+      BEGIN
+      CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        IF (TG_OP = 'INSERT') THEN
+          UPDATE messages set profile_id = (SELECT active_profile_id FROM contacts WHERE id = New.contact_id) where id = New.id;
+        END IF;
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER update_profile_id_on_new_message
+    AFTER INSERT
+    ON messages
+    FOR EACH ROW
+    EXECUTE PROCEDURE update_profile_id_on_new_message();
+    """
   end
 end

--- a/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
+++ b/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
@@ -10,25 +10,25 @@ defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
 
   defp add_profile_to_flow_results() do
     alter table(:flow_results) do
-      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+      add :profile_id, references(:profiles, on_delete: :nilify_all), null: true
     end
   end
 
   defp add_profile_to_flow_contexts() do
     alter table(:flow_contexts) do
-      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+      add :profile_id, references(:profiles, on_delete: :nilify_all), null: true
     end
   end
 
   defp add_profile_to_contact_histories() do
     alter table(:contact_histories) do
-      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+      add :profile_id, references(:profiles, on_delete: :nilify_all), null: true
     end
   end
 
-  defp add_profile_to_messages()() do
+  defp add_profile_to_messages() do
     alter table(:messages) do
-      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+      add :profile_id, references(:profiles, on_delete: :nilify_all), null: true
     end
   end
 end

--- a/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
+++ b/priv/repo/migrations/20220826061242_add_profile_id_to_flow_tables.exs
@@ -5,6 +5,7 @@ defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
     add_profile_to_flow_results()
     add_profile_to_flow_contexts()
     add_profile_to_contact_histories()
+    add_profile_to_messages()
   end
 
   defp add_profile_to_flow_results() do
@@ -21,6 +22,12 @@ defmodule Glific.Repo.Migrations.AddProfileIdToFlowTables do
 
   defp add_profile_to_contact_histories() do
     alter table(:contact_histories) do
+      add :profile_id, references(:profiles, on_delete: :delete_all), null: true
+    end
+  end
+
+  defp add_profile_to_messages()() do
+    alter table(:messages) do
       add :profile_id, references(:profiles, on_delete: :delete_all), null: true
     end
   end


### PR DESCRIPTION
## Summary
 Target issue is #2404  
 
-  Added profile id to messages table
-  Added profile id to flow results table
-  Added profile id to flow contexts table
-  Added profile id to contact history table
-  Added trigger to update profile ids on new insertion

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases. 
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing
