### PR TITLE
bigquery_jobs  bug

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -919,10 +919,22 @@ defmodule Glific.BigQuery.BigQueryWorker do
     max_id = attrs[:max_id]
     last_updated_at = attrs[:last_updated_at]
 
+    case last_updated_at do
+      nil ->
+        Logger.error(
+          "last_updated_at is nil! for #{organization_id} and table: #{table}  Setting DB to one day older."
+        )
+
+        previous_day = Timex.now() |> Timex.shift(days: -1)
+        _last_updated_at = Timex.to_datetime(previous_day)
+
+      _ ->
+        last_updated_at
+    end
+
     BigQuery.make_insert_query(data, table, organization_id,
       max_id: max_id,
-      last_updated_at: if(!is_nil(last_updated_at), do: last_updated_at),
-      else: nil
+      last_updated_at: last_updated_at
     )
 
     :ok

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -210,7 +210,6 @@ defmodule Glific.BigQuery.BigQueryWorker do
   @spec insert_new_records(binary, non_neg_integer, DateTime.t() | nil, non_neg_integer) :: :ok
   defp insert_new_records(table, table_id, table_last_updated_at, organization_id) do
     max_id = insert_max_id(table, table_id, organization_id)
-    last_updated_at = insert_last_updated(table, table_last_updated_at, organization_id)
 
     if max_id > table_id,
       do:
@@ -218,7 +217,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
           min_id: table_id,
           max_id: max_id,
           action: :insert,
-          last_updated_at: last_updated_at
+          last_updated_at: table_last_updated_at
         })
 
     :ok

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -201,22 +201,24 @@ defmodule Glific.BigQuery.BigQueryWorker do
     if action == "update" do
       insert_updated_records(table, table_last_updated_at, organization_id)
     else
-      insert_new_records(table, table_id, organization_id)
+      insert_new_records(table, table_id, table_last_updated_at, organization_id)
     end
 
     :ok
   end
 
-  @spec insert_new_records(binary, non_neg_integer, non_neg_integer) :: :ok
-  defp insert_new_records(table, table_id, organization_id) do
+  @spec insert_new_records(binary, non_neg_integer, DateTime.t(), non_neg_integer) :: :ok
+  defp insert_new_records(table, table_id, table_last_updated_at, organization_id) do
     max_id = insert_max_id(table, table_id, organization_id)
+    last_updated_at = insert_last_updated(table, table_last_updated_at, organization_id)
 
     if max_id > table_id,
       do:
         queue_table_data(table, organization_id, %{
           min_id: table_id,
           max_id: max_id,
-          action: :insert
+          action: :insert,
+          last_updated_at: last_updated_at
         })
 
     :ok

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -207,7 +207,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
     :ok
   end
 
-  @spec insert_new_records(binary, non_neg_integer, DateTime.t(), non_neg_integer) :: :ok
+  @spec insert_new_records(binary, non_neg_integer, DateTime.t() | nil, non_neg_integer) :: :ok
   defp insert_new_records(table, table_id, table_last_updated_at, organization_id) do
     max_id = insert_max_id(table, table_id, organization_id)
     last_updated_at = insert_last_updated(table, table_last_updated_at, organization_id)

--- a/priv/repo/migrations/20230820104852_make_last_updated_at_non_nullable_in_bigquery_jobs.exs
+++ b/priv/repo/migrations/20230820104852_make_last_updated_at_non_nullable_in_bigquery_jobs.exs
@@ -1,0 +1,15 @@
+defmodule Glific.Repo.Migrations.MakeLastUpdatedAtNonNullableInBigqueryJobs do
+  use Ecto.Migration
+
+  def up do
+    alter table(:bigquery_jobs) do
+      modify :last_updated_at, :timestamp, null: false
+    end
+  end
+
+  def down do
+    alter table(:bigquery_jobs) do
+      modify :last_updated_at, :timestamp, null: true
+    end
+  end
+end

--- a/priv/repo/migrations/20230820104852_make_last_updated_at_non_nullable_in_bigquery_jobs.exs
+++ b/priv/repo/migrations/20230820104852_make_last_updated_at_non_nullable_in_bigquery_jobs.exs
@@ -3,13 +3,13 @@ defmodule Glific.Repo.Migrations.MakeLastUpdatedAtNonNullableInBigqueryJobs do
 
   def up do
     alter table(:bigquery_jobs) do
-      modify :last_updated_at, :timestamp, null: false
+      modify :last_updated_at, :timestamp, null: false, default: fragment("NOW()")
     end
   end
 
   def down do
     alter table(:bigquery_jobs) do
-      modify :last_updated_at, :timestamp, null: true
+      modify :last_updated_at, :timestamp, null: true, default: nil
     end
   end
 end


### PR DESCRIPTION
To fix the last_updated_at column when the value is null. 

1. First we haveto run this query in the DB.
```
UPDATE bigquery_jobs
SET last_updated_at = '2023-08-10'
WHERE last_updated_at IS NULL;
```

2. Created a migration to make last_updated_at not nullable
3. Updated bigquery worker file to send the last_updated_at also on the creation time