### PR TITLE
Enhance contact import validation

### DIFF
--- a/lib/glific/contacts/import_worker.ex
+++ b/lib/glific/contacts/import_worker.ex
@@ -96,14 +96,13 @@ defmodule Glific.Contacts.ImportWorker do
 
   defp validate_contact(%{"phone" => phone, "name" => name}) do
     phone_with_plus = if String.starts_with?(phone, "+"), do: phone, else: "+#{phone}"
-    case ExPhoneNumber.parse(phone_with_plus, "") do
-      {:ok, phone_number} ->
-        if ExPhoneNumber.is_valid_number?(phone_number) do
-          validate_name(name, phone)
-        else
-          %{phone => "Phone number is not valid."}
-        end
+
+    with {:ok, phone_number} <- ExPhoneNumber.parse(phone_with_plus, ""),
+         true <- ExPhoneNumber.is_valid_number?(phone_number) do
+      validate_name(name, phone)
+    else
       {:error, reason} -> %{phone => "Phone number is not valid because #{reason}."}
+      false -> %{phone => "Phone number is not valid."}
     end
   end
 

--- a/lib/glific/contacts/import_worker.ex
+++ b/lib/glific/contacts/import_worker.ex
@@ -95,7 +95,8 @@ defmodule Glific.Contacts.ImportWorker do
   end
 
   defp validate_contact(%{"phone" => phone, "name" => name}) do
-    case ExPhoneNumber.parse(phone, "IN") do
+    phone_with_plus = if String.starts_with?(phone, "+"), do: phone, else: "+#{phone}"
+    case ExPhoneNumber.parse(phone_with_plus, "") do
       {:ok, _} -> validate_name(name, phone)
       {:error, reason} -> %{phone => "Phone number is not valid because #{reason}."}
     end

--- a/lib/glific/contacts/import_worker.ex
+++ b/lib/glific/contacts/import_worker.ex
@@ -97,7 +97,12 @@ defmodule Glific.Contacts.ImportWorker do
   defp validate_contact(%{"phone" => phone, "name" => name}) do
     phone_with_plus = if String.starts_with?(phone, "+"), do: phone, else: "+#{phone}"
     case ExPhoneNumber.parse(phone_with_plus, "") do
-      {:ok, _} -> validate_name(name, phone)
+      {:ok, phone_number} ->
+        if ExPhoneNumber.is_valid_number?(phone_number) do
+          validate_name(name, phone)
+        else
+          %{phone => "Phone number is not valid."}
+        end
       {:error, reason} -> %{phone => "Phone number is not valid because #{reason}."}
     end
   end

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Unsupported node type"
 msgstr ""
 
-#: lib/glific/flows/flow_context.ex:482
+#: lib/glific/flows/flow_context.ex:483
 #, elixir-format, elixir-autogen
 msgid "We have finished the flow"
 msgstr ""

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -449,7 +449,7 @@ defmodule Glific.ContactsTest do
 
       [
         ~w(name phone Language opt_in collection),
-        ["test", "9989329297", "english", @optin_date, "collection"]
+        ["test", "+919989329297", "english", @optin_date, "collection"]
       ]
       |> CSV.encode()
       |> Enum.each(&IO.write(file, &1))
@@ -495,7 +495,7 @@ defmodule Glific.ContactsTest do
 
       count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
 
-      assert count == 1
+      assert count == 0
     end
 
     test "import_contact/3 with valid data from URL inserts new contacts in the database" do
@@ -511,7 +511,7 @@ defmodule Glific.ContactsTest do
         %{method: :get} ->
           %Tesla.Env{
             status: 200,
-            body: "name,phone,Language,opt_in\ntest,9989329297,english,2021-03-09 12:34:25\n"
+            body: "name,phone,Language,opt_in\ntest,+919876543210,english,2021-03-09 12:34:25\n"
           }
       end)
 
@@ -550,7 +550,7 @@ defmodule Glific.ContactsTest do
         %{method: :get} ->
           %Tesla.Env{
             status: 200,
-            body: "name,phone,Language,opt_in\ntest,9989329297,english,2021-03-09 12:34:25\n"
+            body: "name,phone,Language,opt_in\ntest,+919876543210,english,2021-03-09 12:34:25\n"
           }
       end)
 
@@ -1467,7 +1467,7 @@ defmodule Glific.ContactsTest do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
-      data = "name,phone,Language,opt_in\nName,9989329297,klingon,2021-03-09 12:34:25\n"
+      data = "name,phone,Language,opt_in\nName,+919989329297,klingon,2021-03-09 12:34:25\n"
 
       [organization | _] = Partners.list_organizations()
 
@@ -1490,7 +1490,7 @@ defmodule Glific.ContactsTest do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
-      data = "name,phone,language,opt_in\nName,9989329297,Hindi,2021-03-09 12:34:25\n"
+      data = "name,phone,language,opt_in\nName,+919989329297,Hindi,2021-03-09 12:34:25\n"
 
       [organization | _] = Partners.list_organizations()
 
