### PR TITLE
Google sheet: Trimming only binary values

### DIFF
--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -242,9 +242,9 @@ defmodule Glific.Sheets do
           key
           |> String.downcase()
           |> String.replace(" ", "_")
-          |> trim_string()
+          |> trim_value()
 
-        Map.put(acc, key, value |> trim_string())
+        Map.put(acc, key, value |> trim_value())
       end)
 
     errors =
@@ -415,10 +415,12 @@ defmodule Glific.Sheets do
     :ok
   end
 
-  @spec trim_string(String.t()) :: String.t()
-  defp trim_string(str) do
-    str
+  @spec trim_value(any()) :: any()
+  defp trim_value(value) when is_binary(value) do
+    value
     |> String.trim()
     |> String.replace(@invisible_unicode_range, "")
   end
+
+  defp trim_value(value), do: value
 end

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -474,7 +474,7 @@ defmodule Glific.ContactsTest do
       assert count == 1
     end
 
-    test "import_contact/3 does not insert contacts without country code prefix"do
+    test "import_contact/3 does not insert contacts without country code prefix" do
       file = get_tmp_file()
 
       [
@@ -508,7 +508,8 @@ defmodule Glific.ContactsTest do
       {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
       user = Map.put(user, :roles, [:admin])
 
-      data = "name,phone,Language,opt_in\ncontact_test,+919989329297,english,2021-03-09 12:34:25\n"
+      data =
+        "name,phone,Language,opt_in\ncontact_test,+919989329297,english,2021-03-09 12:34:25\n"
 
       [organization | _] = Partners.list_organizations()
 

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -164,6 +164,7 @@ defmodule Glific.SheetsTest do
 
       assert h.row_data["key"] == "apple"
       assert h.row_data["val"] == "3"
+      assert h.row_data[""] == ["3", "4"]
     end
 
     test "create_sheet/1, Handling case where multiple headers having same name", %{
@@ -188,6 +189,7 @@ defmodule Glific.SheetsTest do
 
       assert h.row_data["key"] == "apple"
       assert h.row_data["val"] == "3"
+      assert h.row_data["same"] == ["3", "2"]
     end
   end
 end

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -141,5 +141,53 @@ defmodule Glific.SheetsTest do
       assert t2.row_data["key"] == "1/10/2026"
       assert t2.row_data["message_english"] == "Hi welcome to Glific 4"
     end
+
+    test "create_sheet/1, Handling case where some column having no headers", %{
+      organization_id: organization_id
+    } do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{
+            status: 200,
+            body: "Key,Val,,\r\napple,3,3,4"
+          }
+      end)
+
+      attrs = Map.merge(@valid_attrs, %{organization_id: organization_id})
+
+      assert {:ok, %Sheet{} = sheet} = Sheets.create_sheet(attrs)
+
+      [h | _] =
+        SheetData
+        |> where([sd], sd.sheet_id == ^sheet.id)
+        |> Repo.all([])
+
+      assert h.row_data["key"] == "apple"
+      assert h.row_data["val"] == "3"
+    end
+
+    test "create_sheet/1, Handling case where multiple headers having same name", %{
+      organization_id: organization_id
+    } do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{
+            status: 200,
+            body: "Key,Val,same,samed,same\r\napple,3,3,4,2"
+          }
+      end)
+
+      attrs = Map.merge(@valid_attrs, %{organization_id: organization_id})
+
+      assert {:ok, %Sheet{} = sheet} = Sheets.create_sheet(attrs)
+
+      [h | _] =
+        SheetData
+        |> where([sd], sd.sheet_id == ^sheet.id)
+        |> Repo.all([])
+
+      assert h.row_data["key"] == "apple"
+      assert h.row_data["val"] == "3"
+    end
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #4223  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of data with mixed types by ensuring that whitespace and invisible characters are only trimmed from string values, preventing errors when processing non-string values.
- **Tests**
  - Added new tests to verify correct processing of CSV data with empty or duplicate header columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->