### PR TITLE
Added translations for interactive templates

### DIFF
--- a/lib/glific_web/flows/flow_editor_controller.ex
+++ b/lib/glific_web/flows/flow_editor_controller.ex
@@ -240,7 +240,8 @@ defmodule GlificWeb.Flows.FlowEditorController do
             type: interactive.type,
             interactive_content: interactive.interactive_content,
             created_on: interactive.inserted_at,
-            modified_on: interactive.updated_at
+            modified_on: interactive.updated_at,
+            translations: get_interactive_translations(interactive.translations)
           }
           | acc
         ]


### PR DESCRIPTION
Target issue is https://github.com/glific/glific-frontend/issues/3113

Added translations for the templates in the `/interactive-templates` api 