### PR TITLE
Issue support for adding emails

### DIFF
--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -69,7 +69,7 @@ defmodule Glific.Communications.Mailer do
     |> text_body(body)
   end
 
-  @spec get_team_email(Organization.t(), String.t() | nil, tuple | nil) :: tuple() | nil
+  @spec get_team_email(Organization.t(), String.t() | nil, tuple | nil) :: tuple()
   defp get_team_email(org, _team, nil), do: {org.name, org.email}
 
   defp get_team_email(_org, team, send_to) when team in [nil, ""], do: send_to
@@ -78,6 +78,7 @@ defmodule Glific.Communications.Mailer do
     org.team_emails
     |> Jason.decode!()
     |> Map.get(team)
+    |> then(&{team, &1})
   end
 
   defp capture_log(

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -60,7 +60,7 @@ defmodule Glific.Communications.Mailer do
 
     send_to =
       if is_nil(send_to) do
-        if is_nil(team) do
+        if team="" do
           {org.name, org.email}
         else
           get_team_email(org, team)

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -53,22 +53,30 @@ defmodule Glific.Communications.Mailer do
   Lets write a common function and centralize notification
   code
   """
-  @spec common_send(Organization.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
-  def common_send(org, subject, body, send_to \\ nil) do
+  @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
+  def common_send(org, team, subject, body, send_to \\ nil) do
     # Subject can not have a line break
     subject = String.replace(subject, "\n", "")
 
     send_to =
       if is_nil(send_to),
-        do: {org.name, org.email},
+        do: get_team_email(org, team),
         else: send_to
 
     new()
-    |> to(send_to)
-    |> from(sender())
-    |> cc(glific_support())
-    |> subject(subject)
-    |> text_body(body)
+      |> to(send_to)
+      |> from(sender())
+      |> cc(glific_support())
+      |> subject(subject)
+      |> text_body(body)
+  end
+
+  def get_team_email(org, team) do
+    team_emails =
+      org.team_emails
+      |> Jason.decode!()
+
+    Map.get(team_emails, team) || raise ArgumentError, "Team email not found for team #{team}"
   end
 
   defp capture_log(

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -53,35 +53,31 @@ defmodule Glific.Communications.Mailer do
   Lets write a common function and centralize notification
   code
   """
- @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
-  def common_send(org, team \\nil , subject, body, send_to \\ nil) do
+  @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) ::
+          Swoosh.Email.t()
+  def common_send(org, team \\ nil, subject, body, send_to \\ nil) do
     # Subject can not have a line break
     subject = String.replace(subject, "\n", "")
 
-    send_to =
-      if is_nil(send_to) do
-        if team="" do
-          {org.name, org.email}
-        else
-          get_team_email(org, team)
-        end
-      else
-        send_to
-      end
+    send_to = get_team_email(org, team, send_to)
 
     new()
-      |> to(send_to)
-      |> from(sender())
-      |> cc(glific_support())
-      |> subject(subject)
-      |> text_body(body)
+    |> to(send_to)
+    |> from(sender())
+    |> cc(glific_support())
+    |> subject(subject)
+    |> text_body(body)
   end
 
-  def get_team_email(org, team) do
-    team_emails =
-      org.team_emails
-      |> Jason.decode!()
-    Map.get(team_emails, team)
+  @spec common_send(Organization.t(), String.t() | nil, tuple | nil) :: tuple()
+  defp get_team_email(org, _team, nil), do: {org.name, org.email}
+
+  defp get_team_email(_org, team, send_to) when team in [nil, ""], do: send_to
+
+  defp get_team_email(org, team, _send_to) do
+    org.team_emails
+    |> Jason.decode!()
+    |> Map.get(team)
   end
 
   defp capture_log(

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -53,7 +53,7 @@ defmodule Glific.Communications.Mailer do
   Lets write a common function and centralize notification
   code
   """
-  @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
+ @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
   def common_send(org, team \\nil , subject, body, send_to \\ nil) do
     # Subject can not have a line break
     subject = String.replace(subject, "\n", "")
@@ -81,7 +81,6 @@ defmodule Glific.Communications.Mailer do
     team_emails =
       org.team_emails
       |> Jason.decode!()
-
     Map.get(team_emails, team)
   end
 

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -54,14 +54,20 @@ defmodule Glific.Communications.Mailer do
   code
   """
   @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) :: Swoosh.Email.t()
