### PR TITLE
Show Reason for Google Sync Failure in Notification

### DIFF
--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -210,7 +210,7 @@ defmodule Glific.Sheets do
             "Error while syncing google sheet, org id: #{sheet.organization_id}, sheet_id: #{sheet.id} due to #{inspect(err)}"
           )
 
-          create_sync_fail_notification(sheet)
+          create_sync_fail_notification(sheet, inspect(err))
           {:halt, Map.put(acc, export_url, err)}
       end)
 
@@ -397,16 +397,16 @@ defmodule Glific.Sheets do
             "Error while syncing google sheet, org id: #{sheet.organization_id}, sheet_id: #{sheet.id} due to #{inspect(err)}"
           )
 
-          create_sync_fail_notification(sheet)
+          create_sync_fail_notification(sheet, inspect(err))
       end
     end)
   end
 
-  @spec create_sync_fail_notification(Sheet.t()) :: :ok
-  defp create_sync_fail_notification(sheet) do
+  @spec create_sync_fail_notification(Sheet.t(), String.t()) :: :ok
+  defp create_sync_fail_notification(sheet, error_reason) do
     Notifications.create_notification(%{
       category: "Google sheets",
-      message: "Google sheet sync failed",
+      message: "Google sheet sync failed: #{error_reason}",
       severity: Notifications.types().warning,
       organization_id: sheet.organization_id,
       entity: %{url: sheet.url, id: sheet.id, name: sheet.label}


### PR DESCRIPTION

## Summary
Target issue is https://github.com/glific/glific/issues/4164  

**Problem**

Currently, when a Google Sheet sync fails, the system sends a generic notification saying that the sync failed — but it does not include the reason for failure. This makes it difficult for users to troubleshoot issues or understand what went wrong.

**Solution**

This PR enhances the sync failure notification by including the specific error message received from the Google Sheets API.

- Extracts the error message from the API response.
- Displays the detailed reason in the user-facing notification.
- Helps users quickly identify and resolve sync issues without relying on internal logs.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error notifications for Google Sheets synchronization failures by including specific error reasons in the notification messages. End-users will now see more detailed messages when a sync fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->