### PR TITLE
School name fix for - TAP

### DIFF
--- a/lib/glific/clients/tap.ex
+++ b/lib/glific/clients/tap.ex
@@ -162,7 +162,7 @@ defmodule Glific.Clients.Tap do
     org_id = Glific.parse_maybe_integer!(fields["organization_id"])
     contact_id = Glific.parse_maybe_integer!(fields["contact"]["id"])
     school_name = fields["school_name"] || ""
-    formatted_school_name = String.split(school_name, [" ", ","])
+    formatted_school_name = String.split(String.trim(school_name), ~r/[,\s]+/)
 
     school_short_form =
       if length(formatted_school_name) > 1 do


### PR DESCRIPTION
Added fix for the space after comma
<img width="969" alt="image" src="https://github.com/glific/glific/assets/30264862/0d4405a8-51d8-40e3-8c37-7f74629d709a">

**Fixes:**
1. Used String.trim(school_name)  to remove any leading or trailing whitespace from the school name before splitting it. 
2. Added the regular expression ~r/[,\s]+/ is used as the splitting pattern, which matches one or more commas or whitespace characters.
