### PR TITLE
Send emails to respective teams

### DIFF
--- a/lib/glific/mails/balance_alert_mail.ex
+++ b/lib/glific/mails/balance_alert_mail.ex
@@ -7,7 +7,7 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec low_balance_alert(Organization.t(), integer()) :: Swoosh.Email.t()
   def low_balance_alert(org, bsp_balance) do
-    team = ""
+    team = "finance"
 
     subject = """
     [URGENT Low balance $#{bsp_balance}] : Messages on Glific will stop soon
@@ -25,7 +25,7 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec no_balance(Organization.t(), String.t()) :: Swoosh.Email.t()
   def no_balance(org, body) do
-    team = ""
+    team = "finance"
 
     subject = """
     Glific Critical: Your Gupshup balance is zero, please refill immediately.
@@ -37,7 +37,7 @@ defmodule Glific.Mails.BalanceAlertMail do
   @doc false
   @spec rate_exceeded(Organization.t(), String.t()) :: Swoosh.Email.t()
   def rate_exceeded(org, body) do
-    team = ""
+    team = "finance"
 
     subject = """
     Glific Critical: Your organization has exceeded it WhatsApp rate limit.

--- a/lib/glific/mails/critical_notification_mail.ex
+++ b/lib/glific/mails/critical_notification_mail.ex
@@ -9,7 +9,7 @@ defmodule Glific.Mails.CriticalNotificationMail do
   """
   @spec new_mail(Organization.t(), String.t()) :: Swoosh.Email.t()
   def new_mail(org, message) do
-    team = ""
+    team = "chatbot_design"
     subject = "Glific CRITICAL Issue: Needs your immediate attention."
 
     body = """

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -608,6 +608,23 @@ defmodule Glific.Partners do
     %{organization | services: updated_services_map}
   end
 
+  @doc """
+    Update the team emails for respective teams.
+  """
+  @spec update_team_emails(integer()) :: {:ok, any} | {:error, any}
+  def update_team_emails(id) do
+    organization = Repo.get(Organization, id)
+
+    team_emails = %{
+        "finance" => organization.email,
+        "analytics" => organization.email,
+        "chatbot_design" => organization.email
+      }
+
+    changeset = Organization.changeset(organization, %{team_emails: team_emails})
+    Repo.update(changeset)
+  end
+
   # Lets cache keys and secrets of all the active services
   @spec set_credentials(map()) :: map()
   defp set_credentials(organization) do

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -40,6 +40,7 @@ defmodule Glific.Partners.Organization do
     :signature_phrase,
     :last_communication_at,
     :fields,
+    :team_emails,
     :newcontact_flow_id,
     :optin_flow_id,
     :is_suspended,
@@ -81,6 +82,7 @@ defmodule Glific.Partners.Organization do
           inserted_at: :utc_datetime | nil,
           updated_at: :utc_datetime | nil,
           fields: map() | nil,
+          team_emails: map() | nil,
           is_suspended: boolean() | false,
           suspended_until: DateTime.t() | nil,
           parent_org: String.t() | nil,
@@ -145,6 +147,7 @@ defmodule Glific.Partners.Organization do
     field(:last_communication_at, :utc_datetime)
 
     field(:fields, :map, default: %{})
+    field(:team_emails, :map)
 
     # lets add support for suspending orgs briefly
     field(:is_suspended, :boolean, default: false)


### PR DESCRIPTION

## Summary
 Target issue is #2966   

 Explain the **motivation** for making this change. What existing problem does the pull request solve?

- Added query to populate team_emails field with email for every team
- Added support for sending mails to teams for different functions

