### PR TITLE
Dynamic labels were not working for in interactive messages.

### DIFF
--- a/lib/glific/clients.ex
+++ b/lib/glific/clients.ex
@@ -19,7 +19,7 @@ defmodule Glific.Clients do
     gcs_file_name: Glific.Clients.Tap,
     blocked?: Glific.Clients.Stir,
     broadcast: Glific.Clients.Weunlearn,
-    webhook: Glific.Clients.ReapBenefit,
+    webhook: Glific.Clients.Tap,
     daily_tasks: Glific.Clients.DigitalGreen,
     trigger_condition: Glific.Clients.ArogyaWorld
   }

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -274,7 +274,7 @@ defmodule Glific.Flows.Action do
 
     process(json, uuid_map, node, %{
       interactive_template_id: json["id"],
-      labels: json["labels"],
+      labels: process_labels(json["labels"]),
       params: json["params"] || [],
       params_count: json["paramsCount"] || "0",
       attachment_url: json["attachment_url"],


### PR DESCRIPTION
Dynamic labels were not working for in interactive messages. 