### PR TITLE
Revert "[4145] Fix null message for message reactions"

### DIFF
--- a/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
@@ -14,7 +14,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventController do
   Default handle for all billing event callbacks
   """
   @spec handler(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def handler(conn, _params), do: json(conn, "")
+  def handler(conn, _params) do
+    json(conn, nil)
+  end
 
   @doc """
   Message status when the message has been sent to gupshup

--- a/lib/glific_web/providers/gupshup/controllers/default_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/default_controller.ex
@@ -5,7 +5,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg), do: json(conn, "")
+  def handler(conn, _params, _msg) do
+    json(conn, nil)
+  end
 
   @doc false
   @spec unknown(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/lib/glific_web/providers/gupshup/controllers/message_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_controller.ex
@@ -12,7 +12,11 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg), do: json(conn, "")
+  def handler(conn, _params, _msg) do
+    conn
+    |> Plug.Conn.send_resp(200, "")
+    |> Plug.Conn.halt()
+  end
 
   @doc """
   Parse text message payload and convert that into Glific message struct

--- a/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
@@ -10,7 +10,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventController do
   Default handle for all message event callbacks
   """
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg), do: json(conn, "")
+  def handler(conn, _params, _msg) do
+    json(conn, nil)
+  end
 
   @doc """
   Message status when the message has been sent to gupshup

--- a/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
@@ -7,7 +7,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventController do
 
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
-  def handler(conn, _params, _msg), do: json(conn, "")
+  def handler(conn, _params, _msg) do
+    json(conn, nil)
+  end
 
   @doc false
   @spec opted_in(Plug.Conn.t(), map()) :: Plug.Conn.t()

--- a/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
@@ -50,7 +50,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
         |> put_in(["payload", "references", "gsId"], message.bsp_message_id)
 
       conn = post(conn, "/gupshup", billing_event_params)
-      assert json_response(conn, 200) == ""
+      assert json_response(conn, 200) == nil
 
       {:ok, message_conversation} =
         Repo.fetch_by(MessageConversation, %{

--- a/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultControllerTest do
   describe "unknown" do
     test "unknown should return empty data", %{conn: conn} do
       conn = post(conn, "/gupshup")
-      assert json_response(conn, 200) == ""
+      assert json_response(conn, 200) == nil
     end
   end
 end

--- a/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
@@ -41,7 +41,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_request_params)
-      assert json_response(conn, 200) == ""
+      assert json_response(conn, 200) == nil
     end
   end
 
@@ -64,7 +64,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming interactive message should be stored in the database",
          %{conn: conn, message_params: message_params} do
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -118,7 +118,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming text message should be stored in the database",
          %{conn: conn, message_params: message_params} do
       conn2 = post(conn, "/gupshup", message_params)
-      assert json_response(conn2, 200) == ""
+      assert conn2.halted
 
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
@@ -146,7 +146,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
 
       # This will call the lib/glific/communications/message.ex:error function for coverage
       conn3 = post(conn, "/gupshup", message_params)
-      assert json_response(conn3, 200) == ""
+      assert conn3.halted
     end
 
     test "Updating the contacts due to sender contact already existing", %{
@@ -156,7 +156,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert json_response(gupshup_conn, 200) == ""
+      assert gupshup_conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -188,7 +188,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "id"], Faker.String.base64(36))
 
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert json_response(gupshup_conn, 200) == ""
+      assert gupshup_conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -223,7 +223,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "sender", "name"], "Sumit")
 
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert json_response(gupshup_conn, 200) == ""
+      assert gupshup_conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -266,7 +266,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "sender", "phone"], contact.phone)
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
 
       {:error, ["Elixir.Glific.Messages.Message", "Resource not found"]} =
         Repo.fetch_by(Message, %{
@@ -296,7 +296,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
     test "Incoming image message should be stored in the database",
          setup_config = %{conn: conn} do
       conn = post(conn, "/gupshup", setup_config.message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
 
       bsp_message_id = get_in(setup_config.message_params, ["payload", "id"])
 
@@ -336,7 +336,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "payload", "caption"], nil)
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -366,7 +366,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "video")
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -395,7 +395,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "file")
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -425,7 +425,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
         |> put_in(["payload", "type"], "sticker")
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -470,7 +470,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
       message_params = setup_config.message_params
 
       conn = post(conn, "/gupshup", message_params)
-      assert json_response(conn, 200) == ""
+      assert conn.halted
 
       # text_response(conn, 200)
       bsp_message_id = get_in(message_params, ["payload", "id"])

--- a/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_event_request_params)
-      assert json_response(conn, 200) == ""
+      assert json_response(conn, 200) == nil
     end
   end
 

--- a/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventControllerTest do
     test "handler should return nil data", %{conn: conn} do
       params = put_in(@user_event_request_params, ["payload", "type"], "not defined")
       conn = post(conn, "/gupshup", params)
-      assert json_response(conn, 200) == ""
+      assert json_response(conn, 200) == nil
     end
   end
 

--- a/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
@@ -489,7 +489,7 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert json_response(gupshup_conn, 200) == ""
+      assert gupshup_conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =
@@ -795,7 +795,7 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
       # handling a message from gupshup, so that the phone number will be already existing
       # in contacts table.
       gupshup_conn = post(conn, "/gupshup", message_params)
-      assert json_response(gupshup_conn, 200) == ""
+      assert gupshup_conn.halted
       bsp_message_id = get_in(message_params, ["payload", "id"])
 
       {:ok, message} =


### PR DESCRIPTION
Reverts glific/glific#4175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated responses for certain API endpoints to return a JSON null value instead of an empty string, or to send a plain HTTP 200 response with an empty body, ensuring more consistent and standards-compliant responses.

- **Tests**
	- Adjusted test cases to expect the updated response formats, including checking for JSON null values and verifying halted connections where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->