### PR TITLE
Google Sheets: Trimmed zero-width unicode characters

### DIFF
--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -242,9 +242,9 @@ defmodule Glific.Sheets do
           key
           |> String.downcase()
           |> String.replace(" ", "_")
-          |> String.replace(@invisible_unicode_range, "")
+          |> trim_string()
 
-        Map.put(acc, key, value |> String.replace(@invisible_unicode_range, ""))
+        Map.put(acc, key, value |> trim_string())
       end)
 
     errors =
@@ -413,5 +413,12 @@ defmodule Glific.Sheets do
     })
 
     :ok
+  end
+
+  @spec trim_string(String.t()) :: String.t()
+  defp trim_string(str) do
+    str
+    |> String.trim()
+    |> String.replace(@invisible_unicode_range, "")
   end
 end

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -110,7 +110,7 @@ defmodule Glific.SheetsTest do
           %Tesla.Env{
             status: 200,
             body:
-              "Key,Day,Message English\r\n1/10/\u202C2022,1,Hi welcome to Glific.\r\n1/10/2023\u200B,1,Hi welcome to Glific 2.\r\n1/10/2024,1,Hi welcome to Glific 3"
+              "Key,Day,Message English\r\n1/10/\u202C2022,1,Hi welcome to Glific.\r\n1/10/2023\u200B,1,Hi welcome to Glific 2.\r\n1/10/2024,1,Hi welcome to Glific 3\r\n1/10/2026 ,1,Hi welcome to Glific 4  "
           }
       end)
 
@@ -130,7 +130,7 @@ defmodule Glific.SheetsTest do
       assert sheet.is_active == true
       assert sheet.organization_id == organization_id
 
-      [h | [t | [t1 | _]]] =
+      [h | [t | [t1 | [t2 | _]]]] =
         SheetData
         |> where([sd], sd.sheet_id == ^sheet.id)
         |> Repo.all([])
@@ -138,6 +138,8 @@ defmodule Glific.SheetsTest do
       assert h.row_data["key"] == "1/10/2022"
       assert t.row_data["key"] == "1/10/2023"
       assert t1.row_data["key"] == "1/10/2024"
+      assert t2.row_data["key"] == "1/10/2026"
+      assert t2.row_data["message_english"] == "Hi welcome to Glific 4"
     end
   end
 end

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -1,11 +1,15 @@
 defmodule Glific.SheetsTest do
+  import Ecto.Query
+
   use Glific.DataCase
   use ExUnit.Case
 
   alias Glific.{
     Fixtures,
+    Repo,
     Sheets,
-    Sheets.Sheet
+    Sheets.Sheet,
+    Sheets.SheetData
   }
 
   describe "sheets" do
@@ -96,6 +100,44 @@ defmodule Glific.SheetsTest do
          %{organization_id: organization_id} = attrs do
       Fixtures.sheet_fixture(attrs)
       assert Sheets.sync_organization_sheets(organization_id) == :ok
+    end
+
+    test "create_sheet/1 with valid data creates a sheet, where Key has invisible characters", %{
+      organization_id: organization_id
+    } do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{
+            status: 200,
+            body:
+              "Key,Day,Message English\r\n1/10/\u202C2022,1,Hi welcome to Glific.\r\n1/10/2023\u200B,1,Hi welcome to Glific 2.\r\n1/10/2024,1,Hi welcome to Glific 3"
+          }
+      end)
+
+      valid_attrs = %{
+        type: "READ",
+        label: "sample sheet",
+        # this is sample sheet url
+        url:
+          "https://docs.google.com/spreadsheets/d/1fRpFyicqrUFxd79u_dGC8UOHEtAT3rA-G2i4tvOgScw/edit#gid=0"
+      }
+
+      attrs = Map.merge(@valid_attrs, %{organization_id: organization_id})
+
+      assert {:ok, %Sheet{} = sheet} = Sheets.create_sheet(attrs)
+      assert sheet.label == "sample sheet"
+      assert sheet.url == valid_attrs.url
+      assert sheet.is_active == true
+      assert sheet.organization_id == organization_id
+
+      [h | [t | [t1 | _]]] =
+        SheetData
+        |> where([sd], sd.sheet_id == ^sheet.id)
+        |> Repo.all([])
+
+      assert h.row_data["key"] == "1/10/2022"
+      assert t.row_data["key"] == "1/10/2023"
+      assert t1.row_data["key"] == "1/10/2024"
     end
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #4165  

Trimming zero-width unicode characters from gsheet keys and values. Since these were causing problem when we fetch by key from DB.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of sheet data by automatically removing invisible Unicode characters from keys and values, ensuring cleaner and more consistent data processing.

- **Tests**
  - Added a test to verify that sheet data containing invisible Unicode characters is correctly cleaned and normalized during sheet creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->