### PR TITLE
Disable automatic template approval for new organization

### DIFF
--- a/lib/glific/saas/onboard.ex
+++ b/lib/glific/saas/onboard.ex
@@ -24,7 +24,6 @@ defmodule Glific.Saas.Onboard do
     |> Queries.validate(params)
     |> Queries.setup(params)
     |> Queries.seed_data()
-    |> Queries.sync_templates()
     |> format_results()
     |> notify_saas_team()
   end

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -82,15 +82,15 @@ defmodule Glific.OnboardTest do
     assert result.credential != nil
 
     ## new org will have a common otp template
-    [common_otp_template | _tail] =
-      Glific.Templates.list_session_templates(%{
-        is_hsm: true,
-        organization_id: result.organization.id,
-        shortocode: "common_otp"
-      })
+    # [common_otp_template | _tail] =
+    #   Glific.Templates.list_session_templates(%{
+    #     is_hsm: true,
+    #     organization_id: result.organization.id,
+    #     shortocode: "common_otp"
+    #   })
 
-    assert common_otp_template.label == "common_otp"
-    assert common_otp_template.organization_id == result.organization.id
+    # assert common_otp_template.label == "common_otp"
+    # assert common_otp_template.organization_id == result.organization.id
   end
 
   test "ensure that sending in valid parameters, update organization status" do


### PR DESCRIPTION
We recently switched to Partner API to submit the templates. We missed this edge case. 
Disabling the common otp template submission while onboarding an org. 