### PR TITLE
Messages: Updated API to filter using list of message type

### DIFF
--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -121,6 +121,9 @@ defmodule Glific.Messages do
       {:contact_id, contact_id}, query ->
         from(q in query, where: q.contact_id == ^contact_id)
 
+      {:types, types}, query ->
+        from(q in query, where: q.type in ^types)
+
       _, query ->
         query
     end)

--- a/lib/glific_web/schema/message_types.ex
+++ b/lib/glific_web/schema/message_types.ex
@@ -120,6 +120,9 @@ defmodule GlificWeb.Schema.MessageTypes do
     @desc "Match the receiver"
     field :receiver, :string
 
+    @desc "Match the message types"
+    field :types, list_of(:message_type_enum)
+
     @desc "Match the phone with either the sender or receiver"
     field :either, :string
 

--- a/test/glific/messages_test.exs
+++ b/test/glific/messages_test.exs
@@ -134,6 +134,16 @@ defmodule Glific.MessagesTest do
       assert Messages.list_messages(%{filter: attrs}) == [message]
     end
 
+    test "list_messages/1 returns all messages with types filter", attrs do
+      message_fixture(Map.merge(attrs,%{type: :quick_reply}))
+      message_fixture(Map.merge(attrs,%{type: :location}))
+      message_fixture(Map.merge(attrs,%{type: :text}))
+      message_fixture(Map.merge(attrs,%{type: :quick_reply}))
+      message_fixture(Map.merge(attrs,%{type: :text}))
+
+      assert length(Messages.list_messages(%{filter: %{types: [:quick_reply, :location]}})) == 3
+    end
+
     test "list_messages/1 with multiple messages filtered", attrs do
       message = message_fixture(attrs)
 

--- a/test/glific/messages_test.exs
+++ b/test/glific/messages_test.exs
@@ -135,11 +135,11 @@ defmodule Glific.MessagesTest do
     end
 
     test "list_messages/1 returns all messages with types filter", attrs do
-      message_fixture(Map.merge(attrs,%{type: :quick_reply}))
-      message_fixture(Map.merge(attrs,%{type: :location}))
-      message_fixture(Map.merge(attrs,%{type: :text}))
-      message_fixture(Map.merge(attrs,%{type: :quick_reply}))
-      message_fixture(Map.merge(attrs,%{type: :text}))
+      message_fixture(Map.merge(attrs, %{type: :quick_reply}))
+      message_fixture(Map.merge(attrs, %{type: :location}))
+      message_fixture(Map.merge(attrs, %{type: :text}))
+      message_fixture(Map.merge(attrs, %{type: :quick_reply}))
+      message_fixture(Map.merge(attrs, %{type: :text}))
 
       assert length(Messages.list_messages(%{filter: %{types: [:quick_reply, :location]}})) == 3
     end


### PR DESCRIPTION

## Summary
 Target issue is #2885 

## Notes
 Please add here if any other information is required for the reviewer. 
- Add new field called `types` in message filter
- Updated corresponding query
- Added testcases for filtering message using `types`
