### PR TITLE
Notification mails: Using org name and email as `to` email address instead of empty list 

### DIFF
--- a/lib/glific/mails/notification_mail.ex
+++ b/lib/glific/mails/notification_mail.ex
@@ -9,7 +9,6 @@ defmodule Glific.Mails.NotificationMail do
   """
   @spec critical_mail(Organization.t(), String.t()) :: Swoosh.Email.t()
   def critical_mail(org, message) do
-    team = ""
     subject = "Glific CRITICAL Issue: Needs your immediate attention."
 
     body = """
@@ -19,7 +18,7 @@ defmodule Glific.Mails.NotificationMail do
     The Glific team
     """
 
-    Mailer.common_send(org, subject, body, team: team)
+    Mailer.common_send(org, subject, body)
   end
 
   @doc """
@@ -27,7 +26,6 @@ defmodule Glific.Mails.NotificationMail do
   """
   @spec warning_mail(Organization.t(), String.t()) :: Swoosh.Email.t()
   def warning_mail(org, message) do
-    team = ""
     subject = "Glific Warning: Needs your attention."
 
     body = """
@@ -37,6 +35,6 @@ defmodule Glific.Mails.NotificationMail do
     The Glific team
     """
 
-    Mailer.common_send(org, subject, body, team: team)
+    Mailer.common_send(org, subject, body)
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #3618 
 
 
<img width="719" alt="Screenshot 2024-06-21 at 10 30 55 AM" src="https://github.com/glific/glific/assets/17821575/2c051cfd-c731-4128-aee6-6bb6268b943b">


We were sending `team` as "" and no `send_to` which makes clause at ln: 107 execute and returns nil, resulting in `to` of sender to be `[]`

