### PR TITLE
SSL for DB connection

### DIFF
--- a/config/.env.dev.txt
+++ b/config/.env.dev.txt
@@ -16,3 +16,6 @@ STRIPE_SIGNING_SECRET=this_is_not_the_secret
 RECAPTCHA_SECRET_KEY=this_is_not_the_key
 OPEN_AI_KEY=this_is_not_the_key
 GOOGLE_TRANSLATE_KEY=this_is_not_the_key
+CACERT_PATH=/priv/cert/glific-cacert.pem 
+CERT_KEY_PATH=/priv/cert/glific-cert.key
+CERT_PATH=/priv/cert/glific-cert.crt

--- a/config/.env.test
+++ b/config/.env.test
@@ -17,3 +17,6 @@ SES_REGION=this_is_not_the_secret
 SES_KEY=this_is_not_the_secret
 SES_SECRET=this_is_not_the_secret
 OPEN_AI_KEY=this_is_not_the_key
+CACERT_PATH=/priv/cert/glific-cacert.pem 
+CERT_KEY_PATH=/priv/cert/glific-cert.key
+CERT_PATH=/priv/cert/glific-cert.crt

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -15,7 +15,14 @@ config :glific, Glific.Repo,
   pool_size: env!("POOL_SIZE", :integer, 20),
   show_sensitive_data_on_connection_error: true,
   prepare: :named,
-  parameters: [plan_cache_mode: "force_custom_plan"]
+  parameters: [plan_cache_mode: "force_custom_plan"],
+  ssl: true,
+  ssl_opts: [
+    verify: :verify_peer,
+    cacertfile: Path.expand("../", __DIR__) <> env!("CACERT_PATH"),
+    keyfile: Path.expand("../", __DIR__) <> env!("CERT_KEY_PATH"),
+    certfile: Path.expand("../", __DIR__) <> env!("CERT_PATH")
+  ]
 
 check_origin = [env!("REQUEST_ORIGIN", :string!), env!("REQUEST_ORIGIN_WILDCARD", :string!)]
 


### PR DESCRIPTION

## Summary
 Target issue is #3059  

 Adding SSL connection for Db connections on test , dev and prod.

 Documentation about configuring ssl for the project can be found [here](https://github.com/glific/glific/tree/feat/issue-3059-ssl-db-conn?tab=readme-ov-file#database-connection-with-ssl).
 
There's room for automating via scripting later after verifying the steps.

## Notes
Yet to test on windows and mac
