### PR TITLE
WA groups: count API to get the count of wa group contacts

### DIFF
--- a/assets/gql/contact_wa_groups/count_wa_contacts.gql
+++ b/assets/gql/contact_wa_groups/count_wa_contacts.gql
@@ -1,0 +1,3 @@
+query countContactWaGroup($filter: ContactWaGroupFilter) {
+  countContactWaGroup(filter: $filter)
+}

--- a/lib/glific/groups/contact_wa_groups.ex
+++ b/lib/glific/groups/contact_wa_groups.ex
@@ -123,4 +123,14 @@ defmodule Glific.Groups.ContactWAGroups do
     fields = {{:wa_group_id, wa_group_id}, {:contact_id, contact_ids}}
     Repo.delete_relationships_by_ids(ContactWAGroup, fields)
   end
+
+  @doc """
+  Return the count of wa group contacts, using the same filter as list_wa_group_contacts
+  """
+  @spec count_contact_wa_group(map()) :: [ContactWAGroup.t()]
+  def count_contact_wa_group(args) do
+    args
+    |> Repo.list_filter_query(ContactWAGroup, nil, &filter_with/2)
+    |> Repo.aggregate(:count)
+  end
 end

--- a/lib/glific_web/resolvers/wa_group.ex
+++ b/lib/glific_web/resolvers/wa_group.ex
@@ -47,13 +47,12 @@ defmodule GlificWeb.Resolvers.WaGroup do
     end
   end
 
-
   @doc """
   Get the count of contact whastapp groups filtered by args
   """
   @spec count_contact_wa_group(Absinthe.Resolution.t(), map(), %{context: map()}) ::
-  {:ok, any} | {:error, any}
-def count_contact_wa_group(_, args, _) do
-{:ok, ContactWAGroups.count_contact_wa_group(args)}
-end
+          {:ok, any} | {:error, any}
+  def count_contact_wa_group(_, args, _) do
+    {:ok, ContactWAGroups.count_contact_wa_group(args)}
+  end
 end

--- a/lib/glific_web/resolvers/wa_group.ex
+++ b/lib/glific_web/resolvers/wa_group.ex
@@ -46,4 +46,14 @@ defmodule GlificWeb.Resolvers.WaGroup do
       :ok -> {:ok, %{message: "successfully synced"}}
     end
   end
+
+
+  @doc """
+  Get the count of contact whastapp groups filtered by args
+  """
+  @spec count_contact_wa_group(Absinthe.Resolution.t(), map(), %{context: map()}) ::
+  {:ok, any} | {:error, any}
+def count_contact_wa_group(_, args, _) do
+{:ok, ContactWAGroups.count_contact_wa_group(args)}
+end
 end

--- a/lib/glific_web/schema/contact_wa_group_types.ex
+++ b/lib/glific_web/schema/contact_wa_group_types.ex
@@ -65,6 +65,13 @@ defmodule GlificWeb.Schema.ContactWaGroupTypes do
       middleware(Authorize, :staff)
       resolve(&Resolvers.WaGroup.list_contact_wa_group/3)
     end
+
+    @desc "Get a count of all the contacts associated with the wa group"
+    field :count_contact_wa_group, :integer do
+      arg(:filter, :contact_wa_group_filter)
+      middleware(Authorize, :staff)
+      resolve(&Resolvers.WaGroup.count_contact_wa_group/3)
+    end
   end
 
   object :contact_wa_group_mutations do

--- a/test/glific_web/schema/contact_wa_group_test.exs
+++ b/test/glific_web/schema/contact_wa_group_test.exs
@@ -19,6 +19,7 @@ defmodule GlificWeb.Schema.ContactWaGroupTest do
   load_gql(:create, GlificWeb.Schema, "assets/gql/contact_wa_groups/create.gql")
   load_gql(:list, GlificWeb.Schema, "assets/gql/contact_wa_groups/list.gql")
   load_gql(:sync, GlificWeb.Schema, "assets/gql/contact_wa_groups/sync.gql")
+  load_gql(:count, GlificWeb.Schema, "assets/gql/contact_wa_groups/count_wa_contacts.gql")
 
   load_gql(
     :update_wa_group,
@@ -185,5 +186,29 @@ defmodule GlificWeb.Schema.ContactWaGroupTest do
       )
 
     assert deleted_contacts == {1, nil}
+  end
+
+  test "count the contacts associated with wa_groups", %{staff: user} do
+    wa_managed_phone =
+      Fixtures.wa_managed_phone_fixture(%{organization_id: user.organization_id})
+
+    contact_wa_group =
+      Fixtures.contact_wa_group_fixture(%{
+        organization_id: user.organization_id,
+        wa_managed_phone_id: wa_managed_phone.id
+      })
+
+    result =
+      auth_query_gql_by(:count, user,
+        variables: %{
+          "filter" => %{
+            "waGroupId" => contact_wa_group.wa_group_id
+          }
+        }
+      )
+
+    assert {:ok, query_data} = result
+    count = get_in(query_data, [:data, "countContactWaGroup"])
+    assert count == 1
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #3413
 created the count api to get the count of contacts associated to the whatsapp groups