### PR TITLE
Trigger: the flow with no action node

### DIFF
--- a/lib/glific/triggers.ex
+++ b/lib/glific/triggers.ex
@@ -157,22 +157,28 @@ defmodule Glific.Triggers do
     {:ok, flow} =
       Repo.fetch_by(FlowRevision, %{flow_id: Map.get(attrs, :flow_id), status: "published"})
 
-    first_node = flow |> Map.get(:definition) |> Map.get("nodes") |> hd()
-    action = hd(first_node["actions"])
-    type = Map.get(action, "type")
+    action = flow |> Map.get(:definition) |> Map.get("nodes") |> hd() |> Map.get("actions")
 
-    case type do
-      "send_interactive_msg" ->
-        handle_message_type(type, action, attrs)
-
-      "send_msg" ->
-        handle_message_type(type, action, attrs)
-
-      "enter_flow" ->
-        handle_enter_flow(action, attrs)
-
-      _ ->
+    case action do
+      [] ->
         do_create_trigger(attrs)
+
+      [action | _rest] ->
+        type = Map.get(action, "type")
+
+        case type do
+          "send_interactive_msg" ->
+            handle_message_type(type, action, attrs)
+
+          "send_msg" ->
+            handle_message_type(type, action, attrs)
+
+          "enter_flow" ->
+            handle_enter_flow(action, attrs)
+
+          _ ->
+            do_create_trigger(attrs)
+        end
     end
   end
 
@@ -199,11 +205,18 @@ defmodule Glific.Triggers do
     {:ok, entered_flow} =
       Repo.fetch_by(FlowRevision, %{flow_id: flow.id, status: "published"})
 
-    entered_first_node = entered_flow |> Map.get(:definition) |> Map.get("nodes") |> hd()
-    entered_action = hd(entered_first_node["actions"])
-    entered_type = Map.get(entered_action, "type")
+    entered_action =
+      entered_flow |> Map.get(:definition) |> Map.get("nodes") |> hd() |> Map.get("actions")
 
-    handle_message_type(entered_type, entered_action, attrs)
+    case entered_action do
+      [] ->
+        do_create_trigger(attrs)
+
+      [entered_action | _rest] ->
+        entered_type = Map.get(entered_action, "type")
+
+        handle_message_type(entered_type, entered_action, attrs)
+    end
   end
 
   @spec do_create_trigger(map()) :: {:ok, Trigger.t()} | {:error, Ecto.Changeset.t()}


### PR DESCRIPTION

## Summary
 Target issue is #3259
trigger should be created when the flow in trigger starts with the node with no action