### PR TITLE
4191 Enable save-result-flow node for WA Groups

### DIFF
--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -678,6 +678,28 @@ defmodule Glific.Flows.Action do
     WAGroupAction.send_message(context, action, messages)
   end
 
+  def execute(%{type: "set_run_result"} = action, context, messages) do
+    value =
+      context
+      |> FlowContext.parse_context_string(action.value)
+      |> Glific.execute_eex()
+
+    category =
+      context
+      |> FlowContext.parse_context_string(action.category)
+
+    results = %{
+      "input" => value,
+      "value" => value,
+      "category" => category,
+      "inserted_at" => DateTime.utc_now()
+    }
+
+    updated_context = FlowContext.update_results(context, %{action.name => results})
+
+    {:ok, updated_context, messages}
+  end
+
   def execute(action, %{wa_group_id: wa_group_id} = context, messages)
       when wa_group_id != nil do
     Logger.error(
@@ -937,28 +959,6 @@ defmodule Glific.Flows.Action do
     end
 
     {:ok, context, messages}
-  end
-
-  def execute(%{type: "set_run_result"} = action, context, messages) do
-    value =
-      context
-      |> FlowContext.parse_context_string(action.value)
-      |> Glific.execute_eex()
-
-    category =
-      context
-      |> FlowContext.parse_context_string(action.category)
-
-    results = %{
-      "input" => value,
-      "value" => value,
-      "category" => category,
-      "inserted_at" => DateTime.utc_now()
-    }
-
-    updated_context = FlowContext.update_results(context, %{action.name => results})
-
-    {:ok, updated_context, messages}
   end
 
   def execute(%{type: type} = _action, context, [msg])

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -809,7 +809,7 @@ defmodule Glific.Flows.ActionTest do
       results: %{"result1" => "shyness"}
     }
 
-    # preload contact
+    # preload wa_group
     {:ok, context} = FlowContext.create_flow_context(context_attrs)
     set_run_result_context = Repo.preload(context, [:flow, :wa_group])
 

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -797,6 +797,42 @@ defmodule Glific.Flows.ActionTest do
     assert updated_context.results["video_code"]["value"] == "shyness"
   end
 
+  test "execute an action for WA Group when type is set_run_result", attrs do
+    [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
+    [flow | _tail] = Flows.list_flows(%{filter: attrs})
+
+    context_attrs = %{
+      flow_id: flow.id,
+      flow_uuid: Ecto.UUID.generate(),
+      wa_group_id: wa_group.id,
+      organization_id: attrs.organization_id,
+      results: %{"result1" => "shyness"}
+    }
+
+    # preload contact
+    {:ok, context} = FlowContext.create_flow_context(context_attrs)
+    set_run_result_context = Repo.preload(context, [:flow, :wa_group])
+
+    set_run_result_action = %Action{
+      uuid: "UUID 1",
+      node_uuid: "Test UUID",
+      type: "set_run_result",
+      name: "video_code",
+      value: "@results.result1",
+      category: "Video",
+      flow: %{
+        "name" => flow.name,
+        "uuid" => flow.uuid
+      }
+    }
+
+    result = Action.execute(set_run_result_action, set_run_result_context, [])
+    assert {:ok, updated_context, _updated_message_stream} = result
+
+    assert updated_context.results["video_code"]["category"] == "Video"
+    assert updated_context.results["video_code"]["value"] == "shyness"
+  end
+
   test "execute an action when type is set_contact_name", _attrs do
     contact = Repo.get_by(Contact, %{name: "Default receiver"})
 


### PR DESCRIPTION

## Summary
 Target issue is #4191  

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing


## Notes
 Please add here if any other information is required for the reviewer. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Eliminated duplicate handling of "set_run_result" actions to ensure consistent execution and accurate result storage.

- **Tests**
  - Added a test verifying "set_run_result" actions function correctly within WhatsApp Group contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->