### PR TITLE
BQ: Removing recent messages from Flow Counts

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_schema.ex
+++ b/lib/glific/third_party/bigquery/bigquery_schema.ex
@@ -1702,12 +1702,6 @@ defmodule Glific.BigQuery.Schema do
         mode: "NULLABLE"
       },
       %{
-        description: "JSON object for storing the recent messages",
-        name: "recent_messages",
-        type: "STRING",
-        mode: "NULLABLE"
-      },
-      %{
         description: "Time when the flow results entry was first created for a user",
         name: "inserted_at",
         type: "DATETIME",

--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -1027,7 +1027,6 @@ defmodule Glific.BigQuery.BigQueryWorker do
             flow_uuid: row.flow.uuid,
             type: row.type,
             count: row.count,
-            recent_messages: BigQuery.format_json(row.recent_messages),
             inserted_at: format_date_with_millisecond(row.inserted_at, organization_id),
             updated_at: format_date_with_millisecond(row.updated_at, organization_id)
           }


### PR DESCRIPTION
## Summary
 Target issue is #3989  

## Notes
 Stopping syncing `recent_messages` to `flow_counts` table and updating schema as well