### PR TITLE
Bigquery: Syncing message groups

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_schema.ex
+++ b/lib/glific/third_party/bigquery/bigquery_schema.ex
@@ -453,6 +453,18 @@ defmodule Glific.BigQuery.Schema do
         name: "profile_id",
         type: "INTEGER",
         mode: "NULLABLE"
+      },
+      %{
+        description: "ID of group reference to the group table",
+        name: "group_id",
+        type: "INTEGER",
+        mode: "NULLABLE"
+      },
+      %{
+        description: "label of the group referenced to in group table",
+        name: "group_name",
+        type: "STRING",
+        mode: "NULLABLE"
       }
     ]
   end

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -728,7 +728,9 @@ defmodule Glific.BigQuery.BigQueryWorker do
         latitude: if(!is_nil(row.location), do: row.location.latitude),
         errors: BigQuery.format_json(row.errors),
         message_broadcast_id: row.message_broadcast_id,
-        bsp_status: row.bsp_status
+        bsp_status: row.bsp_status,
+        group_id: row.group_id,
+        group_name: row.group.label
       }
       |> Map.merge(message_media_info(row.media))
       |> Map.merge(message_template_info(row))
@@ -853,7 +855,8 @@ defmodule Glific.BigQuery.BigQueryWorker do
         :media,
         :flow_object,
         :location,
-        :template
+        :template,
+        :group
       ])
 
   defp get_query("message_conversations", organization_id, attrs),

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -730,7 +730,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
         message_broadcast_id: row.message_broadcast_id,
         bsp_status: row.bsp_status,
         group_id: row.group_id,
-        group_name: row.group.label
+        group_name: if(!is_nil(row.group), do: row.group.label)
       }
       |> Map.merge(message_media_info(row.media))
       |> Map.merge(message_template_info(row))


### PR DESCRIPTION
## Summary
 Target issue is #2510   

## Notes

- Added support to sync group level info in messages table to BigQuery