### PR TITLE
API:Modify for read only

### DIFF
--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -268,7 +268,25 @@ defmodule Glific.Contacts do
       {:error, %Ecto.Changeset{}}
 
   """
-  @spec update_contact(Contact.t(), map()) :: {:ok, Contact.t()} | {:error, Ecto.Changeset.t()}
+
+  # @spec update_contact(Contact.t(), map()) :: {:ok, Contact.t()} | {:error, Ecto.Changeset.t()}
+  # def update_contact(%Contact{} = contact, attrs) do
+  #   if has_permission?(contact.id) do
+  #     if is_simulator_block?(contact, attrs) do
+  #       # just treat it as if we blocked the simulator
+  #       # but in reality, we don't block the simulator
+  #       {:ok, contact}
+  #     else
+  #       contact
+  #       |> Contact.changeset(attrs)
+  #       |> Repo.update()
+  #     end
+  #   else
+  #     raise "Permission denied"
+  #   end
+  # end
+
+  @spec update_contact(Contact.t(), map()) :: {:ok, Contact.t()} | {:error, String.t()}
   def update_contact(%Contact{} = contact, attrs) do
     if has_permission?(contact.id) do
       if is_simulator_block?(contact, attrs) do
@@ -276,12 +294,31 @@ defmodule Glific.Contacts do
         # but in reality, we don't block the simulator
         {:ok, contact}
       else
-        contact
-        |> Contact.changeset(attrs)
-        |> Repo.update()
+        case check_read_only_fields(attrs) do
+          {:ok, modified_attrs} ->
+            contact
+            |> Contact.changeset(modified_attrs)
+            |> Repo.update()
+
+          {:error, error_message} ->
+            {:error, error_message}
+        end
       end
     else
       raise "Permission denied"
+    end
+  end
+
+  @read_only_fields [:phone, :status, :bspStatus]
+
+  @spec check_read_only_fields(map()) :: {:ok, map()} | {:error, String.t()}
+  defp check_read_only_fields(attrs) do
+    modified_attrs = Map.take(attrs, @read_only_fields)
+
+    if Map.keys(modified_attrs) == [] do
+      {:ok, attrs}
+    else
+      {:error, "Cannot modify read-only fields"}
     end
   end
 


### PR DESCRIPTION

## Summary
 Target issue is #3087

Some of the fields are read only in the frontend but can be modified via the API so we are also making them read only from backend as well  
 