### PR TITLE
#2670 interactive message bug fix

### DIFF
--- a/lib/glific/flows/contact_action.ex
+++ b/lib/glific/flows/contact_action.ex
@@ -92,7 +92,7 @@ defmodule Glific.Flows.ContactAction do
 
     with {false, context} <- has_loops?(context, body, messages) do
       attrs = %{
-        body: body,
+        body: MessageVarParser.parse(body, message_vars),
         uuid: action.node_uuid,
         type: interactive_content["type"],
         receiver_id: cid,


### PR DESCRIPTION
#2670 

1. Parse message body for the sheet interactive messages

**Note** - After fixed added, I checked all the interactive messages and working fine
