### PR TITLE
[4150] feat: ✨ Add is_active filter to profile listing

### DIFF
--- a/lib/glific/profiles.ex
+++ b/lib/glific/profiles.ex
@@ -40,6 +40,9 @@ defmodule Glific.Profiles do
       {:contact_id, contact_id}, query ->
         from(q in query, where: q.contact_id == ^contact_id)
 
+      {:is_active, is_active}, query when is_boolean(is_active) ->
+        from(q in query, where: q.is_active == ^is_active)
+
       _, query ->
         query
     end)
@@ -168,7 +171,7 @@ defmodule Glific.Profiles do
   @spec get_indexed_profile(Contact.t()) :: [{any, integer}]
   def get_indexed_profile(contact) do
     %{
-      filter: %{contact_id: contact.id},
+      filter: %{contact_id: contact.id, is_active: true},
       opts: %{offset: 0, order: :asc},
       organization_id: contact.organization_id
     }

--- a/test/glific/profiles_test.exs
+++ b/test/glific/profiles_test.exs
@@ -24,14 +24,22 @@ defmodule Glific.ProfilesTest do
       "name" => "profile 2",
       "contact_id" => 2
     }
+
+    @valid_attrs_2 %{
+      "name" => "profile 3",
+      "type" => "student",
+      "is_active" => false
+    }
+
     test "get_profile!/1 returns the profile with given id" do
       profile = profile_fixture()
       assert Profiles.get_profile!(profile.id) == profile
     end
 
-    test "list_contacts/1 with multiple profiles filtered" do
+    test "list_profiles/1 with multiple profiles filtered" do
       _p1 = profile_fixture(@valid_attrs)
       _p2 = profile_fixture(@valid_attrs_1)
+      _p3 = profile_fixture(@valid_attrs_2)
 
       # fliter by name
       [profile | _] = Profiles.list_profiles(%{filter: %{name: "profile 1"}})
@@ -39,11 +47,18 @@ defmodule Glific.ProfilesTest do
 
       # If no filter is given it will return all the profile
       profile2 = Profiles.list_profiles(%{})
-      assert Enum.count(profile2) == 3
+      assert Enum.count(profile2) == 4
 
       # filter by contact_id
       profile3 = Profiles.list_profiles(%{filter: %{contact_id: 1}})
       assert Enum.count(profile3) == 1
+
+      # filter by active status
+      profile4 = Profiles.list_profiles(%{filter: %{is_active: false}})
+      assert Enum.count(profile4) == 1
+
+      profile4 = Profiles.list_profiles(%{filter: %{is_active: true}})
+      assert Enum.count(profile4) == 3
     end
 
     test "create_profile/1 with valid data creates a profile" do


### PR DESCRIPTION
## Summary
 Target issue is #4150  
 
Adds ability to filter profiles by their active status through:
- New filter clause for is_active boolean field
- Updated get_indexed_profile to only return active profiles by default
- Added corresponding test cases to verify filtering behavior

This change improves profile management by allowing better control over which profiles are visible in different contexts.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 