@@ -1513,7 +1513,7 @@ defmodule Glific.ContactsTest do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
-      data = "name,phone,language,opt_in\nName,9989329297,,2021-03-09 12:34:25\n"
+      data = "name,phone,language,opt_in\nName,+919989329297,,2021-03-09 12:34:25\n"
 
       [organization | _] = Partners.list_organizations()
 

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -474,7 +474,7 @@ defmodule Glific.ContactsTest do
       assert count == 1
     end
 
-    test "import_contact/3 with invalid data from file inserts new contacts without +prefix in the database" do
+    test "import_contact/3 does not insert contacts without country code prefix"do
       file = get_tmp_file()
 
       [

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -1417,7 +1417,7 @@ defmodule Glific.ContactsTest do
       assert count == 0
     end
 
-    test "import_contact/3 with valid phone number without country code should be accepted" do
+    test "import_contact/3 with valid phone number without + prefix should be accepted" do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
@@ -1440,7 +1440,7 @@ defmodule Glific.ContactsTest do
       assert count == 1
     end
 
-    test "import_contact/3 with valid phone number with country code should be accepted" do
+    test "import_contact/3 with valid phone number with + prefix should be accepted" do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -499,7 +499,7 @@ defmodule Glific.ContactsTest do
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :default, with_scheduled: true)
 
-      count = Contacts.count_contacts(%{filter: %{name: "test"}})
+      count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
 
       assert count == 0
     end

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -478,7 +478,7 @@ defmodule Glific.ContactsTest do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
-      data = "name,phone,Language,opt_in\ncontact_test,9989329297,english,2021-03-09 12:34:25\n"
+      data = "name,phone,Language,opt_in\ncontact_test,+919989329297,english,2021-03-09 12:34:25\n"
 
       [organization | _] = Partners.list_organizations()
 
@@ -493,9 +493,9 @@ defmodule Glific.ContactsTest do
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :default, with_scheduled: true)
 
-      count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
+      count = Contacts.count_contacts(%{filter: %{phone: "+919989329297"}})
 
-      assert count == 0
+      assert count == 1
     end
 
     test "import_contact/3 with valid data from URL inserts new contacts in the database" do

--- a/test/glific_web/schema/contact_test.exs
+++ b/test/glific_web/schema/contact_test.exs
@@ -321,7 +321,7 @@ defmodule GlificWeb.Schema.ContactTest do
     end)
 
     test_name = "test2"
-    test_phone = "919917443992"
+    test_phone = "+919917443992"
 
     data =
       "name,phone,language,opt_in,collection\n#{test_name},#{test_phone},english,2021-03-09 12:34:25,collection"
@@ -391,7 +391,7 @@ defmodule GlificWeb.Schema.ContactTest do
       %{method: :get} ->
         %Tesla.Env{
           body:
-            "name,phone,Language,opt_in,delete,collection\r\nuploaded_contact,9876543311,english,2021-03-09 12:34:25,,collection",
+            "name,phone,Language,opt_in,delete,collection\r\nuploaded_contact,+919876543211,english,2021-03-09 12:34:25,,collection",
           status: 200
         }
     end)
@@ -426,7 +426,7 @@ defmodule GlificWeb.Schema.ContactTest do
 
     [
       ~w(name phone Language opt_in collection),
-      ["test", "9989329297", "english", "2021-03-09 12:34:25", "collection"]
+      ["test", "+919876543210", "english", "2021-03-09 12:34:25", "collection"]
     ]
     |> CSV.encode()
     |> Enum.each(&IO.write(file, &1))
@@ -465,7 +465,7 @@ defmodule GlificWeb.Schema.ContactTest do
 
     [
       ~w(name phone Language opt_in collection),
-      ["test", "9989329297", "english", "2021-03-09 12:34:25", "collection"]
+      ["test", "+91989329297", "english", "2021-03-09 12:34:25", "collection"]
     ]
     |> CSV.encode()
     |> Enum.each(&IO.write(file, &1))
@@ -500,7 +500,7 @@ defmodule GlificWeb.Schema.ContactTest do
 
     [
       ~w(name phone language opt_in delete collection),
-      ["test", "9989329297", "english", "2021-03-09 12:34:25", "0", "collection"]
+      ["test", "+919989329297", "english", "2021-03-09 12:34:25", "0", "collection"]
     ]
     |> CSV.encode()
     |> Enum.each(&IO.write(file, &1))


### PR DESCRIPTION
**## Summary**
Target issue is https://github.com/glific/glific/issues/4132

**Problem**
Right now the system adds an entry to the contact table even if the number doesn't have a required prefix like +91 for ex. This create confusion to users when the message doesn't get delivered to these invalid numbers.

**Solution**
Used the following logic to ensure phone numbers are parsed correctly by ExPhoneNumber:

- phone_with_plus = if String.starts_with?(phone, "+"), do: phone, else: "+#{phone}"

- ExPhoneNumber.parse(phone_with_plus, "")

This ensures that all phone numbers are passed to the parser in a standard international format (E.164), improving validation accuracy and preventing parse errors.
## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced phone number validation during contact import to correctly handle and validate country code prefixes.

- **Tests**
  - Added tests confirming successful import of contacts with valid phone numbers both with and without explicit country code prefixes.
  - Updated existing tests to consistently use internationally formatted phone numbers with a plus sign.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->