### PR TITLE
fix/Login:handle error message in forgot password

### DIFF
--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -157,8 +157,8 @@ defmodule GlificWeb.API.V1.RegistrationController do
       {:ok, _contact} ->
         handle_registration_otp(conn, organization_id, phone, registration)
 
-      _ ->
-        send_otp_error(conn, "Account with phone number #{phone} does not exists")
+      {:error, _} ->
+        send_otp_error(conn, "Account with phone number #{phone} does not exist")
     end
   end
 
@@ -258,7 +258,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
   @spec optin_contact(non_neg_integer(), String.t()) :: {:ok, map()} | {:error, []}
   defp optin_contact(organization_id, phone) do
     case Repo.fetch_by(Contact, %{phone: phone}) do
-      {:ok, existing_contact} ->
+      {:ok, _existing_contact} ->
         {:error, "Account with phone number #{phone} already exists"}
 
       _ ->

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -117,15 +117,6 @@ defmodule GlificWeb.API.V1.RegistrationController do
     end
   end
 
-  # registration false
-  # 1 - check that user exists or not
-  # 2- if exists -> check contact -> if contact opted in ->  send otp
-  # 3- error message
-
-  # registration true
-  # 1- if user exist -> error message
-  # 2- create contact-> otp
-
   def send_otp(
         conn,
         %{"user" => %{"phone" => phone, "registration" => registration}} = _user_params

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -201,7 +201,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       assert json = json_response(conn, 400)
 
       assert get_in(json, ["error", "message"]) ==
-               "Account with phone number #{phone} does not exists"
+               "Account with phone number #{phone} does not exist"
     end
 
     test "send otp to optout contact will optin the contact again", %{conn: conn} do
@@ -215,9 +215,9 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
 
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, invalid_params))
 
-      assert json = json_response(conn, 200)
+      assert json = json_response(conn, 400)
 
-      assert get_in(json, ["error", "message"]) == nil
+      assert get_in(json, ["error", "message"]) == "Cannot send the otp to #{phone}"
     end
 
     test "send otp with registration 'false' flag to existing user should succeed", %{conn: conn} do
@@ -248,9 +248,8 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
           "token" => "some_token"
         }
       }
-
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, valid_params))
-      assert _json = json_response(conn, 200)
+      assert _json = json_response(conn, 400)
     end
   end
 

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -199,7 +199,9 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp), invalid_params)
 
       assert json = json_response(conn, 400)
-      assert get_in(json, ["error", "message"]) == "Account with phone number #{phone} does not exist"
+
+      assert get_in(json, ["error", "message"]) ==
+               "Account with phone number #{phone} does not exist"
     end
 
     test "send otp to optout contact will optin the contact again", %{conn: conn} do

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -189,6 +189,19 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       assert get_in(json, ["error", "message"]) == "Cannot send the otp to #{phone}"
     end
 
+    test "send otp to the non existing contact should get an error message", %{conn: conn} do
+      phone = "912345375758"
+
+      invalid_params = %{
+        "user" => %{"phone" => phone, "registration" => "false"}
+      }
+
+      conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp), invalid_params)
+
+      assert json = json_response(conn, 400)
+      assert get_in(json, ["error", "message"]) == "Account with phone number #{phone} does not exist"
+    end
+
     test "send otp to optout contact will optin the contact again", %{conn: conn} do
       receiver = Fixtures.contact_fixture()
 

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -186,7 +186,9 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, invalid_params))
 
       assert json = json_response(conn, 400)
-      assert get_in(json, ["error", "message"]) == "Account with phone number #{phone} already exists"
+
+      assert get_in(json, ["error", "message"]) ==
+               "Account with phone number #{phone} already exists"
     end
 
     test "send otp to the non existing contact should get an error message", %{conn: conn} do
@@ -216,8 +218,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, invalid_params))
 
       assert json = json_response(conn, 400)
-
-      assert get_in(json, ["error", "message"]) == "Cannot send the otp to #{phone}"
+      assert get_in(json, ["error", "message"]) == "Cannot send the otp to #{receiver.phone}"
     end
 
     test "send otp with registration 'false' flag to existing user should succeed", %{conn: conn} do
@@ -248,8 +249,9 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
           "token" => "some_token"
         }
       }
+
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, valid_params))
-      assert _json = json_response(conn, 400)
+      assert _json = json_response(conn, 200)
     end
   end
 

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -186,7 +186,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, invalid_params))
 
       assert json = json_response(conn, 400)
-      assert get_in(json, ["error", "message"]) == "Cannot send the otp to #{phone}"
+      assert get_in(json, ["error", "message"]) == "Account with phone number #{phone} already exists"
     end
 
     test "send otp to the non existing contact should get an error message", %{conn: conn} do
@@ -201,7 +201,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       assert json = json_response(conn, 400)
 
       assert get_in(json, ["error", "message"]) ==
-               "Account with phone number #{phone} does not exist"
+               "Account with phone number #{phone} does not exists"
     end
 
     test "send otp to optout contact will optin the contact again", %{conn: conn} do
@@ -250,7 +250,6 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       }
 
       conn = post(conn, Routes.api_v1_registration_path(conn, :send_otp, valid_params))
-
       assert _json = json_response(conn, 200)
     end
   end


### PR DESCRIPTION
## Summary
 Target issues are #3180
#3177
 
sending the proper message for forgot password if the user is not registered or the user account does not exist and sending message when user is creating an account and that user already exists into the database