### PR TITLE
Clean the hsm message params as per waba rule

### DIFF
--- a/assets/gql/messages/send_hsm_message.gql
+++ b/assets/gql/messages/send_hsm_message.gql
@@ -1,5 +1,13 @@
-mutation sendHsmMessage($template_id: ID!, $receiver_id: ID!, $parameters: [String]) {
-  sendHsmMessage(template_id: $template_id, receiver_id: $receiver_id, parameters: $parameters) {
+mutation sendHsmMessage(
+  $template_id: ID!
+  $receiver_id: ID!
+  $parameters: [String]
+) {
+  sendHsmMessage(
+    template_id: $template_id
+    receiver_id: $receiver_id
+    parameters: $parameters
+  ) {
     message {
       id
       body

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -558,7 +558,10 @@ defmodule Glific.Messages do
         %{template_id: template_id, receiver_id: receiver_id, parameters: parameters} = attrs
       ) do
     contact_vars = %{"contact" => Contacts.get_contact_field_map(attrs.receiver_id)}
-    parsed_params = Enum.map(parameters, &MessageVarParser.parse(&1, contact_vars))
+
+    parsed_params =
+      Enum.map(parameters, &MessageVarParser.parse(&1, contact_vars))
+      |> Enum.map(&(String.split(&1) |> Enum.join(" ") |> String.replace("\n", "")))
 
     ## As per the WhatsApp policy the params in an HSM can not have more then two
     ## consecutive spaces and a new line.


### PR DESCRIPTION
## Summary
 The target issue is #2473 
 Cleaning the HSM params (Removing the new lines and extra spaces) before sending it to gupshup. 

## Checklist
  Before submitting a pull request, please ensure that you mark these tasks.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
