### PR TITLE
WA Messages: Checking maytapi provider is active instead of Gupshup

### DIFF
--- a/lib/glific/providers/maytapi/wa_worker.ex
+++ b/lib/glific/providers/maytapi/wa_worker.ex
@@ -20,7 +20,7 @@ defmodule Glific.Providers.Maytapi.WAWorker do
   }
 
   require Logger
-
+  @default_bsp_limit 30
   @doc """
   Standard perform method to use Oban worker
   """
@@ -29,7 +29,7 @@ defmodule Glific.Providers.Maytapi.WAWorker do
   def perform(%Oban.Job{args: %{"message" => message}} = job) do
     organization = Partners.organization(message["organization_id"])
 
-    if is_nil(organization.services["bsp"]) do
+    if is_nil(organization.services["maytapi"]) do
       Worker.handle_credential_error(message)
     else
       perform(job, organization)
@@ -48,7 +48,7 @@ defmodule Glific.Providers.Maytapi.WAWorker do
            organization.shortcode,
            # the bsp limit is per organization per shortcode
            1000,
-           organization.services["bsp"].keys["bsp_limit"]
+           @default_bsp_limit
          ) do
       {:ok, _} ->
         process_maytapi(organization.id, payload, message)

--- a/lib/glific/providers/maytapi/wa_worker.ex
+++ b/lib/glific/providers/maytapi/wa_worker.ex
@@ -29,6 +29,7 @@ defmodule Glific.Providers.Maytapi.WAWorker do
   def perform(%Oban.Job{args: %{"message" => message}} = job) do
     organization = Partners.organization(message["organization_id"])
 
+    # organization.services["bsp"] was relying on Gupshup being active or not
     if is_nil(organization.services["maytapi"]) do
       Worker.handle_credential_error(message)
     else

--- a/test/glific/groups/whatsapp_message_test.exs
+++ b/test/glific/groups/whatsapp_message_test.exs
@@ -318,7 +318,6 @@ defmodule Glific.Groups.WhatsappMessageTest do
     assert error_message == "Cannot send message: No WhatsApp group found in the collection"
   end
 
-  @tag :gup
   test "create_and_send_wa_message/3 send media message successfully, even when gupshup is inactive",
        attrs do
     # clearing the org cache that's setup at the beginning of test

--- a/test/glific/groups/whatsapp_message_test.exs
+++ b/test/glific/groups/whatsapp_message_test.exs
@@ -1,6 +1,4 @@
 defmodule Glific.Groups.WhatsappMessageTest do
-  alias Glific.Providers.Maytapi.WAWorker
-  alias Glific.Partners.Credential
   use Glific.DataCase, async: false
   use ExUnit.Case
   use Oban.Pro.Testing, repo: Glific.Repo
@@ -9,7 +7,9 @@ defmodule Glific.Groups.WhatsappMessageTest do
     Fixtures,
     Groups.WaGroupsCollections,
     Partners,
+    Partners.Credential,
     Providers.Maytapi.Message,
+    Providers.Maytapi.WAWorker,
     Seeds.SeedsDev,
     Seeds.SeedsDev
   }


### PR DESCRIPTION
## Summary
 Related issue is https://github.com/glific/glific/issues/4059
 
Related error

```elixir
** (ErlangError) Erlang error: "%MatchError{term: {:error, #Ecto.Changeset<action: :update, changes: %{status: :sent, errors: %{message: \"{\\\"message\\\": \\\"BSP credentials does not exist\\\"}\"}, flow: :outbound, bsp_status: :error}, errors: [sender_id: {\"can't be blank\", [validation: :required]}, receiver_id: {\"can't be blank\", [validation: :required]}], data: #Glific.Messages.Message<>, valid?: false, ...>}}"
```

https://appsignal.com/project-tech4dev/sites/602fcb580264444badac30d8/exceptions/incidents/82/samples/timestamp/2025-03-19T06:25:00Z

