### PR TITLE
Custom certificate: Added retry on rate-limit error

### DIFF
--- a/lib/glific/certificates/certificate_template.ex
+++ b/lib/glific/certificates/certificate_template.ex
@@ -137,7 +137,8 @@ defmodule Glific.Certificates.CertificateTemplate do
   end
 
   @spec validate_url(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
-  defp validate_url(%{changes: changes} = changeset, attrs) when not is_nil(changes.url) do
+  defp validate_url(%{changes: changes} = changeset, attrs)
+       when not is_nil(changes.url) and length(changeset.errors) == 0 do
     url = changeset.changes[:url]
     type = attrs.type
 

--- a/lib/glific/certificates/certificate_template.ex
+++ b/lib/glific/certificates/certificate_template.ex
@@ -138,7 +138,7 @@ defmodule Glific.Certificates.CertificateTemplate do
 
   @spec validate_url(Ecto.Changeset.t(), map()) :: Ecto.Changeset.t()
   defp validate_url(%{changes: changes} = changeset, attrs)
-       when not is_nil(changes.url) and length(changeset.errors) == 0 do
+       when not is_nil(changes.url) and changeset.errors == [] do
     url = changeset.changes[:url]
     type = attrs.type
 

--- a/lib/glific/third_party/google_slide/slide.ex
+++ b/lib/glific/third_party/google_slide/slide.ex
@@ -23,7 +23,7 @@ defmodule Glific.ThirdParty.GoogleSlide.Slide do
   @drive_url "https://www.googleapis.com/drive/v3/files"
   @slide_url "https://slides.googleapis.com/v1/presentations"
 
-  @rety_error_codes [429, 501, 502, 503, 504]
+  @retry_error_codes [429, 501, 502, 503, 504]
 
   @spec auth_headers(String.t()) :: list()
   defp auth_headers(token) do
@@ -196,7 +196,7 @@ defmodule Glific.ThirdParty.GoogleSlide.Slide do
         delay: 500,
         max_retries: 5,
         should_retry: fn
-          {:ok, %{status: status}}, _, _ when status in @rety_error_codes ->
+          {:ok, %{status: status}}, _, _ when status in @retry_error_codes ->
             true
 
           {:error, reason}, _, _ when reason in [:timeout, :connrefused, :nxdomain] ->

--- a/lib/glific/third_party/google_slide/slide.ex
+++ b/lib/glific/third_party/google_slide/slide.ex
@@ -23,6 +23,8 @@ defmodule Glific.ThirdParty.GoogleSlide.Slide do
   @drive_url "https://www.googleapis.com/drive/v3/files"
   @slide_url "https://slides.googleapis.com/v1/presentations"
 
+  @rety_error_codes [429, 501, 502, 503, 504]
+
   @spec auth_headers(String.t()) :: list()
   defp auth_headers(token) do
     [
@@ -192,9 +194,9 @@ defmodule Glific.ThirdParty.GoogleSlide.Slide do
       {
         Tesla.Middleware.Retry,
         delay: 500,
-        max_retries: 3,
+        max_retries: 5,
         should_retry: fn
-          {:ok, %{status: status}}, _, _ when status in 501..504 ->
+          {:ok, %{status: status}}, _, _ when status in @rety_error_codes ->
             true
 
           {:error, reason}, _, _ when reason in [:timeout, :connrefused, :nxdomain] ->


### PR DESCRIPTION
According to slides doc https://developers.google.com/workspace/slides/api/limits Its recommended to do a exp backoff retry on rate-limit



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Enhanced reliability when connecting to Google Slides by increasing retry attempts and including additional error codes for automatic retries.
  - Improved URL validation to prevent redundant checks when other errors are present, ensuring more accurate validation feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->