### PR TITLE
Fetching right env in staging and prod

### DIFF
--- a/priv/repo/seeds/20200723172939_add_glific_data.exs
+++ b/priv/repo/seeds/20200723172939_add_glific_data.exs
@@ -94,7 +94,7 @@ defmodule Glific.Repo.Seeds.AddGlificData do
 
     bigquery_jobs(organization)
 
-    if(Mix.env() in [:dev, :test]) do
+    if Application.get_env(:glific, :environment) in [:dev, :test] do
       set_newcontact_optin_flow_id(organization)
 
       set_regx_flow(organization)
@@ -643,7 +643,7 @@ defmodule Glific.Repo.Seeds.AddGlificData do
       })
 
   def flows(organization) do
-    if(Mix.env() in [:dev, :test]) do
+    if Application.get_env(:glific, :environment) in [:dev, :test] do
       SeedsFlows.seed([organization])
     else
       SeedsFlows.seed_flows([organization])

--- a/test/glific/groups/whatsapp_group_test.exs
+++ b/test/glific/groups/whatsapp_group_test.exs
@@ -110,28 +110,28 @@ defmodule Glific.Groups.WAGroupsTest do
                id: attrs.organization_id,
                shortcode: "maytapi"
              })
-
   end
-    test "fetch_wa_groups/1 fetch groups for empty group label", attrs do
-      Tesla.Mock.mock(fn _env ->
-        %Tesla.Env{
-          status: 200,
-          body:
-            "{\"count\":79,\"data\":[{\"admins\":[\"917834811115@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363213149844251@g.us\",\"name\":\"marketing\",\"participants\":[\"917834811116@c.us\",\"917834811115@c.us\",\"917834811114@c.us\"]},{\"admins\":[\"917834811114@c.us\",\"917834811115@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363203450035277@g.us\",\"name\":\"admin group\",\"participants\":[\"917834811116@c.us\",\"917834811115@c.us\",\"917834811114@c.us\"]},{\"admins\":[\"917834811114@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363218884368888@g.us\",\"name\":\"\",\"participants\":[\"917834811114@c.us\"]}],\"limit\":500,\"success\":true,\"total\":79}"
-        }
-      end)
 
-      assert :ok == WAGroups.fetch_wa_groups(attrs.organization_id)
+  test "fetch_wa_groups/1 fetch groups for empty group label", attrs do
+    Tesla.Mock.mock(fn _env ->
+      %Tesla.Env{
+        status: 200,
+        body:
+          "{\"count\":79,\"data\":[{\"admins\":[\"917834811115@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363213149844251@g.us\",\"name\":\"marketing\",\"participants\":[\"917834811116@c.us\",\"917834811115@c.us\",\"917834811114@c.us\"]},{\"admins\":[\"917834811114@c.us\",\"917834811115@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363203450035277@g.us\",\"name\":\"admin group\",\"participants\":[\"917834811116@c.us\",\"917834811115@c.us\",\"917834811114@c.us\"]},{\"admins\":[\"917834811114@c.us\"],\"config\":{\"disappear\":false,\"edit\":\"all\",\"send\":\"all\"},\"id\":\"120363218884368888@g.us\",\"name\":\"\",\"participants\":[\"917834811114@c.us\"]}],\"limit\":500,\"success\":true,\"total\":79}"
+      }
+    end)
 
-      assert {:ok, group} = Repo.fetch_by(WAGroup, %{label: "marketing"})
-      assert group.label == "marketing"
-      assert group.bsp_id == "120363213149844251@g.us"
+    assert :ok == WAGroups.fetch_wa_groups(attrs.organization_id)
 
-      assert {:ok, group} = Repo.fetch_by(WAGroup, %{label: "admin group"})
-      assert group.label == "admin group"
-      assert group.bsp_id == "120363203450035277@g.us"
+    assert {:ok, group} = Repo.fetch_by(WAGroup, %{label: "marketing"})
+    assert group.label == "marketing"
+    assert group.bsp_id == "120363213149844251@g.us"
 
-      # group with an empty name is not created
-      assert is_nil(Repo.get_by(WAGroup, label: ""))
-    end
+    assert {:ok, group} = Repo.fetch_by(WAGroup, %{label: "admin group"})
+    assert group.label == "admin group"
+    assert group.bsp_id == "120363203450035277@g.us"
+
+    # group with an empty name is not created
+    assert is_nil(Repo.get_by(WAGroup, label: ""))
+  end
 end


### PR DESCRIPTION

## Summary
 Replacing `Mix.env()` with `Application.get_env(:glific, :environment)` since the former doesn't work in gigalixir environment 
