### PR TITLE
feature/Ticketing Syatem: Getting the previous message number before creating a ticket

### DIFF
--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -85,21 +85,21 @@ defmodule Glific.Tickets do
     end
   end
 
-  @spec get_previous_message_number() :: {:ok, integer()}
+  @spec get_previous_message_number() :: {:ok, integer()} | {:error, String.t()}
   defp get_previous_message_number do
     case Repo.one(from m in Message, order_by: [desc: m.message_number], limit: 1) do
       %Message{message_number: number} ->
-        if is_nil(Repo.get_by(Message, %{message_number: number - 3})) do
-          {:ok, 0}
-        else
-          {:ok, number - 3}
-        end
+        if is_nil(Repo.get_by(Message, %{message_number: number - 3})),
+          do: {:ok, 0},
+          else: {:ok, number - 3}
+
+      nil ->
+        {:ok, 0}
     end
   end
 
   @spec do_create_ticket(map()) :: {:ok, Ticket.t()} | {:error, Ecto.Changeset.t()}
   defp do_create_ticket(params) do
-
     %Ticket{}
     |> Ticket.changeset(params)
     |> Repo.insert()

--- a/lib/glific/tickets/ticket.ex
+++ b/lib/glific/tickets/ticket.ex
@@ -14,7 +14,7 @@ defmodule Glific.Tickets.Ticket do
     Users.User
   }
 
-  @required_fields [:body, :contact_id, :status, :organization_id]
+  @required_fields [:body, :contact_id, :status, :organization_id, :message_number]
   @optional_fields [:user_id, :topic, :remarks]
 
   @type t() :: %__MODULE__{
@@ -31,7 +31,8 @@ defmodule Glific.Tickets.Ticket do
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil
+          updated_at: :utc_datetime | nil,
+          message_number: integer()
         }
 
   schema "tickets" do
@@ -39,6 +40,7 @@ defmodule Glific.Tickets.Ticket do
     field(:topic, :string)
     field(:status, :string)
     field(:remarks, :string)
+    field(:message_number, :integer, default: 0, read_after_writes: true)
 
     belongs_to(:contact, Contact)
     belongs_to(:user, User)

--- a/lib/glific/tickets/ticket.ex
+++ b/lib/glific/tickets/ticket.ex
@@ -14,8 +14,8 @@ defmodule Glific.Tickets.Ticket do
     Users.User
   }
 
-  @required_fields [:body, :contact_id, :status, :organization_id, :message_number]
-  @optional_fields [:user_id, :topic, :remarks]
+  @required_fields [:body, :contact_id, :status, :organization_id]
+  @optional_fields [:user_id, :topic, :remarks, :message_number]
 
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),

--- a/priv/repo/migrations/20231122115923_add_message_number_colum_in_ticket_table.exs
+++ b/priv/repo/migrations/20231122115923_add_message_number_colum_in_ticket_table.exs
@@ -1,0 +1,9 @@
+defmodule Glific.Repo.Migrations.AddMessageNumberColumInTicketTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tickets) do
+      add :message_number, :integer
+    end
+  end
+end


### PR DESCRIPTION

## Summary
 Target issue is #3125 
 get the previous message_number before creating the ticketing so that we can navigate to the exact location where the ticket was being created.