### PR TITLE
Auto Translate: Parallel Translation at lang level

### DIFF
--- a/lib/glific/flows/translate/export.ex
+++ b/lib/glific/flows/translate/export.ex
@@ -85,6 +85,7 @@ defmodule Glific.Flows.Translate.Export do
     |> Enum.reverse()
   end
 
+  @spec collect_strings(map(), map(), String.t(), map()) :: Keyword.t()
   defp collect_strings(action_languages, language_labels, default_text, collect) do
     language_labels
     |> Map.keys()
@@ -111,20 +112,30 @@ defmodule Glific.Flows.Translate.Export do
     )
   end
 
+  @spec translate_strings(map()) :: map()
   defp translate_strings(strings) do
     strings
-    |> Enum.reduce(
-      %{},
-      fn {{src, dst}, values}, acc ->
-        {:ok, result} = Translate.translate(values, src, dst)
-
-        Enum.zip(values, result)
-        |> Map.new()
-        |> then(&Map.put(acc, {src, dst}, &1))
-      end
+    |> Task.async_stream(
+      fn {{src, dst}, values} -> {src, dst, values, Translate.translate(values, src, dst)} end,
+      timeout: 300_000,
+      # send {:exit, :timeout} so it can be handled
+      on_timeout: :kill_task
     )
+    |> Enum.reduce(%{}, fn response, acc ->
+      handle_async_response(response, acc)
+    end)
   end
 
+  @spec handle_async_response(tuple(), map()) :: map()
+  defp handle_async_response({:ok, {src, dst, values, {:ok, result}}}, acc) do
+    Enum.zip(values, result)
+    |> Map.new()
+    |> then(&Map.put(acc, {src, dst}, &1))
+  end
+
+  defp handle_async_response({:exit, :timeout}, acc), do: acc
+
+  @spec make_row(map(), map(), String.t(), map()) :: list()
   defp make_row(action_languages, language_labels, default_text, translations) do
     language_labels
     |> Map.keys()

--- a/lib/glific/flows/translate/export.ex
+++ b/lib/glific/flows/translate/export.ex
@@ -118,6 +118,7 @@ defmodule Glific.Flows.Translate.Export do
     |> Task.async_stream(
       fn {{src, dst}, values} -> {src, dst, values, Translate.translate(values, src, dst)} end,
       timeout: 300_000,
+      max_concurrency: 2,
       # send {:exit, :timeout} so it can be handled
       on_timeout: :kill_task
     )

--- a/lib/glific/flows/translate/open_ai.ex
+++ b/lib/glific/flows/translate/open_ai.ex
@@ -26,6 +26,7 @@ defmodule Glific.Flows.Translate.OpenAI do
     |> check_large_strings()
     |> Task.async_stream(fn text -> do_translate(text, src, dst) end,
       timeout: 300_000,
+      max_concurrency: 15,
       # send {:exit, :timeout} so it can be handled
       on_timeout: :kill_task
     )
@@ -72,7 +73,7 @@ defmodule Glific.Flows.Translate.OpenAI do
 
       {:error, error} ->
         Logger.error("Error translating: #{error} String: #{strings}")
-        ["Could not translate, Try again"]
+        ""
     end
   end
 


### PR DESCRIPTION
## Notes
Added concurrency at language level, setting max concurrency at 2 as average number of language per org is 3