### PR TITLE
Webhook: Preventing webhook node execution if there is message stream

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,6 +27,9 @@ config :glific, GlificWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
+config :logger,
+  level: :error
+
 # config :absinthe, Absinthe.Logger,
 #   pipeline: true,
 #   level: :debug

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,9 +27,6 @@ config :glific, GlificWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
-config :logger,
-  level: :error
-
 # config :absinthe, Absinthe.Logger,
 #   pipeline: true,
 #   level: :debug

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -763,7 +763,7 @@ defmodule Glific.Flows.Action do
 
     # Webhooks don't consume message, so if we send a message while a webhook node is running
     # this check will prevent webhook node from running again
-    if length(messages) == 0 do
+    if Enum.empty?(messages) do
       Webhook.execute(action, context)
     end
 

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -760,7 +760,13 @@ defmodule Glific.Flows.Action do
   def execute(%{type: "call_webhook"} = action, context, messages) do
     # just call the webhook, and ask the caller to wait
     # we are processing the webhook using Oban and this happens asynchronously
-    Webhook.execute(action, context)
+
+    # Webhooks don't consume message, so if we send a message while a webhook node is running
+    # this check will prevent webhook node from running again
+    if length(messages) == 0 do
+      Webhook.execute(action, context)
+    end
+
     # webhooks don't consume a message, so we send it forward
     {:wait, context, messages}
   end

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -12,13 +12,14 @@ defmodule Glific.Flows.Webhook do
   use Oban.Worker,
     queue: :webhook,
     max_attempts: 2,
-    priority: 0
-    # unique: [
-    #   period: 60,
-    #   fields: [:args, :worker],
-    #   keys: [:context_id, :url, :webhook_log_id],
-    #   states: [:available, :scheduled, :executing]
-    # ]
+    priority: 1
+
+  # unique: [
+  #   period: 60,
+  #   fields: [:args, :worker],
+  #   keys: [:context_id, :url, :webhook_log_id],
+  #   states: [:available, :scheduled, :executing]
+  # ]
 
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -14,13 +14,6 @@ defmodule Glific.Flows.Webhook do
     max_attempts: 2,
     priority: 1
 
-  # unique: [
-  #   period: 60,
-  #   fields: [:args, :worker],
-  #   keys: [:context_id, :url, :webhook_log_id],
-  #   states: [:available, :scheduled, :executing]
-  # ]
-
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do
     now = System.system_time(:second)

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -211,7 +211,6 @@ defmodule Glific.Flows.Webhook do
       context: %{id: context.id, delay: context.delay},
       organization_id: context.organization_id
     })
-    # |> IO.inspect()
     |> Oban.insert()
     |> case do
       {:ok, %Job{conflict?: true} = response} ->

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -12,13 +12,13 @@ defmodule Glific.Flows.Webhook do
   use Oban.Worker,
     queue: :webhook,
     max_attempts: 2,
-    priority: 1,
-    unique: [
-      period: 60,
-      fields: [:args, :worker],
-      keys: [:context_id, :url],
-      states: [:available, :scheduled, :executing]
-    ]
+    priority: 0
+    # unique: [
+    #   period: 60,
+    #   fields: [:args, :worker],
+    #   keys: [:context_id, :url, :webhook_log_id],
+    #   states: [:available, :scheduled, :executing]
+    # ]
 
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do
@@ -216,6 +216,7 @@ defmodule Glific.Flows.Webhook do
       context: %{id: context.id, delay: context.delay},
       organization_id: context.organization_id
     })
+    # |> IO.inspect()
     |> Oban.insert()
     |> case do
       {:ok, %Job{conflict?: true} = response} ->

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -212,7 +212,7 @@ defmodule Glific.Flows.Webhook do
       body: body,
       headers: headers,
       webhook_log_id: webhook_log.id,
-      # for jon uniqueness,
+      # for job uniqueness,
       context_id: context.id,
       context: %{id: context.id, delay: context.delay},
       organization_id: context.organization_id,


### PR DESCRIPTION
## Summary
 Target issue is #3742  
 Due to the issue mentioned [here](https://github.com/glific/glific/pull/2690), the solution was to prevent webhooks with same context_id and url to run at same time. But due to this restriction same webhook nodes in a flow will not run
 
But the solution proposed in this PR is that to not run the webhook node if there is message in message_stream

