### PR TITLE
Interactive Template: Add warning message for character limit exceedance

### DIFF
--- a/lib/glific/templates/interactive_templates.ex
+++ b/lib/glific/templates/interactive_templates.ex
@@ -209,7 +209,7 @@ defmodule Glific.Templates.InteractiveTemplates do
   end
 
   @spec trim_contents_with_error(map()) ::
-          {:ok, String.t(), map()} | {:error, String.t(), map()}
+          {:ok, String.t() | nil, map()} | {:error, String.t(), map()}
   defp trim_contents_with_error(translated_contents) do
     {processed_content, languages_with_trimming} =
       Enum.reduce(translated_contents, {%{}, []}, fn {language_id, content},
@@ -224,8 +224,7 @@ defmodule Glific.Templates.InteractiveTemplates do
       end)
 
     if languages_with_trimming == [] do
-      message = "updated successfully"
-      {:ok, message, processed_content}
+      {:ok, nil, processed_content}
     else
       language_names = get_language_names_from_id(languages_with_trimming)
 

--- a/lib/glific/templates/interactive_templates.ex
+++ b/lib/glific/templates/interactive_templates.ex
@@ -192,19 +192,17 @@ defmodule Glific.Templates.InteractiveTemplates do
   def update_interactive_template(%InteractiveTemplate{} = interactive, attrs) do
     translations = Map.get(attrs, :translations, interactive.translations)
 
-    case trim_contents_with_error(translations) do
-      {:ok, message, trimmed_contents} ->
-        updated_attrs = Map.put(attrs, :translations, trimmed_contents)
+    {:ok, message, trimmed_contents} = trim_contents_with_error(translations)
+    updated_attrs = Map.put(attrs, :translations, trimmed_contents)
 
-        case interactive
-             |> InteractiveTemplate.changeset(updated_attrs)
-             |> Repo.update() do
-          {:ok, updated_interactive} ->
-            {:ok, updated_interactive, message}
+    case interactive
+         |> InteractiveTemplate.changeset(updated_attrs)
+         |> Repo.update() do
+      {:ok, updated_interactive} ->
+        {:ok, updated_interactive, message}
 
-          {:error, changeset} ->
-            {:error, changeset}
-        end
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/glific_web/resolvers/interactives.ex
+++ b/lib/glific_web/resolvers/interactives.ex
@@ -55,9 +55,9 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
   def update_interactive_template(_, %{id: id, input: params}, _) do
     with {:ok, interactive_template} <-
            InteractiveTemplates.fetch_interactive_template(id),
-         {:ok, interactive_template} <-
+         {:ok, interactive_template, message} <-
            InteractiveTemplates.update_interactive_template(interactive_template, params) do
-      {:ok, %{interactive_template: interactive_template}}
+      {:ok, %{interactive_template: interactive_template, message: message}}
     end
   end
 
@@ -110,9 +110,9 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
   def translate_interactive_template(_, %{id: id}, _) do
     with {:ok, interactive_template} <-
            InteractiveTemplates.fetch_interactive_template(id),
-         {:ok, interactive_template} <-
+         {:ok, interactive_template, message} <-
            InteractiveTemplates.translate_interactive_template(interactive_template) do
-      {:ok, %{interactive_template: interactive_template}}
+      {:ok, %{interactive_template: interactive_template, message: message}}
     end
   end
 
@@ -145,10 +145,10 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
         |> CSV.decode!()
         |> Enum.into([])
 
-      {:ok, interactive_template} =
+      {:ok, interactive_template, message} =
         InteractiveTemplates.import_interactive_template(data_list, interactive_template)
 
-      {:ok, %{interactive_template: interactive_template}}
+      {:ok, %{interactive_template: interactive_template, message: message}}
     end
   end
 end

--- a/lib/glific_web/resolvers/interactives.ex
+++ b/lib/glific_web/resolvers/interactives.ex
@@ -51,7 +51,7 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
   @spec update_interactive_template(Absinthe.Resolution.t(), %{id: integer, input: map()}, %{
           context: map()
         }) ::
