### PR TITLE
Added `node_uuid` in Infinite Loop Notification

### DIFF
--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -186,7 +186,8 @@ defmodule Glific.Flows.FlowContext do
           flow_id: context.flow_id,
           flow_uuid: context.flow.uuid,
           parent_id: context.parent_id,
-          name: context.flow.name
+          name: context.flow.name,
+          node_uuid: context.node_uuid
         }
       })
 

--- a/test/glific/flows/contact_action_test.exs
+++ b/test/glific/flows/contact_action_test.exs
@@ -9,6 +9,7 @@ defmodule Glific.Flows.ContactActionTest do
     Flows.FlowContext,
     Flows.Templating,
     Messages.Message,
+    Notifications,
     Seeds.SeedsDev,
     Templates
   }
@@ -270,5 +271,58 @@ defmodule Glific.Flows.ContactActionTest do
 
     assert message.media.caption ==
              "Hi var_1,\n\nYour account image was updated on var_2 by var_3 with above"
+  end
+
+  test "if loop is detected then flow should be aborted and a notification should be created", attrs do
+    node_uuid = "8b4d2e09-9d72-4436-a01a-8e3def9cf4e5"
+    message = "This is test message"
+
+    [flow | _tail] = Glific.Flows.list_flows(%{filter: attrs})
+
+    [contact | _] =
+      Contacts.list_contacts(%{filter: Map.merge(attrs, %{name: "Default receiver"})})
+
+    context_attrs = %{
+      flow_id: flow.id,
+      flow_uuid: flow.uuid,
+      contact_id: contact.id,
+      organization_id: attrs.organization_id,
+      node_uuid: node_uuid
+    }
+
+    {:ok, context} = FlowContext.create_flow_context(context_attrs)
+    context = Repo.preload(context, [:contact, :flow])
+
+    base_time =
+      DateTime.utc_now()
+      |> DateTime.truncate(:second)
+
+    recent_outbound =
+      Enum.map(0..3, fn index ->
+        date =
+          DateTime.add(base_time, -index * 5, :second)
+          |> DateTime.to_iso8601()
+
+        %{
+          "contact" => %{"name"=> contact.name, "uuid" => contact.id},
+          "date" => date,
+          "message" => message,
+          "message_id" => index,
+          "node_uuid" => node_uuid
+        }
+      end)
+
+    action = %Action{text: message}
+
+    {:ok, new_context} =
+      FlowContext.update_flow_context(context, %{recent_outbound: recent_outbound})
+
+    ContactAction.send_message(new_context, action, [])
+
+    [notification | _] = Notifications.list_notifications(%{filter: %{category: "Flow"}})
+
+    assert notification.message == "Infinite loop detected, body: This is test message. Aborting flow."
+    assert notification.entity["flow_uuid"] == flow.uuid
+    assert notification.entity["node_uuid"] == node_uuid
   end
 end


### PR DESCRIPTION
target issue is #4161

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Notifications now include additional metadata, allowing users to see more detailed information related to the specific step within a flow.
- **Bug Fixes**
  - Added detection and notification for infinite loops during flow execution to prevent repeated message sending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->