### PR TITLE
add a new REST API endpoint to get the name of an org

### DIFF
--- a/lib/glific_web/controllers/api/v1/session_controller.ex
+++ b/lib/glific_web/controllers/api/v1/session_controller.ex
@@ -6,7 +6,7 @@ defmodule GlificWeb.API.V1.SessionController do
   use GlificWeb, :controller
   require Logger
 
-  alias Glific.{Repo, Users.User}
+  alias Glific.{Repo, Users.User, Partners}
   alias GlificWeb.APIAuthPlug
   alias Plug.Conn
 
@@ -84,5 +84,21 @@ defmodule GlificWeb.API.V1.SessionController do
     conn
     |> Pow.Plug.delete()
     |> json(%{data: %{}})
+  end
+
+  @doc """
+  Given the organization ID, lets send back the organization Name
+  so the user is aware that they are logging into the right account.any()
+
+  This is an internal API, so we will not document it (for now)
+  """
+  @spec name(Conn.t(), map()) :: Conn.t()
+  def name(conn, _params) do
+    organization =
+      conn.assigns[:organization_id]
+      |> Partners.get_organization!()
+
+    conn
+    |> json(%{data: %{name: organization.name}})
   end
 end

--- a/lib/glific_web/controllers/api/v1/session_controller.ex
+++ b/lib/glific_web/controllers/api/v1/session_controller.ex
@@ -6,7 +6,7 @@ defmodule GlificWeb.API.V1.SessionController do
   use GlificWeb, :controller
   require Logger
 
-  alias Glific.{Repo, Users.User, Partners}
+  alias Glific.{Partners, Repo, Users.User}
   alias GlificWeb.APIAuthPlug
   alias Plug.Conn
 

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -45,6 +45,7 @@ defmodule GlificWeb.Router do
     post("/registration/reset-password", RegistrationController, :reset_password)
     resources("/session", SessionController, singleton: true, only: [:create, :delete])
     post("/session/renew", SessionController, :renew)
+    post("/session/name", SessionController, :name)
     post("/onboard/setup", OnboardController, :setup)
   end
 

--- a/test/glific_web/session_controller_test.exs
+++ b/test/glific_web/session_controller_test.exs
@@ -116,4 +116,24 @@ defmodule GlificWeb.API.V1.SessionControllerTest do
       assert json["data"] == %{}
     end
   end
+
+  describe "name/2" do
+    setup %{conn: conn, organization_id: organization_id} do
+      params = put_in(@valid_params, ["user", "organization_id"], organization_id)
+      authed_conn = post(conn, Routes.api_v1_session_path(conn, :create, params))
+      :timer.sleep(100)
+
+      {:ok, access_token: authed_conn.private[:api_access_token]}
+    end
+
+    test "name", %{conn: conn, access_token: token} do
+      conn =
+        conn
+        |> Plug.Conn.put_req_header("authorization", token)
+        |> post(Routes.api_v1_session_path(conn, :name))
+
+      assert json = json_response(conn, 200) |> IO.inspect()
+      assert json["data"] == %{"name" => "Glific"}
+    end
+  end
 end

--- a/test/glific_web/session_controller_test.exs
+++ b/test/glific_web/session_controller_test.exs
@@ -132,7 +132,7 @@ defmodule GlificWeb.API.V1.SessionControllerTest do
         |> Plug.Conn.put_req_header("authorization", token)
         |> post(Routes.api_v1_session_path(conn, :name))
 
-      assert json = json_response(conn, 200) |> IO.inspect()
+      assert json = json_response(conn, 200)
       assert json["data"] == %{"name" => "Glific"}
     end
   end


### PR DESCRIPTION

## Summary
 Target issue is #2643 
 At the request of our friends from the frontend

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
