### PR TITLE
[4145] Fix null message for message reactions

### DIFF
--- a/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
@@ -14,9 +14,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventController do
   Default handle for all billing event callbacks
   """
   @spec handler(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def handler(conn, _params) do
-    json(conn, nil)
-  end
+  def handler(conn, _params), do: json(conn, "")
 
   @doc """
   Message status when the message has been sent to gupshup

--- a/lib/glific_web/providers/gupshup/controllers/default_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/default_controller.ex
@@ -6,7 +6,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultController do
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
   def handler(conn, _params, _msg) do
-    json(conn, nil)
+    json(conn, "")
   end
 
   @doc false

--- a/lib/glific_web/providers/gupshup/controllers/default_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/default_controller.ex
@@ -5,9 +5,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg) do
-    json(conn, "")
-  end
+  def handler(conn, _params, _msg), do: json(conn, "")
 
   @doc false
   @spec unknown(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/lib/glific_web/providers/gupshup/controllers/message_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_controller.ex
@@ -12,11 +12,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg) do
-    conn
-    |> Plug.Conn.send_resp(200, "")
-    |> Plug.Conn.halt()
-  end
+  def handler(conn, _params, _msg), do: json(conn, "")
 
   @doc """
   Parse text message payload and convert that into Glific message struct

--- a/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
@@ -10,9 +10,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventController do
   Default handle for all message event callbacks
   """
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg) do
-    json(conn, nil)
-  end
+  def handler(conn, _params, _msg), do: json(conn, "")
 
   @doc """
   Message status when the message has been sent to gupshup

--- a/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
@@ -7,9 +7,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg) do
-    json(conn, nil)
-  end
+  def handler(conn, _params, _msg), do: json(conn, "")
 
   @doc false
   @spec opted_in(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
@@ -50,7 +50,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
         |> put_in(["payload", "references", "gsId"], message.bsp_message_id)
 
       conn = post(conn, "/gupshup", billing_event_params)
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 200) == ""
 
       {:ok, message_conversation} =
         Repo.fetch_by(MessageConversation, %{

--- a/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultControllerTest do
   describe "unknown" do
     test "unknown should return empty data", %{conn: conn} do
       conn = post(conn, "/gupshup")
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 200) == ""
     end
   end
 end

--- a/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
@@ -64,7 +64,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming interactive message should be stored in the database",
          %{conn: conn, message_params: message_params} do
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -118,7 +118,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming text message should be stored in the database",
          %{conn: conn, message_params: message_params} do
       conn2 = post(conn, "/gupshup", message_params)
-      assert conn2.halted
+      assert json_response(conn2, 200) == ""
 
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
@@ -146,7 +146,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
 
       # This will call the lib/glific/communications/message.ex:error function for coverage
       conn3 = post(conn, "/gupshup", message_params)
-      assert conn3.halted
+      assert json_response(conn3, 200) == ""
     end
 
     test "Updating the contacts due to sender contact already existing", %{
@@ -156,7 +156,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert gupshup_conn.halted
+      assert json_response(gupshup_conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -188,7 +188,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "id"], Faker.String.base64(36))
 
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert gupshup_conn.halted
+      assert json_response(gupshup_conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -223,7 +223,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "sender", "name"], "Sumit")
 
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert gupshup_conn.halted
+      assert json_response(gupshup_conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -266,7 +266,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "sender", "phone"], contact.phone)
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
 
       {:error, ["Elixir.Glific.Messages.Message", "Resource not found"]} =
         Repo.fetch_by(Message, %{
@@ -296,7 +296,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming image message should be stored in the database",
          setup_config = %{conn: conn} do
       conn = post(conn, "/gupshup", setup_config.message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
 
       bsp_message_id = get_in(setup_config.message_params, ["payload", "id"])
 
@@ -336,7 +336,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "payload", "caption"], nil)
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -366,7 +366,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "video")
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -395,7 +395,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "file")
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -425,7 +425,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "sticker")
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -470,7 +470,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
       message_params = setup_config.message_params
 
       conn = post(conn, "/gupshup", message_params)
-      assert conn.halted
+      assert json_response(conn, 200) == ""
 
       # text_response(conn, 200)
       bsp_message_id = get_in(message_params, ["payload", "id"])

--- a/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
@@ -41,7 +41,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_request_params)
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 200) == ""
     end
   end
 

--- a/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_event_request_params)
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 200) == ""
     end
   end
 

--- a/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventControllerTest do
     test "handler should return nil data", %{conn: conn} do
       params = put_in(@user_event_request_params, ["payload", "type"], "not defined")
       conn = post(conn, "/gupshup", params)
-      assert json_response(conn, 200) == nil
+      assert json_response(conn, 200) == ""
     end
   end
 

--- a/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
@@ -489,7 +489,7 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert gupshup_conn.halted
+      assert json_response(gupshup_conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -795,7 +795,7 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert gupshup_conn.halted
+      assert json_response(gupshup_conn, 200) == ""
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =


### PR DESCRIPTION
## Summary
 Target issue is #4145  
 Explain the **motivation** for making this change. What existing problem does the pull request solve?
Changes the default handler response from `nil` to an empty string (`""`). This modification fixes the issue where users got "null" as a message when they react to messages. Returning nil got serialized to "null" string which Gupshup delivered as a literal message to users.

Updates corresponding test to reflect the new expected response value.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated API responses to consistently return an empty string ("") instead of null for multiple endpoints.
- **Tests**
  - Adjusted tests to expect an empty string ("") in the response body across various message and event handling scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->