### PR TITLE
Add pie chart for inbound and outbound counts

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -46,4 +46,26 @@ Hooks.dateInput = {
   },
 };
 
+Hooks.pieChart = {
+  mounted() {
+    var ctx = this.el.getContext("2d");
+    let chartData = JSON.parse(this.el.dataset.chartData);
+
+    var chart = new Chart(ctx, {
+      type: "pie",
+      data: {
+        labels: ["Inbound", "Outbound"],
+        datasets: [
+          {
+            backgroundColor: ["rgb(17, 150, 86)", "rgb(255, 99, 132)"],
+            borderColor: "rgb(255, 99, 132)",
+            data: chartData.data,
+          },
+        ],
+      },
+      options: {},
+    });
+  },
+};
+
 export default Hooks;

--- a/lib/glific/reports.ex
+++ b/lib/glific/reports.ex
@@ -99,6 +99,7 @@ defmodule Glific.Reports do
     """
   end
 
+  @doc false
   @spec get_kpi_pie_data(non_neg_integer(), String.t()) :: map()
   def get_kpi_pie_data(org_id, table) do
     presets = get_date_preset()

--- a/lib/glific/reports.ex
+++ b/lib/glific/reports.ex
@@ -99,6 +99,32 @@ defmodule Glific.Reports do
     """
   end
 
+  @spec get_kpi_pie_data(non_neg_integer(), String.t()) :: map()
+  def get_kpi_pie_data(org_id, table) do
+    presets = get_date_preset()
+
+    query_data =
+      get_kpi_pie_query(presets, table, org_id)
+      |> Repo.query!([])
+
+    Enum.reduce(query_data.rows, %{}, fn [_, inbound, outbound], acc ->
+      Map.put(acc, :inbound, inbound) |> Map.put(:outbound, outbound)
+    end)
+  end
+
+  defp get_kpi_pie_query(presets, table, org_id) do
+    """
+    SELECT
+      date_trunc('day', inserted_at) AS date,
+      inbound AS inbound_count,
+      outbound AS outbound_count
+    FROM #{table}
+    WHERE
+      inserted_at >= '#{presets.today}'
+      AND organization_id = #{org_id};
+    """
+  end
+
   @spec get_date_preset(DateTime.t()) :: map()
   defp get_date_preset(time \\ DateTime.utc_now()) do
     today = shifted_time(time, 1) |> Timex.format!("{YYYY}-{0M}-{0D}")

--- a/lib/glific_web/templates/live/stats_live.ex
+++ b/lib/glific_web/templates/live/stats_live.ex
@@ -53,6 +53,10 @@ defmodule GlificWeb.StatsLive do
       conversation_chart_data: %{
         data: fetch_data("messages_conversations"),
         labels: fetch_date_labels("messages_conversations")
+      },
+      stats_chart_data: %{
+        data: fetch_pie_data("stats"),
+        labels: ["Inbound", "Outbound"]
       }
     ]
   end
@@ -67,5 +71,11 @@ defmodule GlificWeb.StatsLive do
   defp fetch_date_labels(table_name) do
     Reports.get_kpi_data(1, table_name)
     |> Map.keys()
+  end
+
+  @spec fetch_pie_data(String.t()) :: list()
+  defp fetch_pie_data(table_name) do
+    Reports.get_kpi_pie_data(1, table_name)
+    |> Map.values()
   end
 end

--- a/lib/glific_web/templates/live/stats_live.html.heex
+++ b/lib/glific_web/templates/live/stats_live.html.heex
@@ -44,6 +44,14 @@ Commented out the filter code. Will add this once the functionality is ready
       data-chart-data={Jason.encode!(@conversation_chart_data)}
     >
     </canvas>
+    <canvas
+      class="card"
+      id="stats_chart"
+      phx-hook="pieChart"
+      data-label="Stats"
+      data-chart-data={Jason.encode!(@stats_chart_data)}
+    >
+    </canvas>
   </div>
 </div>
 


### PR DESCRIPTION

## Summary
 Target issue is #2879

## Notes
- Created an SQL query to retrieve the `inbound` and `outbound` counts from the database.
- Included the HTML structure for rendering the pie chart
- Defined functions to fetch the `inbound` and `outbound` counts to live view.
- Defined a hook for the pie chart in `hooks.js`