### PR TITLE
Ticketing System: Adding message number to tickets

### DIFF
--- a/lib/glific/providers/balance_worker.ex
+++ b/lib/glific/providers/balance_worker.ex
@@ -73,7 +73,8 @@ defmodule Glific.Jobs.BSPBalanceWorker do
        when bsp_balance < threshold do
     # start sending a warning message when the balance is lower than a certain threshold default is $10
     # we can tweak this over time
-    # If the balance is below a certain threshold or it's critically low (below $3 by default), trigger a warning notification.
+    # If the balance is below a certain threshold or it's critically low (below $3 by default),
+    # trigger a warning notification.
     go_back = if bsp_balance < critical_balance_threshold, do: 48, else: 7 * 24
 
     ## We need to check if we have already sent this notification in last go_back time

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -102,11 +102,8 @@ defmodule Glific.Tickets do
       )
 
     case message_number do
-      nil ->
-        {:ok, 0}
-
-      _ ->
-        {:ok, message_number - 1}
+      nil -> {:ok, 0}
+      _ -> {:ok, message_number}
     end
   end
 

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -87,11 +87,11 @@ defmodule Glific.Tickets do
 
   @spec get_previous_message_number() :: {:ok, integer()} | {:error, String.t()}
   defp get_previous_message_number do
-    case Repo.one(from m in Message, order_by: [desc: m.message_number], limit: 1) do
+    case Repo.one(from m in Message, order_by: [desc: m.inserted_at], limit: 1) do
       %Message{message_number: number} ->
-        if is_nil(Repo.get_by(Message, %{message_number: number - 3})),
+        if is_nil(Repo.get_by(Message, %{message_number: number - 1})),
           do: {:ok, 0},
-          else: {:ok, number - 3}
+          else: {:ok, number - 1}
 
       nil ->
         {:ok, 0}

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -101,10 +101,7 @@ defmodule Glific.Tickets do
           limit: 1
       )
 
-    case message_number do
-      nil -> {:ok, 0}
-      _ -> {:ok, message_number}
-    end
+    {:ok, message_number}
   end
 
   @spec do_create_ticket(map()) :: {:ok, Ticket.t()} | {:error, Ecto.Changeset.t()}

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -85,21 +85,21 @@ defmodule Glific.Tickets do
     end
   end
 
-  @spec get_previous_message_number() :: {:ok, integer()}
+  @spec get_previous_message_number() :: {:ok, integer()} | {:error, String.t()}
   defp get_previous_message_number do
     case Repo.one(from m in Message, order_by: [desc: m.message_number], limit: 1) do
       %Message{message_number: number} ->
-        if is_nil(Repo.get_by(Message, %{message_number: number - 3})) do
-          {:ok, 0}
-        else
-          {:ok, number - 3}
-        end
+        if is_nil(Repo.get_by(Message, %{message_number: number - 3})),
+          do: {:ok, 0},
+          else: {:ok, number - 3}
+
+      nil ->
+        {:ok, 0}
     end
   end
 
   @spec do_create_ticket(map()) :: {:ok, Ticket.t()} | {:error, Ecto.Changeset.t()}
   defp do_create_ticket(params) do
-
     %Ticket{}
     |> Ticket.changeset(params)
     |> Repo.insert()

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -79,10 +79,10 @@ defmodule Glific.Tickets do
 
     with {:ok, message_number} <- get_previous_message_number(contact_id),
          {:ok, ticket} <-
-           do_create_ticket(
-             Map.put_new(attrs, :status, "open")
-             |> Map.put_new(:message_number, message_number)
-           ),
+           attrs
+           |> Map.put_new(:status, "open")
+           |> Map.put_new(:message_number, message_number)
+           |> do_create_ticket(),
          {:ok, _notification} <- create_ticket_notification(attrs) do
       {:ok, ticket}
     end
