### PR TITLE
Gupshup: Removed using deprecated /user api

### DIFF
--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -26,7 +26,6 @@ defmodule Glific.Partners do
     Partners.Provider,
     Providers.Gupshup.GupshupWallet,
     Providers.Gupshup.PartnerAPI,
-    Providers.GupshupContacts,
     Providers.Maytapi.WAWorker,
     Repo,
     Settings.Language,
@@ -917,8 +916,6 @@ defmodule Glific.Partners do
       update_organization(organization, %{bsp_id: credential.provider.id})
 
       if credential.is_active do
-        GupshupContacts.fetch_opted_in_contacts(credential)
-
         set_bsp_app_id(organization, "gupshup")
       else
         {:ok, credential}

--- a/lib/glific/providers/contact_behaviour.ex
+++ b/lib/glific/providers/contact_behaviour.ex
@@ -7,6 +7,4 @@ defmodule Glific.Providers.ContactBehaviour do
 
   @callback optin_contact(attrs :: map()) ::
               {:ok, Contact.t()} | {:error, Ecto.Changeset.t()} | {:error, list()}
-
-  @callback fetch_opted_in_contacts(attrs :: map()) :: :ok | {:error, String.t()}
 end

--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -63,17 +63,6 @@ defmodule Glific.Providers.Gupshup.ApiClient do
   end
 
   @doc """
-  Update a contact phone as opted in
-  """
-  @spec optin_contact(non_neg_integer(), map()) :: Tesla.Env.result() | {:error, String.t()}
-  def optin_contact(org_id, payload) do
-    with {:ok, credentials} <- get_credentials(org_id) do
-      url = @gupshup_api_url <> "/app/opt/in/" <> credentials.app_name
-      gupshup_post(url, payload, credentials.api_key)
-    end
-  end
-
-  @doc """
   Fetch opted in contacts data from providers server
   """
   @spec fetch_opted_in_contacts(non_neg_integer(), non_neg_integer()) ::

--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -7,7 +7,6 @@ defmodule Glific.Providers.Gupshup.ApiClient do
   use Gettext, backend: GlificWeb.Gettext
 
   @gupshup_msg_url "https://api.gupshup.io/wa/api/v1"
-  @gupshup_api_url "https://api.gupshup.io/sm/api/v1"
 
   use Tesla
   # you can add , log_level: :debug to the below if you want debugging info
@@ -60,25 +59,5 @@ defmodule Glific.Providers.Gupshup.ApiClient do
       url = @gupshup_msg_url <> "/msg"
       gupshup_post(url, payload, credentials.api_key)
     end
-  end
-
-  @doc """
-  Fetch opted in contacts data from providers server
-  """
-  @spec fetch_opted_in_contacts(non_neg_integer(), non_neg_integer()) ::
-          Tesla.Env.result() | {:error, String.t()}
-  def fetch_opted_in_contacts(org_id, page) do
-    with {:ok, credentials} <- get_credentials(org_id),
-         do: users_get(credentials.api_key, credentials.app_name, page)
-  end
-
-  @doc """
-  Build the Gupshup user list url
-  """
-  @spec users_get(String.t(), String.t(), non_neg_integer()) ::
-          Tesla.Env.result() | {:error, String.t()}
-  def users_get(api_key, app_name, page \\ 0) do
-    url = @gupshup_api_url <> "/users/" <> app_name <> "?maxResult=5000&pageNo=#{page}"
-    gupshup_get(url, api_key)
   end
 end

--- a/lib/glific/providers/gupshup/contacts.ex
+++ b/lib/glific/providers/gupshup/contacts.ex
@@ -23,19 +23,12 @@ defmodule Glific.Providers.GupshupContacts do
   @spec optin_contact(map()) ::
           {:ok, Contact.t()} | {:error, Ecto.Changeset.t()} | {:error, list()}
   def optin_contact(%{organization_id: organization_id} = attrs) do