-          {:ok, any} | {:error, any}
+          {:ok, any, String.t()} | {:error, any}
   def update_interactive_template(_, %{id: id, input: params}, _) do
     with {:ok, interactive_template} <-
            InteractiveTemplates.fetch_interactive_template(id),
@@ -106,7 +106,7 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
   @spec translate_interactive_template(Absinthe.Resolution.t(), %{id: integer, input: map()}, %{
           context: map()
         }) ::
-          {:ok, any} | {:error, any}
+          {:ok, any, String.t()} | {:error, any}
   def translate_interactive_template(_, %{id: id}, _) do
     with {:ok, interactive_template} <-
            InteractiveTemplates.fetch_interactive_template(id),
@@ -133,7 +133,7 @@ defmodule GlificWeb.Resolvers.InteractiveTemplates do
   import interactive template
   """
   @spec import_interactive_template(Absinthe.Resolution.t(), map(), %{context: map()}) ::
-          {:ok, any} | {:error, any}
+          {:ok, %{interactive_template: any, message: String.t()}} | {:error, any}
   def import_interactive_template(_, %{translation: data, id: id}, _) do
     with {:ok, interactive_template} <-
            InteractiveTemplates.fetch_interactive_template(id) do

--- a/lib/glific_web/schema/interactive_template_types.ex
+++ b/lib/glific_web/schema/interactive_template_types.ex
@@ -12,6 +12,7 @@ defmodule GlificWeb.Schema.InteractiveTemplateTypes do
 
   object :interactive_template_result do
     field :interactive_template, :interactive_template
+    field :message, :string
     field :errors, list_of(:input_error)
   end
 

--- a/test/glific/interactive_templates_test.exs
+++ b/test/glific/interactive_templates_test.exs
@@ -134,7 +134,7 @@ defmodule Glific.InteractiveTemplatesTest do
             "type" => "text"
           },
           "options" => [
-            %{"title" => "उत्कृष्ट", "type" => "text"},
+            %{"title" => "उत्कृष", "type" => "text"},
             %{"title" => "शानदार", "type" => "text"}
           ],
           "type" => "quick_reply"
@@ -169,15 +169,14 @@ defmodule Glific.InteractiveTemplatesTest do
       },
       translations: %{
         "1" => %{
-          "action" => %{"name" => "send_location"},
-          "body" => %{"text" => "please share your location", "type" => "text"},
+          "action" => %{"button" => nil},
+          "body" => %{"text" => "please share your location"},
           "type" => "location_request_message"
         },
         "2" => %{
-          "action" => %{"name" => "send_location"},
+          "action" => %{"button" => nil},
           "body" => %{
-            "text" => "कृपया अपना स्थान साझा करें",
-            "type" => "text"
+            "text" => "कृपया अपना स्थान साझा करें"
           },
           "type" => "location_request_message"
         }
@@ -272,12 +271,9 @@ defmodule Glific.InteractiveTemplatesTest do
           "type" => "list"
         },
         "2" => %{
-          "body" => "ग्लिफ़िक त्वरित उत्तर का परीक्षण करें?",
+          "body" => "ग्लिफ़िक त्वरित उत्तर ",
           "globalButtons" => [
-            %{
-              "title" => "शानदार विशेषताएं",
-              "type" => "text"
-            }
+            %{"title" => "शानदार ", "type" => "text"}
           ],
           "items" => [
             %{
@@ -288,8 +284,8 @@ defmodule Glific.InteractiveTemplatesTest do
                   "type" => "text"
                 }
               ],
-              "subtitle" => "उत्साह का स्तर",
-              "title" => "उत्साह का स्तर"
+              "subtitle" => "उत्साह क",
+              "title" => "उत्साह क"
             }
           ],
           "title" => "ग्लिफ़िक",
@@ -376,11 +372,12 @@ defmodule Glific.InteractiveTemplatesTest do
     } do
       interactive = Fixtures.interactive_fixture(%{organization_id: organization_id})
 
-      assert {:ok, %InteractiveTemplate{} = interactive} =
+      assert {:ok, %InteractiveTemplate{} = interactive, message} =
                InteractiveTemplates.update_interactive_template(interactive, @update_attrs)
 
       assert interactive.label == "Updated Quick Reply label"
       assert interactive.type == :quick_reply
+      assert message == "updated successfully"
     end
 
     test "update_interactive_template/2 with invalid data returns error changeset", %{
@@ -663,13 +660,16 @@ defmodule Glific.InteractiveTemplatesTest do
 
     result = InteractiveTemplates.translate_interactive_template(interactive)
 
-    assert {:ok, %InteractiveTemplate{translations: translations}} = result
+    assert {:ok, %InteractiveTemplate{translations: translations}, message} = result
 
     assert Map.has_key?(translations, "2")
     assert translations["2"]["content"]["text"] == "ग्लिफ़िक त्वरित उत्तर का परीक्षण करें?"
     assert translations["2"]["content"]["header"] == "त्वरित उत्तर स्थिरता"
-    assert Enum.any?(translations["2"]["options"], fn option -> option["title"] == "परीक्षण 1" end)
-    assert Enum.any?(translations["2"]["options"], fn option -> option["title"] == "परीक्षण 2" end)
+    assert Enum.any?(translations["2"]["options"], fn option -> option["title"] == "परीक्ष" end)
+    assert Enum.any?(translations["2"]["options"], fn option -> option["title"] == "परीक्ष" end)
+
+    assert message ==
+             "Trimming has been done for the following languages due to exceeding character limits: Hindi. Please verify the content before saving."
   end
 
   test "export the interactive template when add translation is true",
@@ -683,7 +683,7 @@ defmodule Glific.InteractiveTemplatesTest do
     Attribute,en,hi
     Header,Quick Reply Test Text 2,त्वरित उत्तर स्थिरता
     Text,How was your experience with Glific?,ग्लिफ़िक त्वरित उत्तर का परीक्षण करें?
-    OptionTitle 1,Great,उत्कृष्ट
+    OptionTitle 1,Great,उत्कृष
     OptionTitle 2,Awesome,शानदार
     """
 
