### PR TITLE
fix: prevent redundant sync

### DIFF
--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -90,7 +90,7 @@ defmodule Glific.GCS.GcsWorker do
 
     max_id = List.last(data)
 
-    if !is_nil(max_id) and max_id >= message_media_id do
+    if !is_nil(max_id) and max_id > message_media_id do
       Logger.info(
         "GCSWORKER: Updating #{phase} GCS jobs with max id:  #{max_id} , min id: #{message_media_id} for org_id: #{organization_id}"
       )

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -145,6 +145,7 @@ defmodule Glific.GcsWorkerTest do
     end
   end
 
+  @tag :tt
   test "perform_periodic/2, sweeping from start on every night for unsynced media_ids", attrs do
     with_mock(
       Goth.Token,
@@ -186,11 +187,10 @@ defmodule Glific.GcsWorkerTest do
 
       assert :ok = GcsWorker.perform_periodic(attrs.organization_id, %{phase: "unsynced"})
 
-      # When we run unsynced again after few mins, we see that only one jobs is
+      # When we run unsynced again after few mins, we see that no more jobs are
       # enqueued, this is due to the media_id pointer is ahead and we don't look
       # backwards. This is intended as once the nightly job starts then its incremental
-      # if the last max_id gcs_url was not null, then, no jobs would have been enqueued
-      assert %{success: 0, failure: 1, snoozed: 0, discard: 0, cancelled: 0} ==
+      assert %{success: 0, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :gcs)
 
       unsynced_gcs_job = Jobs.get_gcs_job(attrs.organization_id, "unsynced")


### PR DESCRIPTION

## Summary
There can be case of redundant sync due to using `>=` while queuing urls, since it can take time to generate gcs-url and that might affect this. Anyway nightly sync should handle this



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the logic for updating and queuing GCS jobs to prevent unnecessary processing of already handled items.

- **Tests**
  - Updated test assertions to accurately reflect that no jobs are enqueued during repeated unsynced runs.
  - Enhanced test clarity with updated comments and tagging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->