### PR TITLE
[4145] Send empty body for Gupshup callbacks

### DIFF
--- a/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
@@ -15,7 +15,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventController do
   """
   @spec handler(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def handler(conn, _params) do
-    json(conn, nil)
+    conn
+    |> Plug.Conn.send_resp(200, "")
+    |> Plug.Conn.halt()
   end
 
   @doc """

--- a/lib/glific_web/providers/gupshup/controllers/default_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/default_controller.ex
@@ -6,7 +6,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultController do
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
   def handler(conn, _params, _msg) do
-    json(conn, nil)
+    conn
+    |> Plug.Conn.send_resp(200, "")
+    |> Plug.Conn.halt()
   end
 
   @doc false

--- a/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
@@ -11,7 +11,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventController do
   """
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
   def handler(conn, _params, _msg) do
-    json(conn, nil)
+    conn
+    |> Plug.Conn.send_resp(200, "")
+    |> Plug.Conn.halt()
   end
 
   @doc """

--- a/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/user_event_controller.ex
@@ -8,7 +8,9 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventController do
   @doc false
   @spec handler(Plug.Conn.t(), map(), String.t()) :: Plug.Conn.t()
   def handler(conn, _params, _msg) do
-    json(conn, nil)
+    conn
+    |> Plug.Conn.send_resp(200, "")
+    |> Plug.Conn.halt()
   end
 
   @doc false

--- a/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
@@ -50,7 +50,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
         |> put_in(["payload", "references", "gsId"], message.bsp_message_id)
 
       conn = post(conn, "/gupshup", billing_event_params)
-      assert json_response(conn, 200) == nil
+      assert response(conn, 200) == ""
 
       {:ok, message_conversation} =
         Repo.fetch_by(MessageConversation, %{

--- a/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/default_controller_test.exs
@@ -4,7 +4,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.DefaultControllerTest do
   describe "unknown" do
     test "unknown should return empty data", %{conn: conn} do
       conn = post(conn, "/gupshup")
-      assert json_response(conn, 200) == nil
+      assert response(conn, 200) == ""
     end
   end
 end

--- a/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_controller_test.exs
@@ -41,7 +41,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_request_params)
-      assert json_response(conn, 200) == nil
+      assert response(conn, 200) == ""
     end
   end
 

--- a/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/message_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventControllerTest do
   describe "handler" do
     test "handler should return nil data", %{conn: conn} do
       conn = post(conn, "/gupshup", @message_event_request_params)
-      assert json_response(conn, 200) == nil
+      assert response(conn, 200) == ""
     end
   end
 
@@ -58,35 +58,35 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventControllerTest do
     test "enqueued status should update the message status", setup_config = %{conn: conn} do
       # when message enqueued
       success_conn = post(conn, "/gupshup", setup_config.message_params)
-      json_response(success_conn, 200)
+      response(success_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :enqueued
 
       # when message sent
       message_params = put_in(setup_config.message_params, ["payload", "type"], "sent")
       sent_conn = post(conn, "/gupshup", message_params)
-      json_response(sent_conn, 200)
+      response(sent_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :sent
 
       # when message read
       message_params = put_in(setup_config.message_params, ["payload", "type"], "read")
       read_conn = post(conn, "/gupshup", message_params)
-      json_response(read_conn, 200)
+      response(read_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :read
 
       # when message delivered
       message_params = put_in(setup_config.message_params, ["payload", "type"], "delivered")
       delivered_conn = post(conn, "/gupshup", message_params)
-      json_response(delivered_conn, 200)
+      response(delivered_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :delivered
 
       # when message failed with no code
       message_params = put_in(setup_config.message_params, ["payload", "type"], "failed")
       failed_conn = post(conn, "/gupshup", message_params)
-      json_response(failed_conn, 200)
+      response(failed_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :error
       assert message.errors != nil
@@ -99,7 +99,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventControllerTest do
         |> put_in(["payload", "payload"], %{"ts" => "1592311836", "code" => 1002})
 
       failed_conn = post(conn, "/gupshup", message_params)
-      json_response(failed_conn, 200)
+      response(failed_conn, 200)
       message = Messages.get_message!(setup_config.message.id)
       assert message.bsp_status == :error
       assert message.errors != nil

--- a/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/user_event_controller_test.exs
@@ -33,7 +33,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventControllerTest do
     test "handler should return nil data", %{conn: conn} do
       params = put_in(@user_event_request_params, ["payload", "type"], "not defined")
       conn = post(conn, "/gupshup", params)
-      assert json_response(conn, 200) == nil
+      assert response(conn, 200) == ""
     end
   end
 
@@ -54,7 +54,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventControllerTest do
     test "optin_time and status should be updated", setup_config = %{conn: conn} do
       phone = get_in(setup_config.message_params, ["payload", "phone"])
       conn = post(conn, "/gupshup", setup_config.message_params)
-      json_response(conn, 200)
+      response(conn, 200)
 
       {:ok, contact} =
         Repo.fetch_by(Contact, %{phone: phone, organization_id: conn.assigns[:organization_id]})
@@ -83,7 +83,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.UserEventControllerTest do
     test "optout_time and status should be updated", setup_config = %{conn: conn} do
       phone = get_in(setup_config.message_params, ["payload", "phone"])
       conn = post(conn, "/gupshup", setup_config.message_params)
-      json_response(conn, 200)
+      response(conn, 200)
 
       {:ok, contact} =
         Repo.fetch_by(Contact, %{phone: phone, organization_id: conn.assigns[:organization_id]})


### PR DESCRIPTION
## Summary
 Target issue is #4145 

## Changes
Updates Gupshup controller responses to use direct connection response instead of json/2.

- Replaces json(conn, nil) with explicit 200 empty response
- Maintains consistent response pattern across all Gupshup webhook handlers
- Updates corresponding tests to verify empty string response


The earlier PR #4175 was explicitly sending json responses, leading to JSON serialization which meant we returned empty string as response and Gupshup treated that as another message and forwarded it to whatsapp. This fixes that

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved HTTP responses for certain endpoints to return an empty 200 OK response instead of a JSON null value.
- **Tests**
	- Updated tests to verify that endpoints return an empty string in the response body, rather than a JSON null, for successful 200 OK responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->