### PR TITLE
WA Groups: Handling translation for case handlers in split_by_expression node

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,6 +27,9 @@ config :glific, GlificWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
+config :logger,
+  level: :error
+
 # config :absinthe, Absinthe.Logger,
 #   pipeline: true,
 #   level: :debug

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -27,9 +27,6 @@ config :glific, GlificWeb.Endpoint,
     tailwind: {Tailwind, :install_and_run, [:default, ~w(--watch)]}
   ]
 
-config :logger,
-  level: :error
-
 # config :absinthe, Absinthe.Logger,
 #   pipeline: true,
 #   level: :debug

--- a/lib/glific/flows/localization.ex
+++ b/lib/glific/flows/localization.ex
@@ -160,6 +160,14 @@ defmodule Glific.Flows.Localization do
   Given a language id and an case uuid, return the translation if
   one exists, else return the original text
   """
+
+  @spec get_translated_case_arguments(FlowContext.t(), Case.t()) :: any()
+  def get_translated_case_arguments(%{wa_group_id: wa_group_id} = _context, flow_case)
+      when wa_group_id != nil do
+    # Right now WA group doesnt have a concept of language like in Contact
+    flow_case.arguments
+  end
+
   @spec get_translated_case_arguments(FlowContext.t(), Case.t()) :: any()
   def get_translated_case_arguments(context, flow_case) do
     language_id = context.contact.language_id

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -1486,7 +1486,7 @@ defmodule Glific.Flows.ActionTest do
     assert_raise(UndefinedFunctionError, fn -> Action.execute(action, context, message_stream) end)
   end
 
-  test "execute an wa group unsupported action",
+  test "execute a wa group unsupported action",
        _attrs do
     [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
 

--- a/test/glific/flows/flow_context_test.exs
+++ b/test/glific/flows/flow_context_test.exs
@@ -43,22 +43,6 @@ defmodule Glific.Flows.FlowContextTest do
     |> Repo.preload(:flow)
   end
 
-  def wa_flow_context_fixture(attrs \\ %{}) do
-    wa_phone = Fixtures.wa_managed_phone_fixture(attrs)
-    wa_group = Fixtures.wa_group_fixture(Map.put(attrs, :wa_managed_phone_id, wa_phone.id))
-
-    {:ok, flow_context} =
-      attrs
-      |> Map.put(:wa_group_id, wa_group.id)
-      |> Map.put(:organization_id, wa_group.organization_id)
-      |> Enum.into(@valid_attrs)
-      |> FlowContext.create_flow_context()
-
-    flow_context
-    |> Repo.preload(:wa_group)
-    |> Repo.preload(:flow)
-  end
-
   test "create_flow_context/1 will create a new flow context", attrs do
     # create a simple flow context
     {:ok, context} =
@@ -186,7 +170,7 @@ defmodule Glific.Flows.FlowContextTest do
     [node | _tail] = flow.nodes
 
     flow_context =
-      wa_flow_context_fixture(%{node_uuid: node.uuid, organization_id: organization_id})
+      Fixtures.wa_flow_context_fixture(%{node_uuid: node.uuid, organization_id: organization_id})
 
     flow_context = FlowContext.load_context(flow_context, flow)
     assert flow_context.uuid_map == flow.uuid_map
@@ -208,7 +192,7 @@ defmodule Glific.Flows.FlowContextTest do
     [node | _tail] = flow.nodes
 
     flow_context =
-      wa_flow_context_fixture(%{node_uuid: node.uuid, organization_id: organization_id})
+      Fixtures.wa_flow_context_fixture(%{node_uuid: node.uuid, organization_id: organization_id})
 
     flow_context = FlowContext.load_context(flow_context, flow)
     message = Messages.create_temp_message(Fixtures.get_org_id(), "help")
@@ -290,7 +274,7 @@ defmodule Glific.Flows.FlowContextTest do
     wakeup_at = Timex.shift(Timex.now(), minutes: -3)
 
     flow_context =
-      wa_flow_context_fixture(%{
+      Fixtures.wa_flow_context_fixture(%{
         node_uuid: node.uuid,
         wakeup_at: wakeup_at,
         is_background_flow: true,

--- a/test/glific/flows/router_test.exs
+++ b/test/glific/flows/router_test.exs
@@ -1,5 +1,4 @@
 defmodule Glific.Flows.RouterTest do
-  alias Glific.Flows.FlowContextTest
   use Glific.DataCase, async: true
 
   alias Glific.{
@@ -361,7 +360,7 @@ defmodule Glific.Flows.RouterTest do
       |> Router.process(uuid_map, node)
 
     context =
-      FlowContextTest.wa_flow_context_fixture(%{
+      Fixtures.wa_flow_context_fixture(%{
         uuid_map: uuid_map,
         organization_id: attrs.organization_id,
         phone: Phone.EnUs.phone()
@@ -387,7 +386,7 @@ defmodule Glific.Flows.RouterTest do
       |> Router.process(uuid_map, node)
 
     context =
-      FlowContextTest.flow_context_fixture(%{
+      flow_context_fixture(%{
         uuid_map: uuid_map,
         organization_id: attrs.organization_id,
         phone: Phone.EnUs.phone()

--- a/test/glific/flows/router_test.exs
+++ b/test/glific/flows/router_test.exs
@@ -1,4 +1,5 @@
 defmodule Glific.Flows.RouterTest do
+  alias Glific.Flows.FlowContextTest
   use Glific.DataCase, async: true
 
   alias Glific.{
@@ -6,6 +7,8 @@ defmodule Glific.Flows.RouterTest do
     Groups,
     Messages
   }
+
+  alias Faker.Phone
 
   alias Glific.Flows.{
     Flow,
@@ -33,6 +36,22 @@ defmodule Glific.Flows.RouterTest do
 
     flow_context
     |> Repo.preload(:contact)
+    |> Repo.preload(:flow)
+  end
+
+  def wa_flow_context_fixture(attrs \\ %{}) do
+    wa_phone = Fixtures.wa_managed_phone_fixture(attrs)
+    wa_group = Fixtures.wa_group_fixture(Map.put(attrs, :wa_managed_phone_id, wa_phone.id))
+
+    {:ok, flow_context} =
+      attrs
+      |> Map.put(:wa_group_id, wa_group.id)
+      |> Map.put(:organization_id, wa_phone.organization_id)
+      |> Enum.into(@valid_attrs)
+      |> FlowContext.create_flow_context()
+
+    flow_context
+    |> Repo.preload(:wa_group)
     |> Repo.preload(:flow)
   end
 
@@ -299,6 +318,98 @@ defmodule Glific.Flows.RouterTest do
 
     context = flow_context_fixture(%{uuid_map: uuid_map})
     {:ok, _, _} = Router.execute(router, context, [])
+  end
+
+  test "router with split by expression with EEx code for wa_group flow", attrs do
+    flow = %Flow{uuid: "Flow UUID 1", id: 1}
+    exit_uuid = Ecto.UUID.generate()
+    uuid_map = %{}
+
+    json = %{
+      "uuid" => "Node UUID",
+      "actions" => [],
+      "exits" => [
+        %{"uuid" => exit_uuid, "destination_uuid" => nil}
+      ]
+    }
+
+    {node, uuid_map} = Node.process(json, uuid_map, flow)
+
+    json = %{
+      "type" => "switch",
+      "default_category_uuid" => "Default Cat UUID",
+      "result_name" => "Language",
+      "categories" => [
+        %{
+          "uuid" => "Default Cat UUID",
+          "exit_uuid" => exit_uuid,
+          "name" => "Default Category"
+        }
+      ],
+      "cases" => [
+        %{
+          "id" => nil,
+          "uuid" => "e254c8f0-69e7-4911-9b65-577a54b9de7e",
+          "name" => nil,
+          "type" => "has_only_phrase",
+          "arguments" => ["true"],
+          "parsed_arguments" => nil,
+          "category_uuid" => "Default Cat UUID",
+          "category" => nil
+        },
+        %{
+          "id" => nil,
+          "uuid" => "e254c8f0-69e7-4911-9b65-577a54b9de7e",
+          "name" => nil,
+          "type" => "has_number_eq",
+          "arguments" => ["true"],
+          "parsed_arguments" => nil,
+          "category_uuid" => "Default Cat UUID",
+          "category" => nil
+        }
+      ]
+    }
+
+    # correct EEx expression
+    {router, uuid_map} =
+      json
+      |> Map.merge(%{"operand" => "<%= rem(5, 2) %>"})
+      |> Router.process(uuid_map, node)
+
+    context =
+      FlowContextTest.wa_flow_context_fixture(%{
+        uuid_map: uuid_map,
+        organization_id: attrs.organization_id,
+        phone: Phone.EnUs.phone()
+      })
+
+    assert {:ok, _, _} = Router.execute(router, context, [])
+
+    {router, uuid_map} =
+      json
+      |> Map.put("cases", [
+        %{
+          "id" => nil,
+          "uuid" => "e254c8f0-69e7-4911-9b65-577a54b9de7e",
+          "name" => nil,
+          "type" => "has_number_eq",
+          "arguments" => ["true"],
+          "parsed_arguments" => nil,
+          "category_uuid" => "Default Cat UUID",
+          "category" => nil
+        }
+      ])
+      |> Map.merge(%{"operand" => "<%= rem(5, 2) %>"})
+      |> Router.process(uuid_map, node)
+
+    context =
+      FlowContextTest.flow_context_fixture(%{
+        uuid_map: uuid_map,
+        organization_id: attrs.organization_id,
+        phone: Phone.EnUs.phone()
+      })
+
+    assert {:ok, _, _} = Router.execute(router, context, [])
   end
 
   test "router with split by groups" do

--- a/test/glific/flows/router_test.exs
+++ b/test/glific/flows/router_test.exs
@@ -39,22 +39,6 @@ defmodule Glific.Flows.RouterTest do
     |> Repo.preload(:flow)
   end
 
-  def wa_flow_context_fixture(attrs \\ %{}) do
-    wa_phone = Fixtures.wa_managed_phone_fixture(attrs)
-    wa_group = Fixtures.wa_group_fixture(Map.put(attrs, :wa_managed_phone_id, wa_phone.id))
-
-    {:ok, flow_context} =
-      attrs
-      |> Map.put(:wa_group_id, wa_group.id)
-      |> Map.put(:organization_id, wa_phone.organization_id)
-      |> Enum.into(@valid_attrs)
-      |> FlowContext.create_flow_context()
-
-    flow_context
-    |> Repo.preload(:wa_group)
-    |> Repo.preload(:flow)
-  end
-
   test "process extracts the right values from json" do
     json = %{
       "operand" => "@input.text",

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -1334,6 +1334,7 @@ defmodule Glific.Fixtures do
   end
 
   @doc false
+  @spec wa_flow_context_fixture(map()) :: FlowContext.t()
   def wa_flow_context_fixture(attrs \\ %{}) do
     wa_phone = wa_managed_phone_fixture(attrs)
     wa_group = wa_group_fixture(Map.put(attrs, :wa_managed_phone_id, wa_phone.id))

--- a/test/support/fixtures.ex
+++ b/test/support/fixtures.ex
@@ -68,6 +68,12 @@ defmodule Glific.Fixtures do
     WaPoll
   }
 
+  @valid_attrs %{
+    flow_id: 1,
+    flow_uuid: Ecto.UUID.generate(),
+    uuid_map: %{},
+    node_uuid: Ecto.UUID.generate()
+  }
   @doc """
   temp function for test to get org id. use sparingly
   """
@@ -1325,5 +1331,22 @@ defmodule Glific.Fixtures do
     |> Map.merge(attrs)
     |> WaPoll.create_wa_poll()
     |> then(fn {:ok, wa_poll} -> wa_poll end)
+  end
+
+  @doc false
+  def wa_flow_context_fixture(attrs \\ %{}) do
+    wa_phone = wa_managed_phone_fixture(attrs)
+    wa_group = wa_group_fixture(Map.put(attrs, :wa_managed_phone_id, wa_phone.id))
+
+    {:ok, flow_context} =
+      attrs
+      |> Map.put(:wa_group_id, wa_group.id)
+      |> Map.put(:organization_id, wa_group.organization_id)
+      |> Enum.into(@valid_attrs)
+      |> FlowContext.create_flow_context()
+
+    flow_context
+    |> Repo.preload(:wa_group)
+    |> Repo.preload(:flow)
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #4078  

Although wa group flows already support split_by_expression node, it was crashing when case handlers inside a split_by_expression node try to access the translations, assuming the flowContext is only for contact and not for wa_group


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test scenario to validate dynamic routing in group-based flows.
  - Updated test fixtures and descriptions for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->