### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,23 +199,15 @@ You cannot do much from the glific_backend unless you are an API developer. To s
 install [Glific Frontend](https://github.com/glific/glific-frontend/)
 
 ```bash
-git clone https://github.com/glific/glific_frontend
-cd glific_frontend
+git clone https://github.com/glific/glific-frontend
+cd glific-frontend
 ```
 
-open package.json and update start script
+open package.json
 
 ```bash
 nano package.json
 ```
-
-from
-
-    "start": "HTTPS=true SSL_CRT_FILE=../glific/priv/cert/glific.test+1.pem SSL_KEY_FILE=../glific/priv/cert/glific.test+1-key.pem react-scripts start"
-
-to
-
-    "start": "HTTPS=true SSL_CRT_FILE=../glific_backend/priv/cert/glific.test+1.pem SSL_KEY_FILE=../glific_backend/priv/cert/glific.test+1-key.pem react-scripts start"
 
 Copy config file
 


### PR DESCRIPTION

## Summary
 Target issue is #_PLEASE_TYPE_ISSUE_NUMBER_  
 Fixing 2 typos in README under "8. Frontend - Install glific_frontend": 
1. replacing glific_frontend with glific-frontend for git clone to work.
2. deleting "update start script" - original start script is correct. 

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
