### PR TITLE
Improve the error message that users see upon hsm template submission 

### DIFF
--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -182,11 +182,17 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
       org_id: org_id
     )
     |> case do
-      {:ok, response} ->
-        {:ok, response}
 
-      {:error, error} ->
-        {:error, error}
+      {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
+        {:ok, Jason.decode!(body)}
+        
+      {:ok, %Tesla.Env{status: status, body: %{"message" => message}}} when status in 400..499 ->
+        {:error, message}
+
+      unmatched_response ->
+        Logger.error(unmatched_response)
+        {:error, "unmatched_response"}
+
     end
   end
 

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -32,7 +32,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
         res["partnerApps"]
 
       {:error, error} ->
-        error = "#{inspect error}"
+        error = "#{inspect(error)}"
         if String.contains?(error, "Re-linking"), do: fetch_gupshup_app_id(org_id), else: error
     end
   end
@@ -56,7 +56,6 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
          }}
 
       error ->
-
         {:error, "Error while getting the ratings. #{inspect(error)}"}
     end
   end
@@ -183,20 +182,17 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     |> post_request(payload,
       org_id: org_id
     )
-
     |> case do
-
-      {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
-        {:ok, Jason.decode!(body)}
+      {:ok, response} ->
+        {:ok, response}
 
       {:error, %Tesla.Env{status: status, body: body}} when status in 400..499 ->
         decoded_body = Jason.decode!(body)
         {:error, decoded_body["message"]}
 
       unmatched_response ->
-        Logger.error("#{inspect unmatched_response}")
-        {:error, "Your template was not able to be submitted for approval."}
-
+        Logger.error("#{inspect(unmatched_response)}")
+        {:error, "Something went wrong, not able to submit the template for approval."}
     end
   end
 

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -73,6 +73,7 @@ defmodule Glific.Providers.Gupshup.Template do
       {:error, error} ->
         Logger.error(error)
         {:error, ["BSP", "couldn't submit for approval"]}
+        {:error, ["BSP", error]}
     end
   end
 

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -72,8 +72,7 @@ defmodule Glific.Providers.Gupshup.Template do
     else
       {:error, error} ->
         Logger.error(error)
-        {:error, ["BSP", "couldn't submit for approval"]}
-        {:error, ["BSP", error]}
+        {:error, ["BSP", "couldn't submit for approval: " <> error]}
     end
   end
 

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -72,7 +72,7 @@ defmodule Glific.Providers.Gupshup.Template do
     else
       {:error, error} ->
         Logger.error(error)
-        {:error, ["BSP", "couldn't submit for approval: " <> error]}
+        {:error, ["BSP", "Couldn't submit for approval: " <> error]}
     end
   end
 

--- a/test/glific/mail_logs_test.exs
+++ b/test/glific/mail_logs_test.exs
@@ -157,7 +157,6 @@ defmodule Glific.MailLogTest do
     # content should mimic the actual one
 
     attrs = Map.merge(@valid_critical_attrs, %{organization_id: organization_id})
-    # |> IO.inspect()
     assert {:ok, %MailLog{} = mail_log} = MailLog.create_mail_log(attrs)
     old_time = Glific.go_back_time(24)
 

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -1284,12 +1284,14 @@ defmodule Glific.PartnersTest do
         %{method: :post} ->
           %Tesla.Env{
             status: 400,
-            body: "{\"message\":\"Template Already exists with same namespace and elementName and languageCode\",\"status\":\"error\"}"
+            body:
+              "{\"message\":\"Template Already exists with same namespace and elementName and languageCode\",\"status\":\"error\"}"
           }
       end)
 
-      assert {:error, "Template Already exists with same namespace and elementName and languageCode"} =
-        PartnerAPI.apply_for_template(1, %{ elementName: "trial"}, false)
+      assert {:error,
+              "Template Already exists with same namespace and elementName and languageCode"} =
+               PartnerAPI.apply_for_template(1, %{elementName: "trial"}, false)
     end
   end
 
@@ -1303,9 +1305,8 @@ defmodule Glific.PartnersTest do
           }
       end)
 
-      assert {:ok, "{\"message\":\"Success\",\"status\":\"error\"}"} =
-        PartnerAPI.apply_for_template(1, %{ elementName: "trial"}, false)
+      assert {:ok, %{"message" => "Success", "status" => "error"}} =
+               PartnerAPI.apply_for_template(1, %{elementName: "trial"}, false)
     end
   end
-
 end

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -1277,4 +1277,35 @@ defmodule Glific.PartnersTest do
       assert {:error, :enoent} = PartnerAPI.delete_local_resource("sample2.png", "sample2")
     end
   end
+
+  describe "test gupshup error handling on applying for template/3" do
+    test "successfull gupshup error handling for HSM template" do
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 400,
+            body: "{\"message\":\"Template Already exists with same namespace and elementName and languageCode\",\"status\":\"error\"}"
+          }
+      end)
+
+      assert {:error, "Template Already exists with same namespace and elementName and languageCode"} =
+        PartnerAPI.apply_for_template(1, %{ elementName: "trial"}, false)
+    end
+  end
+
+  describe "test sucessful response on the api: applying for template/3" do
+    test "successfull response for applying for HSM template" do
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: "{\"message\":\"Success\",\"status\":\"error\"}"
+          }
+      end)
+
+      assert {:ok, "{\"message\":\"Success\",\"status\":\"error\"}"} =
+        PartnerAPI.apply_for_template(1, %{ elementName: "trial"}, false)
+    end
+  end
+
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -692,7 +692,7 @@ defmodule Glific.TemplatesTest do
         organization_id: attrs.organization_id
       }
 
-      assert {:error, ["BSP", "couldn't submit for approval"]} =
+      assert {:error, ["BSP", "Couldn't submit for approval: Something went wrong"]} =
                Templates.create_session_template(attrs)
     end
 


### PR DESCRIPTION
## Summary
 Target issue is #3637
Currently, users do not receive helpful error messages when submitting HSM templates. There is one static message shown for all errors thus the user is not able to adjust their input correctly. This pull request solves that problem by showing the user what the actual error is. 

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases. 
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