-    ApiClient.optin_contact(organization_id, %{user: attrs.phone})
-    |> case do
-      {:ok, %Tesla.Env{status: status}} when status in 200..299 ->
-        Contacts.contact_opted_in(
-          attrs,
-          organization_id,
-          attrs[:optin_time] || DateTime.utc_now(),
-          method: attrs[:method] || "BSP"
-        )
-
-      _ ->
-        {:error, ["gupshup", "couldn't connect"]}
-    end
+    Contacts.contact_opted_in(
+      attrs,
+      organization_id,
+      attrs[:optin_time] || DateTime.utc_now(),
+      method: attrs[:method] || "BSP"
+    )
   end
 
   @per_page_limit 5000

--- a/lib/glific/providers/gupshup/contacts.ex
+++ b/lib/glific/providers/gupshup/contacts.ex
@@ -28,31 +28,4 @@ defmodule Glific.Providers.GupshupContacts do
       method: attrs[:method] || "BSP"
     )
   end
-
-  @doc """
-  Perform the gupshup API call and parse the results for downstream functions.
-  We need to think about if we want to add him to behaviour
-  """
-  @spec validate_opted_in_contacts(Tesla.Env.result()) ::
-          {:ok, list()} | {:error, String.t(), atom()}
-  def validate_opted_in_contacts(result) do
-    case result do
-      {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
-        {:ok, response_data} = Jason.decode(body)
-
-        if response_data["status"] == "error" do
-          {:error, dgettext("errors", "Message: %{message}", message: response_data["message"]),
-           :app_name}
-        else
-          users = response_data["users"]
-          {:ok, users}
-        end
-
-      {:ok, %Tesla.Env{status: status}} when status in 400..499 ->
-        {:error, dgettext("errors", "Invalid BSP API key"), :api_key}
-
-      {:error, %Tesla.Error{reason: reason}} ->
-        {:error, dgettext("errors", "Reason: %{reason}", reason: reason), :app_name}
-    end
-  end
 end

--- a/lib/glific/providers/gupshup/contacts.ex
+++ b/lib/glific/providers/gupshup/contacts.ex
@@ -35,6 +35,7 @@ defmodule Glific.Providers.GupshupContacts do
   @doc """
   Fetch opted in contacts data from providers server
   """
+  @deprecated "Gupshup deprecated /users api which this function uses underneath"
   @spec fetch_opted_in_contacts(map()) :: :ok | {:error, String.t()}
   def fetch_opted_in_contacts(attrs) do
     do_fetch_opted_in_contacts(attrs.organization_id, @per_page_limit, 1)

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -23,7 +23,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @app_url "https://partner.gupshup.io/partner/app/"
 
   @doc """
-  Fetch app details org id
+  Fetch app details by org id, will link the app if not linked
   """
   @spec fetch_app_details(non_neg_integer()) :: map() | String.t()
   def fetch_app_details(org_id) do
@@ -125,9 +125,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   end
 
   @doc """
-  Getting app ID once the app is already linked
+  Fetch Gupshup app details by orgId or Gupshup app name
   """
-  @spec fetch_gupshup_app_details(non_neg_integer()) :: map() | String.t()
+  @spec fetch_gupshup_app_details(non_neg_integer() | String.t()) :: map() | String.t()
   def fetch_gupshup_app_details(org_id) when is_number(org_id) do
     organization = Partners.organization(org_id)
     gupshup_secrets = organization.services["bsp"].secrets

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -23,7 +23,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @app_url "https://partner.gupshup.io/partner/app/"
 
   @doc """
-    Fetch App details based on API key and App name
+  Fetch app details org id
   """
   @spec fetch_app_details(non_neg_integer()) :: map() | String.t()
   def fetch_app_details(org_id) do
@@ -122,7 +122,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   end
 
   @doc """
-    Getting app ID once the app is already linked
+  Getting app ID once the app is already linked
   """
   @spec fetch_gupshup_app_id(non_neg_integer()) :: map() | String.t()
   def fetch_gupshup_app_id(org_id) do
@@ -515,5 +515,16 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
       |> List.last()
 
     "template-asset-#{media_name}.#{file_format}"
+  end
+
+  @spec fetch_partner_apps :: list() | String.t()
+  defp fetch_partner_apps do
+    case get_request(@partner_url <> "/api/partnerApps", token_type: :partner_token) do
+      {:ok, %{"partnerAppsList" => list}} ->
+        list
+
+      {:error, error} ->
+        error
+    end
   end
 end

--- a/lib/glific/providers/gupshup_enterprise/contacts.ex
+++ b/lib/glific/providers/gupshup_enterprise/contacts.ex
@@ -38,7 +38,6 @@ defmodule Glific.Providers.GupshupEnterpriseContacts do
   @doc """
   Fetch opted in contacts data from providers server
   """
-  @impl Glific.Providers.ContactBehaviour
   @spec fetch_opted_in_contacts(map()) :: :ok | {:error, String.t()}
   def fetch_opted_in_contacts(_attrs), do: :ok
 end

--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -333,7 +333,7 @@ defmodule Glific.Saas.Queries do
   # Validate the APIKey and AppName entered by the organization. We will use the gupshup
   # opt-in url which requires both and ensure that it returns success to validate these two
   # parameters
-  @spec validate_bsp_keys(map(), map() | String.t()) :: map()
+  @spec validate_bsp_keys(map(), map()) :: map()
   defp validate_bsp_keys(result, params) do
     api_key = params["api_key"]
     app_name = params["app_name"]

--- a/lib/glific/seeds/seeds_optins.ex
+++ b/lib/glific/seeds/seeds_optins.ex
@@ -8,8 +8,7 @@ defmodule Glific.Seeds.SeedsOptins do
 
   alias Glific.{
     Contacts,
-    Partners,
-    Providers.GupshupContacts
+    Partners
   }
 
   @spec import_optin_contacts(map(), list()) :: :ok | any
@@ -67,12 +66,5 @@ defmodule Glific.Seeds.SeedsOptins do
       # upsert contact with provided phone and name
       import_optin_contacts(organization, contact)
     end)