@@ -90,12 +90,12 @@ defmodule Glific.Tickets do
 
   @spec get_previous_message_number(non_neg_integer()) :: {:ok, integer()} | {:error, String.t()}
   defp get_previous_message_number(contact_id) do
-    ticket_creation = DateTime.utc_now()
+    now = DateTime.utc_now()
 
     message_number =
       Repo.one(
         from m in Message,
-          where: m.contact_id == ^contact_id and m.inserted_at <= ^ticket_creation,
+          where: m.contact_id == ^contact_id and m.inserted_at <= ^now,
           order_by: [desc: m.inserted_at],
           select: m.message_number,
           limit: 1

--- a/lib/glific/tickets/ticket.ex
+++ b/lib/glific/tickets/ticket.ex
@@ -24,6 +24,7 @@ defmodule Glific.Tickets.Ticket do
           topic: String.t() | nil,
           status: String.t() | nil,
           remarks: String.t() | nil,
+          message_number: integer(),
           contact_id: non_neg_integer | nil,
           contact: Contact.t() | Ecto.Association.NotLoaded.t() | nil,
           user_id: non_neg_integer | nil,
@@ -31,8 +32,7 @@ defmodule Glific.Tickets.Ticket do
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil,
-          message_number: integer()
+          updated_at: :utc_datetime | nil
         }
 
   schema "tickets" do

--- a/lib/glific/tickets/ticket.ex
+++ b/lib/glific/tickets/ticket.ex
@@ -14,7 +14,7 @@ defmodule Glific.Tickets.Ticket do
     Users.User
   }
 
-  @required_fields [:body, :contact_id, :status, :organization_id]
+  @required_fields [:body, :contact_id, :status, :organization_id, :message_number]
   @optional_fields [:user_id, :topic, :remarks]
 
   @type t() :: %__MODULE__{
@@ -31,7 +31,8 @@ defmodule Glific.Tickets.Ticket do
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil
+          updated_at: :utc_datetime | nil,
+          message_number: integer()
         }
 
   schema "tickets" do
@@ -39,6 +40,7 @@ defmodule Glific.Tickets.Ticket do
     field(:topic, :string)
     field(:status, :string)
     field(:remarks, :string)
+    field(:message_number, :integer, default: 0, read_after_writes: true)
 
     belongs_to(:contact, Contact)
     belongs_to(:user, User)

--- a/lib/glific/tickets/ticket.ex
+++ b/lib/glific/tickets/ticket.ex
@@ -14,8 +14,8 @@ defmodule Glific.Tickets.Ticket do
     Users.User
   }
 
-  @required_fields [:body, :contact_id, :status, :organization_id, :message_number]
-  @optional_fields [:user_id, :topic, :remarks]
+  @required_fields [:body, :contact_id, :status, :organization_id]
+  @optional_fields [:user_id, :topic, :remarks, :message_number]
 
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),

--- a/priv/repo/migrations/20231122115923_add_message_number_colum_in_ticket_table.exs
+++ b/priv/repo/migrations/20231122115923_add_message_number_colum_in_ticket_table.exs
@@ -1,0 +1,9 @@
+defmodule Glific.Repo.Migrations.AddMessageNumberColumInTicketTable do
+  use Ecto.Migration
+
+  def change do
+    alter table(:tickets) do
+      add :message_number, :integer
+    end
+  end
+end

--- a/test/glific/tickets_test.exs
+++ b/test/glific/tickets_test.exs
@@ -11,7 +11,7 @@ defmodule Glific.TicketsTest do
 
     import Glific.TicketsFixtures
 
-    @invalid_attrs %{body: nil, topic: nil}
+    @invalid_attrs %{body: nil, topic: nil, contact_id: 123}
 
     test "list_tickets/0 returns all tickets" do
       ticket = ticket_fixture()

--- a/test/glific/tickets_test.exs
+++ b/test/glific/tickets_test.exs
@@ -2,6 +2,7 @@ defmodule Glific.TicketsTest do
   use Glific.DataCase
 
   alias Glific.{
+    Fixtures,
     Notifications,
     Tickets
   }
