### PR TITLE
GCS Worker: Handling account not found error

### DIFF
--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -1011,7 +1011,7 @@ defmodule Glific.Partners do
 
         {:error, error} ->
           Logger.info(
-            "Error fetching token for: #{provider_shortcode}, error: #{error}, org_id: #{organization_id}"
+            "Error fetching token for: #{provider_shortcode}, error: #{inspect error}, org_id: #{organization_id}"
           )
 
           handle_token_error(organization_id, provider_shortcode, "#{inspect(error)}")

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -1011,7 +1011,7 @@ defmodule Glific.Partners do
 
         {:error, error} ->
           Logger.info(
-            "Error fetching token for: #{provider_shortcode}, error: #{inspect error}, org_id: #{organization_id}"
+            "Error fetching token for: #{provider_shortcode}, error: #{inspect(error)}, org_id: #{organization_id}"
           )
 
           handle_token_error(organization_id, provider_shortcode, "#{inspect(error)}")

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -57,7 +57,7 @@ defmodule Glific.GcsWorkerTest do
       {:ok, _credential} = Partners.create_credential(valid_attrs)
 
       assert nil ==
-      Partners.get_goth_token(attrs.organization_id, "google_cloud_storage")
+               Partners.get_goth_token(attrs.organization_id, "google_cloud_storage")
     end
   end
 end

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -1,0 +1,63 @@
+defmodule Glific.GcsWorkerTest do
+  use GlificWeb.ConnCase
+  import Mock
+
+  alias Glific.{
+    Partners,
+    Seeds.SeedsDev
+  }
+
+  setup do
+    default_provider = SeedsDev.seed_providers()
+    SeedsDev.seed_organizations(default_provider)
+    :ok
+  end
+
+  @tag :upload
+  test "upload_media/3", attrs do
+    Application.put_env(:waffle, :token_fetcher, Glific.GCS)
+
+    body = %{
+      error: "invalid_grant",
+      error_description: "Invalid grant: account not found"
+    }
+
+    body = Jason.encode!(body)
+
+    err_response = """
+    unexpected status 400 from Google
+
+    #{body}
+    """
+
+    with_mock(
+      Goth.Token,
+      [],
+      fetch: fn _url ->
+        {:error, RuntimeError.exception(err_response)}
+      end
+    ) do
+      valid_attrs = %{
+        shortcode: "google_cloud_storage",
+        secrets: %{
+          "service_account" =>
+            Jason.encode!(%{
+              project_id: "DEFAULT PROJECT ID",
+              private_key_id: "DEFAULT API KEY",
+              client_email: "DEFAULT CLIENT EMAIL",
+              private_key: "DEFAULT PRIVATE KEY"
+            })
+        },
+        is_active: true,
+        organization_id: attrs.organization_id
+      }
+
+      Glific.Caches.remove(attrs.organization_id, [{:provider_token, "google_cloud_storage"}])
+
+      {:ok, _credential} = Partners.create_credential(valid_attrs)
+
+      assert nil ==
+      Partners.get_goth_token(attrs.organization_id, "google_cloud_storage")
+    end
+  end
+end

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -13,7 +13,6 @@ defmodule Glific.GcsWorkerTest do
     :ok
   end
 
-  @tag :upload
   test "upload_media/3", attrs do
     Application.put_env(:waffle, :token_fetcher, Glific.GCS)
 


### PR DESCRIPTION

## Summary
 Target issue is #3491 
 
Actual handling of account not found is handled already with creating notification and deleting GCS. But due to a wrong interpolation of error in logs, interpolation error occurred instead.

Steps to reproduce this in tests,
- change the log level to :info and comment the purging like below in `config/test.exs`
```
config :logger,
  level: :info,
  # compile_time_purge_matching: [[level_lower_than: :emergency]]
```
- Remove the `inspect` which we added in the commit
- run ` mix test_full test/glific/gcs_worker_test.exs` 
