### PR TITLE
Internal Dashboard: Most Active Hour fix

### DIFF
--- a/lib/glific_web/templates/live/stats_live.ex
+++ b/lib/glific_web/templates/live/stats_live.ex
@@ -176,9 +176,14 @@ defmodule GlificWeb.StatsLive do
 
   defp render_bar_chart("Most Active Hour" = title, dataset) do
     opts = series_barchart_opts(title)
+    has_no_data = [] == dataset.data
 
-    Contex.Plot.new(dataset, Contex.BarChart, 1600, 400, opts)
-    |> Contex.Plot.to_svg()
+    if has_no_data do
+      Jason.encode!(title <> ": No data")
+    else
+      Contex.Plot.new(dataset, Contex.BarChart, 1600, 400, opts)
+      |> Contex.Plot.to_svg()
+    end
   end
 
   defp render_bar_chart(title, dataset) do


### PR DESCRIPTION

## Summary
 Target issue is #3015   
Fixing the most active hour bug where the dashboard crashes if the stats table is not populated.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases. 
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