@@ -698,7 +698,6 @@ defmodule Glific.InteractiveTemplatesTest do
 
     location_export_data = """
     Attribute,en,hi
-    Action,send_location,send_location
     Body,please share your location,कृपया अपना स्थान साझा करें
     """
 
@@ -806,7 +805,7 @@ defmodule Glific.InteractiveTemplatesTest do
         ["OptionDescription 1.1", "Awesome", "शानदार"]
       ]
 
-    {:ok, imported_temp} =
+    {:ok, imported_temp, _message} =
       InteractiveTemplates.import_interactive_template(translated_data, interactive)
 
     imported_translation = imported_temp.translations
@@ -828,7 +827,7 @@ defmodule Glific.InteractiveTemplatesTest do
       ["OptionTitle 2", "Awesome", "शानदार"]
     ]
 
-    {:ok, imported_temp} =
+    {:ok, imported_temp, _message} =
       InteractiveTemplates.import_interactive_template(translated_data, interactive)
 
     imported_translation = imported_temp.translations
@@ -847,8 +846,9 @@ defmodule Glific.InteractiveTemplatesTest do
       ["Body", "please share your location", "कृपया अपना स्थान साझा करें"]
     ]
 
-    {:ok, imported_temp} =
+    {:ok, imported_temp, _message} =
       InteractiveTemplates.import_interactive_template(translated_data, interactive)
+      |> IO.inspect()
 
     imported_translation = imported_temp.translations
 

