### PR TITLE
Added sheet type in the floweditor sheet API

### DIFF
--- a/lib/glific_web/flows/flow_editor_controller.ex
+++ b/lib/glific_web/flows/flow_editor_controller.ex
@@ -545,7 +545,8 @@ defmodule GlificWeb.Flows.FlowEditorController do
           %{
             id: sheet.id,
             name: sheet.label,
-            url: sheet.url
+            url: sheet.url,
+            type: sheet.type
           }
           | acc
         ]


### PR DESCRIPTION
## Summary
 Added sheet type in the floweditor sheet API. This is needed to filter out the sheets the link sheet node.