### PR TITLE
Template: Update the get template api end point

### DIFF
--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -67,8 +67,6 @@ defmodule Glific.Providers.Gupshup.ApiClient do
   """
   @spec optin_contact(non_neg_integer(), map()) :: Tesla.Env.result() | {:error, String.t()}
   def optin_contact(org_id, payload) do
-    get_credentials(org_id)
-
     with {:ok, credentials} <- get_credentials(org_id) do
       url = @gupshup_api_url <> "/app/opt/in/" <> credentials.app_name
       gupshup_post(url, payload, credentials.api_key)

--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -39,7 +39,7 @@ defmodule Glific.Providers.Gupshup.ApiClient do
       bsp_credentials = organization.services["bsp"]
 
       with false <- is_nil(bsp_credentials.secrets["api_key"]),
-           false <- is_nil(bsp_credentials.secrets["api_key"]) do
+           false <- is_nil(bsp_credentials.secrets["app_name"]) do
         api_key = bsp_credentials.secrets["api_key"]
         app_name = bsp_credentials.secrets["app_name"]
         {:ok, %{api_key: api_key, app_name: app_name}}

--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -8,7 +8,6 @@ defmodule Glific.Providers.Gupshup.ApiClient do
 
   @gupshup_msg_url "https://api.gupshup.io/wa/api/v1"
   @gupshup_api_url "https://api.gupshup.io/sm/api/v1"
-  @gupshup_temp_url "https://api.gupshup.io/wa/app/"
 
   use Tesla
   # you can add , log_level: :debug to the below if you want debugging info
@@ -43,24 +42,12 @@ defmodule Glific.Providers.Gupshup.ApiClient do
            false <- is_nil(bsp_credentials.secrets["api_key"]) do
         api_key = bsp_credentials.secrets["api_key"]
         app_name = bsp_credentials.secrets["app_name"]
-        app_id = bsp_credentials.secrets["app_id"]
-        {:ok, %{api_key: api_key, app_name: app_name, app_id: app_id}}
+        {:ok, %{api_key: api_key, app_name: app_name}}
       else
         _ ->
           {:error,
            "Please check your credential settings and ensure you have added the API Key and App Name also"}
       end
-    end
-  end
-
-  @doc """
-  Fetching HSM templates for an organization
-  """
-  @spec get_templates(non_neg_integer()) :: Tesla.Env.result() | {:error, String.t()}
-  def get_templates(org_id) do
-    with {:ok, credentials} <- get_credentials(org_id) do
-      template_url = @gupshup_temp_url <> credentials.app_id <> "/template"
-      gupshup_get(template_url, credentials.api_key)
     end
   end
 

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -324,9 +324,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   """
   @spec get_templates(non_neg_integer()) :: {:ok, any()} | {:error, String.t()}
   def get_templates(org_id) do
-    with {:ok, %{partner_app_token: token}} <- get_partner_app_token(org_id),
-         url <- app_url(org_id) <> "/templates",
-         headers = [{"Authorization", token}] do
+    with {:ok, %{partner_app_token: token}} <- get_partner_app_token(org_id) do
+      url = app_url(org_id) <> "/templates"
+      headers = [{"Authorization", token}]
       get(url, headers: headers)
     end
   end

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -20,6 +20,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   )
 
   @partner_url "https://partner.gupshup.io/partner/account"
+  @app_url "https://partner.gupshup.io/partner/app/"
 
   @doc """
     Fetch App details based on API key and App name
@@ -318,6 +319,18 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     end
   end
 
+  @doc """
+  Fetch HSM templates using partner token (Gupshup partner API)
+  """
+  @spec get_templates(non_neg_integer()) :: {:ok, any()} | {:error, String.t()}
+  def get_templates(org_id) do
+    with {:ok, %{partner_app_token: token}} <- get_partner_app_token(org_id),
+         url <- app_url(org_id) <> "/templates",
+         headers = [{"Authorization", token}] do
+      get(url, headers: headers)
+    end
+  end
+
   @global_organization_id 0
   @spec get_partner_token :: {:ok, map()} | {:error, any}
   defp get_partner_token do
@@ -492,8 +505,6 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     {:ok, app_id} = app_id(org_id)
     app_id
   end
-
-  @app_url "https://partner.gupshup.io/partner/app/"
 
   @spec app_url(non_neg_integer()) :: String.t()
   defp app_url(org_id),

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -30,7 +30,6 @@ defmodule Glific.Providers.Gupshup.Template do
     Messages.MessageMedia,
     Partners,
     Partners.Organization,
-    Providers.Gupshup.ApiClient,
     Providers.Gupshup.PartnerAPI,
     Repo,
     Settings.Language,
@@ -390,7 +389,7 @@ defmodule Glific.Providers.Gupshup.Template do
     organization = Partners.organization(org_id)
 
     with {:ok, response} <-
-           ApiClient.get_templates(org_id),
+           PartnerAPI.get_templates(org_id),
          {:ok, response_data} <- Jason.decode(response.body),
          false <- is_nil(response_data["templates"]) do
       response_data["templates"]

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -183,7 +183,7 @@ msgstr ""
 
 #: lib/glific/partners.ex:423
 #: lib/glific/partners.ex:440
-#: lib/glific/providers/gupshup/api_client.ex:38
+#: lib/glific/providers/gupshup/api_client.ex:37
 #: lib/glific/providers/gupshup_enterprise/api_client.ex:36
 #, elixir-format, elixir-autogen
 msgid "No active BSP available"


### PR DESCRIPTION

## Summary
 Target issue is #4101


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new function for retrieving messaging templates using partner tokens.
- **Bug Fixes**
  - Simplified the credentials response by removing an obsolete field.
  - Removed the legacy template retrieval mechanism.
- **Tests**
  - Enhanced test scenarios to simulate a broader range of API interactions, reflecting the updated API structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->