### PR TITLE
removed hardcoded organization ID in Internal Dashboard

### DIFF
--- a/lib/glific_web/templates/live/stats_live.ex
+++ b/lib/glific_web/templates/live/stats_live.ex
@@ -25,70 +25,79 @@ defmodule GlificWeb.StatsLive do
   end
 
   def handle_info({:get_stats, kpi}, socket) do
-    user = socket.assigns[:current_user]
-    {:noreply, assign(socket, kpi, Reports.get_kpi(kpi, user.organization_id))}
+    org_id = get_org_id(socket)
+    {:noreply, assign(socket, kpi, Reports.get_kpi(kpi, org_id))}
   end
 
   @spec assign_stats(Phoenix.LiveView.Socket.t(), atom()) :: Phoenix.LiveView.Socket.t()
   defp assign_stats(socket, :init) do
     stats = Enum.map(Reports.kpi_list(), &{&1, "loading.."})
 
+    org_id = get_org_id(socket)
+
     assign(socket, Keyword.merge(stats, page_title: "Glific Dashboard"))
-    |> assign(get_chart_data())
+    |> assign(get_chart_data(org_id))
   end
 
   defp assign_stats(socket, :call) do
     Enum.each(Reports.kpi_list(), &send(self(), {:get_stats, &1}))
-    assign(socket, get_chart_data())
+    org_id = get_org_id(socket)
+    assign(socket, get_chart_data(org_id))
   end
 
   @doc false
-  @spec get_chart_data :: list()
-  def get_chart_data do
+  @spec get_org_id(Phoenix.LiveView.Socket.t()) :: non_neg_integer()
+  def get_org_id(socket) do
+    socket.assigns[:current_user].organization_id
+  end
+
+  @doc false
+  @spec get_chart_data(non_neg_integer()) :: list()
+  def get_chart_data(org_id) do
     [
       contact_chart_data: %{
-        data: fetch_data("contacts"),
-        labels: fetch_date_labels("contacts")
+        data: fetch_data("contacts", org_id),
+        labels: fetch_date_labels("contacts", org_id)
       },
       conversation_chart_data: %{
-        data: fetch_data("messages_conversations"),
-        labels: fetch_date_labels("messages_conversations")
+        data: fetch_data("messages_conversations", org_id),
+        labels: fetch_date_labels("messages_conversations", org_id)
       },
       optin_chart_data: %{
-        data: fetch_optin_data(),
+        data: fetch_optin_data(org_id),
         labels: ["Opted In", "Opted Out", "Non Opted"]
       },
       message_type_chart_data: %{
-        data: fetch_message_type_data("stats"),
+        data: fetch_message_type_data("stats", org_id),
         labels: ["Inbound", "Outbound"]
       }
     ]
   end
 
-  @spec fetch_optin_data() :: list()
-  defp fetch_optin_data do
+  @spec fetch_optin_data(non_neg_integer()) :: list()
+  defp fetch_optin_data(org_id) do
     [
-      Reports.get_kpi(:opted_in_contacts_count, 1),
-      Reports.get_kpi(:opted_out_contacts_count, 1),
-      Reports.get_kpi(:non_opted_contacts_count, 1)
+      Reports.get_kpi(:opted_in_contacts_count, org_id),
+      Reports.get_kpi(:opted_out_contacts_count, org_id),
+      Reports.get_kpi(:non_opted_contacts_count, org_id)
     ]
   end
 
-  @spec fetch_data(String.t()) :: list()
-  defp fetch_data(table_name) do
-    Reports.get_kpi_data(1, table_name)
+  @spec fetch_data(String.t(), non_neg_integer()) :: list()
+  defp fetch_data(table_name, org_id) do
+    Reports.get_kpi_data(org_id, table_name)
     |> Map.values()
   end
 
-  @spec fetch_date_labels(String.t()) :: list()
-  defp fetch_date_labels(table_name) do
-    Reports.get_kpi_data(1, table_name)
+  @spec fetch_date_labels(String.t(), non_neg_integer()) :: list()
+  defp fetch_date_labels(table_name, org_id) do
+    Reports.get_kpi_data(org_id, table_name)
     |> Map.keys()
   end
 
-  @spec fetch_message_type_data(String.t()) :: list()
-  defp fetch_message_type_data(table_name) do
-    Reports.get_message_type_data(1, table_name)
+  @spec fetch_message_type_data(String.t(), non_neg_integer()) :: list()
+  defp fetch_message_type_data(table_name, org_id) do
+    Reports.get_message_type_data(org_id, table_name)
     |> Map.values()
   end
 end


### PR DESCRIPTION

## Summary
 Target issue is #_PLEASE_TYPE_ISSUE_NUMBER_  
 Explain the **motivation** for making this change. What existing problem does the pull request solve?

The Internal Dashboard code had a lot of places where organisation ID was hardcoded in several places. Created functionality to get rid of this. 

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases. 
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
