### PR TITLE
Geolocation: Changes in the results variable

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -268,8 +268,7 @@ defmodule Glific.Clients.CommonWebhook do
             state = find_component(components, "administrative_area_level_1")
             country = find_component(components, "country")
             postal_code = find_component(components, "postal_code")
-            district = find_component(components, "administrative_area_level_2")
-            ward = find_component(components, "administrative_area_level_3")
+            district = find_component(components, "administrative_area_level_3")
 
             %{
               success: true,
@@ -278,7 +277,6 @@ defmodule Glific.Clients.CommonWebhook do
               country: country,
               postal_code: postal_code,
               district: district,
-              ward: ward,
               address: formatted_address
             }
 

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -49,7 +49,6 @@ defmodule Glific.Flows.CommonWebhookTest do
     assert result[:country] == "USA"
     assert result[:postal_code] == "N/A"
     assert result[:district] == "N/A"
-    assert result[:ward] == "N/A"
     assert result[:address] == "San Francisco, CA, USA"
   end
 


### PR DESCRIPTION

## Summary
 Target issue is #3813 
- Removed ward from results variable
- Using `administrative_area_level_3` for district variable
