### PR TITLE
Contact actions add node id instead of action uuid to message

### DIFF
--- a/lib/glific/flows/contact_action.ex
+++ b/lib/glific/flows/contact_action.ex
@@ -93,7 +93,7 @@ defmodule Glific.Flows.ContactAction do
     with {false, context} <- has_loops?(context, body, messages) do
       attrs = %{
         body: body,
-        uuid: action.uuid,
+        uuid: action.node_uuid,
         type: interactive_content["type"],
         receiver_id: cid,
         flow_label: action.labels,
@@ -252,7 +252,7 @@ defmodule Glific.Flows.ContactAction do
 
     attrs = %{
       receiver_id: cid,
-      uuid: action.uuid,
+      uuid: action.node_uuid,
       flow_id: context.flow_id,
       message_broadcast_id: context.message_broadcast_id,
       is_hsm: true,
@@ -318,7 +318,7 @@ defmodule Glific.Flows.ContactAction do
     {type, media_id} = get_media_from_attachment(attachments, text, context, cid)
 
     attrs = %{
-      uuid: action.uuid,
+      uuid: action.node_uuid,
       body: body,
       type: type,
       media_id: media_id,

--- a/lib/glific/third_party/bigquery/bigquery_schema.ex
+++ b/lib/glific/third_party/bigquery/bigquery_schema.ex
@@ -248,7 +248,8 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
-        description: "Uniquely generated message UUID, primarily needed for the flow editor",
+        description:
+          "Uniquely generated message UUID, in case of flow it's id of that particular node which have the message.",
         name: "uuid",
         type: "STRING",
         mode: "NULLABLE"

--- a/test/glific/flows_test.exs
+++ b/test/glific/flows_test.exs
@@ -353,7 +353,7 @@ defmodule Glific.FLowsTest do
       first_action = hd(hd(flow.nodes).actions)
 
       assert {:ok, _message} =
-               Repo.fetch_by(Message, %{uuid: first_action.uuid, contact_id: contact.id})
+               Repo.fetch_by(Message, %{uuid: first_action.node_uuid, contact_id: contact.id})
     end
 
     test "start_contact_flow/2 if flow is not available", attrs do
@@ -428,10 +428,10 @@ defmodule Glific.FLowsTest do
       first_action = hd(hd(flow.nodes).actions)
 
       assert {:ok, _message} =
-               Repo.fetch_by(Message, %{uuid: first_action.uuid, contact_id: contact.id})
+               Repo.fetch_by(Message, %{uuid: first_action.node_uuid, contact_id: contact.id})
 
       assert {:ok, _message} =
-               Repo.fetch_by(Message, %{uuid: first_action.uuid, contact_id: contact2.id})
+               Repo.fetch_by(Message, %{uuid: first_action.node_uuid, contact_id: contact2.id})
 
       Broadcast.execute_group_broadcasts(attrs.organization_id)
 


### PR DESCRIPTION
- replace action.uuid to action.node_uuid to message table. 