--- a/test/glific/interactive_templates_test.exs
+++ b/test/glific/interactive_templates_test.exs
@@ -372,12 +372,11 @@ defmodule Glific.InteractiveTemplatesTest do
     } do
       interactive = Fixtures.interactive_fixture(%{organization_id: organization_id})
 
-      assert {:ok, %InteractiveTemplate{} = interactive, message} =
+      assert {:ok, %InteractiveTemplate{} = interactive, _message} =
                InteractiveTemplates.update_interactive_template(interactive, @update_attrs)
 
       assert interactive.label == "Updated Quick Reply label"
       assert interactive.type == :quick_reply
-      assert message == "updated successfully"
     end
 
     test "update_interactive_template/2 with invalid data returns error changeset", %{

--- a/test/glific/interactive_templates_test.exs
+++ b/test/glific/interactive_templates_test.exs
@@ -713,10 +713,10 @@ defmodule Glific.InteractiveTemplatesTest do
     list_export_data = """
     Attribute,en,hi
     Title,glific,ग्लिफ़िक
-    Body,How was your experience with Glific?,ग्लिफ़िक त्वरित उत्तर का परीक्षण करें?
-    GlobalButtonTitle,Glific Features,शानदार विशेषताएं
-    ItemTitle 1,Excitement level,उत्साह का स्तर
-    ItemSubtitle 1,Excitement level,उत्साह का स्तर
+    Body,How was your experience with Glific?,ग्लिफ़िक त्वरित उत्तर
+    GlobalButtonTitle,Glific Features,शानदार
+    ItemTitle 1,Excitement level,उत्साह क
+    ItemSubtitle 1,Excitement level,उत्साह क
     OptionTitle 1.1,Great,उत्कृष्ट
     OptionDescription 1.1,Awesome,शानदार
     """
@@ -724,7 +724,12 @@ defmodule Glific.InteractiveTemplatesTest do
     {:ok, %{export_data: export_data}} =
       InteractiveTemplates.export_interactive_template(interactive, add_translation)
 
-    assert String.trim(export_data) == String.trim(list_export_data)
+    export_data_trimmed =
+      String.split(export_data, "\n")
+      |> Enum.map(&String.trim_trailing(&1))
+      |> Enum.join("\n")
+
+    assert String.trim(export_data_trimmed) == String.trim(list_export_data)
 
     # type quick reply with footer
     interactive =
@@ -735,7 +740,7 @@ defmodule Glific.InteractiveTemplatesTest do
     Footer,caption is footer,कैप्शन पाद लेख है
     Header,Glific Features,शानदार विशेषताएं
     Text,How was your experience with Glific?,ग्लिफ़िक त्वरित उत्तर का परीक्षण करें?
-    OptionTitle 1,Great,उत्कृष्ट
+    OptionTitle 1,Great,उत्कृष
     OptionTitle 2,Awesome,शानदार
     """
 
@@ -848,7 +853,6 @@ defmodule Glific.InteractiveTemplatesTest do
 
     {:ok, imported_temp, _message} =
       InteractiveTemplates.import_interactive_template(translated_data, interactive)
-      |> IO.inspect()
 
     imported_translation = imported_temp.translations
 

--- a/test/glific/interactive_templates_test.exs
+++ b/test/glific/interactive_templates_test.exs
@@ -726,8 +726,7 @@ defmodule Glific.InteractiveTemplatesTest do
 
     export_data_trimmed =
       String.split(export_data, "\n")
-      |> Enum.map(&String.trim_trailing(&1))
-      |> Enum.join("\n")
+      |> Enum.map_join("\n", &String.trim_trailing/1)
 
     assert String.trim(export_data_trimmed) == String.trim(list_export_data)
 


### PR DESCRIPTION

## Summary
 Target issue is #3641 
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
When translating an interactive template, it often happens that the character limit is fulfilled in english but the character limit exceeds in its hindi or other language translations. We need to show a warning message when saving the interactive language if any of the translations exceed the character limit.



