### PR TITLE
Google sheets: fixed wrong csv export url

### DIFF
--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -165,11 +165,12 @@ defmodule Glific.Sheets do
 
   def sync_sheet_data(sheet) do
     Glific.Metrics.increment("Sheets Read")
-
-    [sheet_url, gid] = String.split(sheet.url, ["edit", "view", "comment"])
+    [sheet_url, _gid] = String.split(sheet.url, ["edit", "view", "comment"])
 
     last_synced_at = DateTime.utc_now()
-    export_url = sheet_url <> "export?format=csv&&" <> String.replace(gid, "#", "")
+    {:ok, uri} = URI.new(sheet.url)
+    # https://developers.google.com/sheets/api/guides/concepts#spreadsheet_id
+    export_url = sheet_url <> "export?format=csv&" <> uri.fragment
 
     SheetData
     |> where([sd], sd.sheet_id == ^sheet.id)

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1063,7 +1063,7 @@ defmodule Glific.Fixtures do
       %{
         method: :get,
         url:
-          "https://docs.google.com/spreadsheets/d/1fRpFyicqrUFxd79u_dGC8UOHEtAT3rA-G2i4tvOgScw/export?format=csv&&gid=0"
+          "https://docs.google.com/spreadsheets/d/1fRpFyicqrUFxd79u_dGC8UOHEtAT3rA-G2i4tvOgScw/export?format=csv&gid=0"
       } ->
         %Tesla.Env{
           body:


### PR DESCRIPTION
## Summary
 Target issue is #3665   


## Notes

### Old csv format url
https://docs.google.com/spreadsheets/d/17DKns-o7-NxkhYPMle-xNz9Z_iQ_9vCS2gvbNrYctu8/export?format=csv&&gid=0gid=0

### New working csv format url

https://docs.google.com/spreadsheets/d/17DKns-o7-NxkhYPMle-xNz9Z_iQ_9vCS2gvbNrYctu8/export?format=csv&gid=0