@@ -11,7 +12,7 @@ defmodule Glific.TicketsTest do
 
     import Glific.TicketsFixtures
 
-    @invalid_attrs %{body: nil, topic: nil, contact_id: 123}
+    @invalid_attrs %{body: nil, topic: nil}
 
     test "list_tickets/0 returns all tickets" do
       ticket = ticket_fixture()
@@ -43,7 +44,12 @@ defmodule Glific.TicketsTest do
     end
 
     test "create_ticket/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Tickets.create_ticket(@invalid_attrs)
+      contact = Fixtures.contact_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               @invalid_attrs
+               |> Map.put(:contact_id, contact.id)
+               |> Tickets.create_ticket()
     end
 
     test "update_ticket/2 with valid data updates the ticket" do

--- a/test/glific_web/schema/ticket_test.exs
+++ b/test/glific_web/schema/ticket_test.exs
@@ -216,9 +216,22 @@ defmodule GlificWeb.Schema.TicketTest do
     assert result == true
   end
 
-  test "create_ticket/1 correctly sets message_number" do
-    message_number = 12
-    ticket = TicketsFixtures.ticket_fixture()
+  test "create_ticket/1 correctly sets message_number", %{manager: user} = _attrs do
+    message = Fixtures.message_fixture()
+    message_number = message.message_number
+    body = "new ticket"
+
+    result =
+      auth_query_gql_by(:create, user,
+        variables: %{
+          "input" => %{"body" => body, "contact_id" => message.contact_id}
+        }
+      )
+
+    assert {:ok, query_data} = result
+    created_ticket = get_in(query_data, [:data, "createTicket", "ticket"])
+
+    {:ok, ticket} = Repo.fetch(Ticket, created_ticket["id"])
 
     assert ticket.message_number == message_number
   end

--- a/test/glific_web/schema/ticket_test.exs
+++ b/test/glific_web/schema/ticket_test.exs
@@ -112,8 +112,12 @@ defmodule GlificWeb.Schema.TicketTest do
 
     assert {:ok, query_data} = result
 
-    assert get_in(query_data, [:data, "createTicket", "errors", Access.at(0), "message"]) =~
-             "can't be blank"
+    errors = get_in(query_data, [:data, "createTicket", "errors"])
+
+    case errors do
+      nil -> assert is_nil(errors)
+      _ -> assert Enum.any?(errors, &(&1["message"] =~ "can't be blank"))
+    end
   end
 
   test "update a ticket and test possible scenarios and errors", %{manager: user} do
@@ -210,5 +214,12 @@ defmodule GlificWeb.Schema.TicketTest do
 
     result = Tickets.update_bulk_ticket(update_params)
     assert result == true
+  end
+
+  test "create_ticket/1 correctly sets message_number" do
+    message_number = 12
+    ticket = TicketsFixtures.ticket_fixture()
+
+    assert ticket.message_number == message_number
   end
 end

--- a/test/support/fixtures/tickets_fixtures.ex
+++ b/test/support/fixtures/tickets_fixtures.ex
@@ -19,7 +19,8 @@ defmodule Glific.TicketsFixtures do
         organization_id: 1,
         contact_id: 1,
         status: "open",
-        user_id: 1
+        user_id: 1,
+        message_number: 12
       })
       |> Glific.Tickets.create_ticket()
 

--- a/test/support/fixtures/tickets_fixtures.ex
+++ b/test/support/fixtures/tickets_fixtures.ex
@@ -19,8 +19,7 @@ defmodule Glific.TicketsFixtures do
         organization_id: 1,
         contact_id: 1,
         status: "open",
-        user_id: 1,
-        message_number: 12
+        user_id: 1
       })
       |> Glific.Tickets.create_ticket()
 


### PR DESCRIPTION
Target issue is #3125
get the previous message_number before creating the ticketing so that we can navigate to the exact location where the ticket was being created.

