### PR TITLE
Partner API: Setting Callback URL

### DIFF
--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -140,6 +140,16 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     end
   end
 
+  @doc """
+  For setting callback URL
+  """
+  @spec set_callback_url(String.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  def set_callback_url(org_id, callback_url) do
+    url = app_url(org_id) <> "/callbackUrl"
+    data = %{"callbackUrl" => callback_url}
+    put_request(url, data, org_id: org_id)
+  end
+
   @global_organization_id 0
   @spec get_partner_token :: {:ok, map()} | {:error, any}
   defp get_partner_token do

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -143,7 +143,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @doc """
   For setting callback URL
   """
-  @spec set_callback_url(String.t(), String.t()) :: {:ok, map()} | {:error, String.t()}
+  @spec set_callback_url(String.t(), String.t()) :: tuple()
   def set_callback_url(org_id, callback_url) do
     url = app_url(org_id) <> "/callbackUrl"
     data = %{"callbackUrl" => callback_url}

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -153,7 +153,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @doc """
   For setting callback URL
   """
-  @spec set_callback_url(String.t(), String.t()) :: tuple()
+  @spec set_callback_url(non_neg_integer(), String.t()) :: tuple()
   def set_callback_url(org_id, callback_url) do
     url = app_url(org_id) <> "/callbackUrl"
     data = %{"callbackUrl" => callback_url}

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -7,6 +7,7 @@ defmodule Glific.PartnersTest do
     Fixtures,
     Notifications.Notification,
     Partners,
+    Seeds.SeedsDev,
     Partners.Credential,
     Partners.Provider,
     Repo
@@ -126,6 +127,21 @@ defmodule Glific.PartnersTest do
       organization = Fixtures.organization_fixture()
       {:ok, data} = Partners.get_bsp_balance(organization.id)
       assert %{"balance" => 0.787, "status" => "success"} == data
+    end
+
+    test "set_callback_url/2 for setting callback URL" do
+      Tesla.Mock.mock(fn
+        %{method: :put} ->
+          %Tesla.Env{
+            status: 200,
+            body: "{\"status\":\"success\"}"
+          }
+      end)
+
+      org = SeedsDev.seed_organizations()
+      callback_url = "https://webhook.site/"
+      {:ok, data} = Glific.Providers.Gupshup.PartnerAPI.set_callback_url(org.id, callback_url)
+      assert %{"status" => "success"} == data
     end
 
     test "delete_provider/1 deletes the provider" do

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -131,6 +131,7 @@ defmodule Glific.PartnersTest do
 
     test "enable template messaging for an app" do
       org = SeedsDev.seed_organizations()
+
       Tesla.Mock.mock(fn
         %{method: :put} ->
           %Tesla.Env{


### PR DESCRIPTION

## Summary
 Target issue is #3214 

 Explain the **motivation** for making this change. What existing problem does the pull request solve?
New feature has been added in partner api to set the callback url using api calls.

## Notes
Takes 2 parameters:
1. Org_id
2. Callback Url
