### PR TITLE
Bigquery: increasing timeout for max_last_update

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -128,7 +128,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
       |> add_organization_id(table_name, organization_id)
       |> order_by([m], asc: m.id)
       |> limit(@per_min_limit)
-      |> Repo.aggregate(:max, :updated_at, skip_organization_id: true)
+      |> Repo.aggregate(:max, :updated_at, skip_organization_id: true, timeout: 15_000)
 
     if is_nil(max_last_update),
       do: table_last_updated_at,


### PR DESCRIPTION
## Summary
 Target issue is #2607 

## Notes
Added timeout to query while syncing data to BQ.

**Screenshot**
Query timeout while syncing data
<img width="1862" alt="Screenshot 2022-12-19 at 5 11 30 PM" src="https://user-images.githubusercontent.com/40158831/208459859-398e1356-6743-4b53-8919-6a92aad11121.png">