-  def common_send(org, team, subject, body, send_to \\ nil) do
+  def common_send(org, team \\nil , subject, body, send_to \\ nil) do
     # Subject can not have a line break
     subject = String.replace(subject, "\n", "")
 
     send_to =
-      if is_nil(send_to),
-        do: get_team_email(org, team),
-        else: send_to
+      if is_nil(send_to) do
+        if is_nil(team) do
+          {org.name, org.email}
+        else
+          get_team_email(org, team)
+        end
+      else
+        send_to
+      end
 
     new()
       |> to(send_to)
@@ -76,7 +82,7 @@ defmodule Glific.Communications.Mailer do
       org.team_emails
       |> Jason.decode!()
 
-    Map.get(team_emails, team) || raise ArgumentError, "Team email not found for team #{team}"
+    Map.get(team_emails, team)
   end
 
   defp capture_log(

--- a/lib/glific/communications/mailer.ex
+++ b/lib/glific/communications/mailer.ex
@@ -53,7 +53,7 @@ defmodule Glific.Communications.Mailer do
   Lets write a common function and centralize notification
   code
   """
-  @spec common_send(Organization.t(), String.t(), String.t(), String.t(), tuple() | nil) ::
+  @spec common_send(Organization.t(), String.t() | nil, String.t(), String.t(), tuple() | nil) ::
           Swoosh.Email.t()
   def common_send(org, team \\ nil, subject, body, send_to \\ nil) do
     # Subject can not have a line break
@@ -69,7 +69,7 @@ defmodule Glific.Communications.Mailer do
     |> text_body(body)
   end
 
-  @spec common_send(Organization.t(), String.t() | nil, tuple | nil) :: tuple()
+  @spec get_team_email(Organization.t(), String.t() | nil, tuple | nil) :: tuple() | nil
   defp get_team_email(org, _team, nil), do: {org.name, org.email}
 
   defp get_team_email(_org, team, send_to) when team in [nil, ""], do: send_to

--- a/lib/glific/mails/balance_alert_mail.ex
+++ b/lib/glific/mails/balance_alert_mail.ex
@@ -7,6 +7,7 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec low_balance_alert(Organization.t(), integer()) :: Swoosh.Email.t()
   def low_balance_alert(org, bsp_balance) do
+    team=""
     subject = """
     [URGENT Low balance $#{bsp_balance}] : Messages on Glific will stop soon
     """
@@ -17,26 +18,28 @@ defmodule Glific.Mails.BalanceAlertMail do
     Please top up your account to keep sending and receiving messages on Glific."
     """
 
-    Mailer.common_send(org, subject, body)
+    Mailer.common_send(org, team, subject, body)
   end
 
   @doc false
   @spec no_balance(Organization.t(), String.t()) :: Swoosh.Email.t()
   def no_balance(org, body) do
+    team=""
     subject = """
     Glific Critical: Your Gupshup balance is zero, please refill immediately.
     """
 
-    Mailer.common_send(org, subject, body)
+    Mailer.common_send(org, team, subject, body)
   end
 
   @doc false
   @spec rate_exceeded(Organization.t(), String.t()) :: Swoosh.Email.t()
   def rate_exceeded(org, body) do
+    team=""
     subject = """
     Glific Critical: Your organization has exceeded it WhatsApp rate limit.
     """
 
-    Mailer.common_send(org, subject, body)
+    Mailer.common_send(org, team, subject, body)
   end
 end

--- a/lib/glific/mails/balance_alert_mail.ex
+++ b/lib/glific/mails/balance_alert_mail.ex
@@ -7,7 +7,8 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec low_balance_alert(Organization.t(), integer()) :: Swoosh.Email.t()
   def low_balance_alert(org, bsp_balance) do
-    team=""
+    team = ""
+
     subject = """
     [URGENT Low balance $#{bsp_balance}] : Messages on Glific will stop soon
     """
@@ -24,7 +25,8 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec no_balance(Organization.t(), String.t()) :: Swoosh.Email.t()
   def no_balance(org, body) do
-    team=""
+    team = ""
+
     subject = """
     Glific Critical: Your Gupshup balance is zero, please refill immediately.
     """
@@ -35,7 +37,8 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec rate_exceeded(Organization.t(), String.t()) :: Swoosh.Email.t()
   def rate_exceeded(org, body) do
-    team=""
+    team = ""
+
     subject = """
     Glific Critical: Your organization has exceeded it WhatsApp rate limit.
     """

--- a/lib/glific/mails/critical_notification_mail.ex
+++ b/lib/glific/mails/critical_notification_mail.ex
@@ -9,6 +9,7 @@ defmodule Glific.Mails.CriticalNotificationMail do
   """
   @spec new_mail(Organization.t(), String.t()) :: Swoosh.Email.t()
   def new_mail(org, message) do
+    team=""
     subject = "Glific CRITICAL Issue: Needs your immediate attention."
 
     body = """
@@ -21,6 +22,6 @@ defmodule Glific.Mails.CriticalNotificationMail do
     The Glific team
     """
 
-    Mailer.common_send(org, subject, body)
+    Mailer.common_send(org, team, subject, body)
   end
 end

--- a/lib/glific/mails/critical_notification_mail.ex
+++ b/lib/glific/mails/critical_notification_mail.ex
@@ -9,7 +9,7 @@ defmodule Glific.Mails.CriticalNotificationMail do
   """
   @spec new_mail(Organization.t(), String.t()) :: Swoosh.Email.t()
   def new_mail(org, message) do
-    team=""
+    team = ""
     subject = "Glific CRITICAL Issue: Needs your immediate attention."
 
     body = """

--- a/lib/glific/mails/new_partner_onboarded_mail.ex
+++ b/lib/glific/mails/new_partner_onboarded_mail.ex
@@ -11,7 +11,8 @@ defmodule Glific.Mails.NewPartnerOnboardedMail do
   @doc false
   @spec new_mail(Organization.t()) :: Swoosh.Email.t()
   def new_mail(org) do
-    team=""
+    team = ""
+
     subject = """
     Glific: Congratulations! We onboarded a new NGO.
     """

--- a/lib/glific/mails/new_partner_onboarded_mail.ex
+++ b/lib/glific/mails/new_partner_onboarded_mail.ex
@@ -11,6 +11,7 @@ defmodule Glific.Mails.NewPartnerOnboardedMail do
   @doc false
   @spec new_mail(Organization.t()) :: Swoosh.Email.t()
   def new_mail(org) do
+    team=""
     subject = """
     Glific: Congratulations! We onboarded a new NGO.
     """
@@ -24,6 +25,6 @@ defmodule Glific.Mails.NewPartnerOnboardedMail do
     Email: #{org.email}
     """
 
-    Mailer.common_send(org, subject, body, {"", Saas.primary_email()})
+    Mailer.common_send(org, team, subject, body, {"", Saas.primary_email()})
   end
 end

--- a/priv/repo/migrations/20230725091730_addteamemailsto.exs
+++ b/priv/repo/migrations/20230725091730_addteamemailsto.exs
@@ -1,0 +1,9 @@
+defmodule MyApp.Repo.Migrations.AddTeamEmailsToOrganizations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add :team_emails, :map
+    end
+  end
+end

--- a/priv/repo/migrations/20230725091730_addteamemailsto.exs
+++ b/priv/repo/migrations/20230725091730_addteamemailsto.exs
@@ -1,4 +1,4 @@
-defmodule MyApp.Repo.Migrations.AddTeamEmailsToOrganizations do
+defmodule Glific.Repo.Migrations.AddTeamEmailsToOrganizations do
   use Ecto.Migration
 
   def change do


### PR DESCRIPTION

## Summary
 Target issue is #2941 
 

- Ran migration to add field `team_emails` in the organization table
- Fetch the JSON content from there and use it to send email