-
-    # fetch and update contact details of optin time, last message at, bsp status
-    {:ok, credential} =
-      %{organization_id: organization.id, shortcode: "gupshup"}
-      |> Partners.get_credential()
-
-    GupshupContacts.fetch_opted_in_contacts(credential)
   end
 end

--- a/priv/gettext/error.pot
+++ b/priv/gettext/error.pot
@@ -11,43 +11,43 @@
 msgid ""
 msgstr ""
 
-#: lib/glific/saas/queries.ex:343
+#: lib/glific/saas/queries.ex:342
 #, elixir-autogen, elixir-format
 msgid "API Key or App Name is empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:476
+#: lib/glific/saas/queries.ex:471
 #, elixir-autogen, elixir-format
 msgid "Billing frequency cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:387
+#: lib/glific/saas/queries.ex:382
 #, elixir-autogen, elixir-format
 msgid "Email is not valid."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:137
-#: lib/glific/saas/queries.ex:159
+#: lib/glific/saas/queries.ex:136
+#: lib/glific/saas/queries.ex:158
 #, elixir-autogen, elixir-format
 msgid "Field cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:552
+#: lib/glific/saas/queries.ex:547
 #, elixir-autogen, elixir-format
 msgid "Field cannot be false."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:163
+#: lib/glific/saas/queries.ex:162
 #, elixir-autogen, elixir-format
 msgid "Field cannot be less than %{length} letters."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:170
+#: lib/glific/saas/queries.ex:169
 #, elixir-autogen, elixir-format
 msgid "Field cannot be more than %{length} letters."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:399
+#: lib/glific/saas/queries.ex:394
 #, elixir-autogen, elixir-format
 msgid "Phone is not valid."
 msgstr ""
@@ -62,17 +62,17 @@ msgstr ""
 msgid "Registration doesn't exist for given registration ID."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:365
