### PR TITLE
Added type in templates API for floweditor

### DIFF
--- a/lib/glific/clients/kef.ex
+++ b/lib/glific/clients/kef.ex
@@ -61,7 +61,7 @@ defmodule Glific.Clients.KEF do
         _ -> "Others"
       end
 
-    if flow_id == 13850 do
+    if flow_id == 13_850 do
       "stories_activities_campaign/#{media_subfolder}/#{phone}/" <> media["remote_name"]
     else
       "#{folder_structure}/#{media_subfolder}/#{phone}/" <> media["remote_name"]

--- a/lib/glific_web/flows/flow_editor_controller.ex
+++ b/lib/glific_web/flows/flow_editor_controller.ex
@@ -300,6 +300,7 @@ defmodule GlificWeb.Flows.FlowEditorController do
           %{
             uuid: template.uuid,
             name: template.label,
+            type: template.type,
             created_on: template.inserted_at,
             modified_on: template.updated_at,
             translations:


### PR DESCRIPTION

## Summary
 Target issue is https://github.com/glific/glific-frontend/issues/2633
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
 To check if the template type is media we need to get the type of the template from the API. Added the type in the response for the API

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
