### PR TITLE
Bigquery: Handling date-only format in the formatter

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -396,8 +396,7 @@ defmodule Glific.BigQuery do
   def format_date(date, organization_id) when is_binary(date) do
     timezone = Partners.organization(organization_id).timezone
 
-    Timex.parse(date, "{RFC3339z}")
-    |> elem(1)
+    parse_datetime(date)
     |> Timex.Timezone.convert(timezone)
     |> Timex.format!("{YYYY}-{0M}-{0D} {h24}:{m}:{s}")
   end
@@ -859,5 +858,18 @@ defmodule Glific.BigQuery do
     if is_nil(data),
       do: {:error, "Registration details for org_id: #{organization_id} not found"},
       else: {:ok, data}
+  end
+
+  # Handling datetime and date formats
+  @spec parse_datetime(String.t()) :: DateTime.t() | NaiveDateTime.t() | nil
+  defp parse_datetime(date) do
+    with {:error, _} <- Timex.parse(date, "{RFC3339z}"),
+         {:error, _} <- Timex.parse(date, "{YYYY}-{0M}-{D}") do
+      nil
+    else
+      {:ok, %DateTime{} = datetime} -> datetime
+      {:ok, %NaiveDateTime{} = datetime} -> datetime
+      _ -> nil
+    end
   end
 end

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -396,7 +396,10 @@ defmodule Glific.BigQuery do
   def format_date(date, organization_id) when is_binary(date) do
     timezone = Partners.organization(organization_id).timezone
 
-    # Handling datetime and date formats
+    # We try to parse a string into date or datetime, since there
+    # were cases where we have seen both formats, which is weird.
+    # This will handle that until we can find the RCA.
+
     with {:error, _} <- Timex.parse(date, "{RFC3339z}"),
          {:error, _} <- Timex.parse(date, "{YYYY}-{0M}-{D}") do
       nil

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -403,7 +403,6 @@ defmodule Glific.BigQuery do
     else
       {:ok, %DateTime{} = datetime} -> format_datetime(datetime, timezone)
       {:ok, %NaiveDateTime{} = datetime} -> format_datetime(datetime, timezone)
-      _ -> nil
     end
   end
 

--- a/lib/glific_web/providers/maytapi/controller/message_event_controller.ex
+++ b/lib/glific_web/providers/maytapi/controller/message_event_controller.ex
@@ -49,6 +49,9 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageEventController do
 
         %{"ackType" => ack_type} ->
           do_update_status(response, ack_type, org_id)
+
+        _ ->
+          nil
       end
     end)
   end

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -346,6 +346,10 @@ defmodule Glific.BigQueryTest do
 
     assert @formatted_time ==
              BigQuery.format_date(DateTime.to_string(datetime), attrs.organization_id)
+
+    # There are cases where we get date as a iso date only type, so handling that too
+    assert "#{String.split(@formatted_time, " ") |> List.first()} 00:00:00" ==
+             BigQuery.format_date(DateTime.to_date(datetime) |> to_string, attrs.organization_id)
   end
 
   test "queue_table_data/3 should process and queue data correctly", %{organization_id: org_id} do

--- a/test/glific_web/schema/wa_reaction_test.exs
+++ b/test/glific_web/schema/wa_reaction_test.exs
@@ -116,4 +116,24 @@ defmodule GlificWeb.Schema.WaReactionTest do
 
     assert is_nil(MessageEventController.update_statuses(payload, user.organization_id))
   end
+
+  @tag :payload_2
+  test "handling ignored payload-2", user do
+    payload =
+      %{
+        "data" => [
+          %{
+            "chatId" => "120363257477740000@g.us",
+            "msgId" =>
+              "false_120363257477740000@g.us_DA8E37F4819D2982F3FAD894DBB287F3_919783328334@c.us",
+            "rxid" =>
+              "false_120363257477740000@g.us_DA8E37F4819D2982F3FAD894DBB287F3_919783328334@c.us",
+            "time" => 1_739_257_237
+          }
+        ],
+        "type" => "ack"
+      }
+
+    assert :ok = MessageEventController.update_statuses(payload, user.organization_id)
+  end
 end

--- a/test/glific_web/schema/wa_reaction_test.exs
+++ b/test/glific_web/schema/wa_reaction_test.exs
@@ -117,7 +117,6 @@ defmodule GlificWeb.Schema.WaReactionTest do
     assert is_nil(MessageEventController.update_statuses(payload, user.organization_id))
   end
 
-  @tag :payload_2
   test "handling ignored payload-2", user do
     payload =
       %{


### PR DESCRIPTION
## Summary
 Target issue is #3997  
 
- Parsing `Date.t()` also now so that org which has contact_field inserted date in `Date` format rather than `DateTime.t` can also sync their contacts to BQ