+#: lib/glific/saas/queries.ex:360
 #, elixir-autogen, elixir-format
 msgid "Shortcode cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:372
+#: lib/glific/saas/queries.ex:367
 #, elixir-autogen, elixir-format
 msgid "Shortcode has already been taken."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:480
+#: lib/glific/saas/queries.ex:475
 #, elixir-autogen, elixir-format
 msgid "Value should be one of Monthly , Quarterly, Half-Yearly, Annually."
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -165,13 +165,8 @@ msgstr ""
 msgid "Error while fetching the BSP balance"
 msgstr ""
 
-#: lib/glific/providers/gupshup/contacts.ex:93
-#, elixir-format, elixir-autogen
-msgid "Invalid BSP API key"
-msgstr ""
-
-#: lib/glific/partners.ex:426
-#: lib/glific/partners.ex:443
+#: lib/glific/partners.ex:425
+#: lib/glific/partners.ex:442
 #, elixir-format, elixir-autogen
 msgid "Invalid BSP provider"
 msgstr ""
@@ -181,9 +176,9 @@ msgstr ""
 msgid "Invoice status updated for %{invoice_id}"
 msgstr ""
 
-#: lib/glific/partners.ex:422
-#: lib/glific/partners.ex:439
-#: lib/glific/providers/gupshup/api_client.ex:37
+#: lib/glific/partners.ex:421
+#: lib/glific/partners.ex:438
+#: lib/glific/providers/gupshup/api_client.ex:36
 #: lib/glific/providers/gupshup_enterprise/api_client.ex:36
 #, elixir-format, elixir-autogen
 msgid "No active BSP available"
@@ -308,19 +303,9 @@ msgstr ""
 msgid "Invalid event type"
 msgstr ""
 
-#: lib/glific/providers/gupshup/contacts.ex:85
-#, elixir-autogen, elixir-format
-msgid "Message: %{message}"
-msgstr ""
-
 #: lib/glific_web/resolvers/profiles.ex:22
 #, elixir-autogen, elixir-format
 msgid "Profile not found or permission denied."
-msgstr ""
-
-#: lib/glific/providers/gupshup/contacts.ex:96
-#, elixir-autogen, elixir-format
-msgid "Reason: %{reason}"
 msgstr ""
 
 #: lib/glific_web/resolvers/wa_group.ex:21

--- a/test/glific/flows/contact_action_test.exs
+++ b/test/glific/flows/contact_action_test.exs
@@ -23,7 +23,7 @@ defmodule Glific.Flows.ContactActionTest do
     :ok
   end
 
-  test "optout", attrs do
+  test "optout/optin", attrs do
     [contact | _] =
       Contacts.list_contacts(%{filter: Map.merge(attrs, %{name: "Default receiver"})})
 
@@ -37,6 +37,11 @@ defmodule Glific.Flows.ContactActionTest do
     contact = Contacts.get_contact!(contact.id)
     assert contact.optout_time != nil
     assert contact.optin_time == nil
+
+    ContactAction.optin(context)
+    contact = Contacts.get_contact!(contact.id)
+    assert contact.optout_time == nil
+    assert contact.optin_time != nil
   end
 
   test "send message text", attrs do

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -684,6 +684,40 @@ defmodule Glific.OnboardTest do
       |> Map.put("shortcode", "NEW_Glific")
       |> Map.put("phone", "919917443995")
 
-    _result = Onboard.setup(attrs)
+    assert %{is_valid: false} = Onboard.setup(attrs)
+  end
+
+  test "Partnerapps api returns error" do
+    Tesla.Mock.mock(fn
+      %{method: :get} ->
+        {:error,
+        %Tesla.Env{
+          status: 400,
+          body:
+            Jason.encode!(%{
+              "error" => "some error"
+            })
+        }}
+
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "token" => "ks_test_token",
+              "status" => "success",
+              "templates" => [],
+              "template" => %{"id" => Ecto.UUID.generate(), "status" => "PENDING"}
+            })
+        }
+    end)
+
+    attrs =
+      @valid_attrs
+      |> Map.put("name", " First")
+      |> Map.put("shortcode", "NEW_Glific")
+      |> Map.put("phone", "919917443995")
+
+    assert %{is_valid: false} = Onboard.setup(attrs)
   end
 end

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -60,8 +60,7 @@ defmodule Glific.OnboardTest do
           status: 200,
           body:
             Jason.encode!(%{
-              "status" => "ok",
-              "users" => [1, 2, 3]
+              "partnerAppsList" => [%{"name" => "fake app name"}]
             })
         }
 
