### PR TITLE
Bug/2410

### DIFF
--- a/lib/glific/messages/message_media.ex
+++ b/lib/glific/messages/message_media.ex
@@ -20,13 +20,15 @@ defmodule Glific.Messages.MessageMedia do
     :thumbnail,
     :provider_media_id,
     :caption,
-    :gcs_url
+    :gcs_url,
+    :content_type
   ]
 
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: non_neg_integer | nil,
           url: String.t() | nil,
+          content_type: String.t() | nil,
           source_url: String.t() | nil,
           caption: String.t() | nil,
           thumbnail: String.t() | nil,
@@ -39,14 +41,15 @@ defmodule Glific.Messages.MessageMedia do
         }
 
   schema "messages_media" do
-    field :url, :string
-    field :source_url, :string
-    field :thumbnail, :string
-    field :caption, :string
-    field :provider_media_id, :string
-    field :gcs_url, :string
+    field(:url, :string)
+    field(:source_url, :string)
+    field(:thumbnail, :string)
+    field(:caption, :string)
+    field(:provider_media_id, :string)
+    field(:gcs_url, :string)
+    field(:content_type, :string)
 
-    belongs_to :organization, Organization
+    belongs_to(:organization, Organization)
 
     timestamps(type: :utc_datetime)
   end

--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -150,7 +150,7 @@ defmodule Glific.Providers.Gupshup.Message do
       context_id: context_id(payload),
       caption: message_payload["caption"],
       url: message_payload["url"],
-      content_type: message_payload["contentType"]
+      content_type: message_payload["contentType"],
       source_url: message_payload["url"],
       sender: %{
         phone: payload["sender"]["phone"],

--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -150,6 +150,7 @@ defmodule Glific.Providers.Gupshup.Message do
       context_id: context_id(payload),
       caption: message_payload["caption"],
       url: message_payload["url"],
+      content_type: message_payload["contentType"]
       source_url: message_payload["url"],
       sender: %{
         phone: payload["sender"]["phone"],

--- a/lib/glific/providers/gupshup_enterprise/message.ex
+++ b/lib/glific/providers/gupshup_enterprise/message.ex
@@ -242,6 +242,7 @@ defmodule Glific.Providers.Gupshup.Enterprise.Message do
       context_id: params["messageId"],
       caption: message_payload["caption"],
       url: message_payload["url"] <> message_payload["signature"],
+      content_type: message_payload["contentType"],
       source_url: message_payload["url"] <> message_payload["signature"],
       sender: %{
         phone: params["mobile"],

--- a/lib/glific/third_party/bigquery/bigquery_schema.ex
+++ b/lib/glific/third_party/bigquery/bigquery_schema.ex
@@ -513,6 +513,12 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
+        description: "Content Type of media file from provider",
+        name: "content_type",
+        type: "STRING",
+        mode: "NULLABLE"
+      },
+      %{
         description: "URL of media file stored in GCS",
         name: "gcs_url",
         type: "STRING",

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -759,6 +759,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
             caption: row.caption,
             url: row.url,
             source_url: row.source_url,
+            content_type: row.content_type,
             gcs_url: row.gcs_url,
             inserted_at: format_date_with_millisecond(row.inserted_at, organization_id),
             updated_at: format_date_with_millisecond(row.updated_at, organization_id)

--- a/priv/repo/migrations/20230403001516_content_type_media.exs
+++ b/priv/repo/migrations/20230403001516_content_type_media.exs
@@ -1,0 +1,17 @@
+defmodule Glific.Repo.Migrations.ContentTypeMedia do
+  use Ecto.Migration
+
+  def change do
+    add_content_type_to_message_media()
+  end
+
+  defp add_content_type_to_message_media() do
+    alter table(:messages_media) do
+      # content type string
+      add(:content_type, :string,
+        null: true,
+        comment: "Content Type for the media message sent by WABA"
+      )
+    end
+  end
+end


### PR DESCRIPTION

## Summary
 Target issue is #2410  
 Add content type to message media table, since the url does not have the extension. This will allow NGOs to make decisions based on the media and not have to download and check for the media type

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
