### PR TITLE
Dashboard UI: added textwrap in the broadcast table

### DIFF
--- a/lib/glific_web/templates/live/stats_live.html.heex
+++ b/lib/glific_web/templates/live/stats_live.html.heex
@@ -375,7 +375,7 @@
           <%= for item <- @broadcast_data do %>
             <tr>
               <%= for value <- item do %>
-                <td><%= value %></td>
+                <td class="break-all"><%= value %></td>
               <% end %>
             </tr>
           <% end %>


### PR DESCRIPTION

## Summary
 Target issue is #3347 

## Notes
 Please add here if any other information is required for the reviewer. 
- Added `word-break: break-all` to the broadcast table UI