@@ -653,5 +652,39 @@ defmodule Glific.OnboardTest do
 
     assert result.organization.name == "First"
     assert result.organization.shortcode == "new_glific"
+  end
+
+  @tag :tt
+  test "Handling submitting invalid app name" do
+    Tesla.Mock.mock(fn
+      %{method: :get} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "partnerAppsList" => []
+            })
+        }
+
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "token" => "ks_test_token",
+              "status" => "success",
+              "templates" => [],
+              "template" => %{"id" => Ecto.UUID.generate(), "status" => "PENDING"}
+            })
+        }
+    end)
+
+    attrs =
+      @valid_attrs
+      |> Map.put("name", " First")
+      |> Map.put("shortcode", "NEW_Glific")
+      |> Map.put("phone", "919917443995")
+
+    _result = Onboard.setup(attrs)
   end
 end

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -654,7 +654,6 @@ defmodule Glific.OnboardTest do
     assert result.organization.shortcode == "new_glific"
   end
 
-  @tag :tt
   test "Handling submitting invalid app name" do
     Tesla.Mock.mock(fn
       %{method: :get} ->

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -1011,6 +1011,46 @@ defmodule Glific.PartnersTest do
       assert "updated_user_id" == updated_credential.secrets["user_id"]
     end
 
+    test "update_credential/2 for gupshup  should update credentials",
+         %{organization_id: organization_id} = _attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          {:error,
+           %Tesla.Env{
+             status: 400,
+             body:
+               Jason.encode!(%{
+                 "error" => "some error"
+               })
+           }}
+
+        %{method: :post} ->
+          {:error,
+           %Tesla.Env{
+             status: 400,
+             body:
+               Jason.encode!(%{
+                 "error" => "Re-linking"
+               })
+           }}
+      end)
+
+      {:ok, provider} = Repo.fetch_by(Provider, %{shortcode: "gupshup"})
+
+      assert {:ok, %Credential{} = credential} =
+               Repo.fetch_by(Credential, %{provider_id: provider.id})
+
+      valid_update_attrs = %{
+        keys: %{"api_end_point" => "test_end_point"},
+        shortcode: provider.shortcode,
+        secrets: %{"app_name" => "some_app", "api_key" => "some_key"},
+        organization_id: organization_id
+      }
+
+      {:ok, updated_credential} = Partners.update_credential(credential, valid_update_attrs)
+      assert "some_app" == updated_credential.secrets["app_name"]
+    end
+
     test "update_credential/2 for bigquery should call create bigquery dataset",
          %{organization_id: organization_id} = _attrs do
       valid_attrs = %{


### PR DESCRIPTION
## Summary
 Target issue is #4110  

- Removed /user api which was used to fetch_optin_contacts
- Removed fetch_optin_contacts process when updating credentials
- fetch_optin_contacts was also used to verify the app which is replaced by `PartnerAPI.fetch_gupshup_app_details(app_name)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified and removed external API calls for Gupshup contact opt-in and opted-in contacts fetching, streamlining related flows.
  - Updated Gupshup app validation to rely solely on app details, removing API key-based user validation.
  - Generalized and improved Gupshup app details retrieval for onboarding and validation processes.

- **Tests**
  - Enhanced opt-in/opt-out contact action tests for more comprehensive verification.
  - Added onboarding tests for handling invalid app names and partner API errors.
  - Introduced new tests for updating Gupshup credentials under various response scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->