### PR TITLE
Removed translations from list interactive templates api

### DIFF
--- a/lib/glific_web/flows/flow_editor_controller.ex
+++ b/lib/glific_web/flows/flow_editor_controller.ex
@@ -240,8 +240,7 @@ defmodule GlificWeb.Flows.FlowEditorController do
             type: interactive.type,
             interactive_content: interactive.interactive_content,
             created_on: interactive.inserted_at,
-            modified_on: interactive.updated_at,
-            translations: get_interactive_translations(interactive.translations)
+            modified_on: interactive.updated_at
           }
           | acc
         ]


### PR DESCRIPTION
Removed translations from the list api because it was taking a lot of time to load.