### PR TITLE
Add is_active to Profile GraphQL Return Type

### DIFF
--- a/assets/gql/profiles/list.gql
+++ b/assets/gql/profiles/list.gql
@@ -4,5 +4,6 @@ query profiles ($filter: ProfileFilter, $opts: Opts) {
     name
     fields
     is_active
+    is_default
   }
 }

--- a/lib/glific_web/schema/profile_types.ex
+++ b/lib/glific_web/schema/profile_types.ex
@@ -25,6 +25,7 @@ defmodule GlificWeb.Schema.ProfileTypes do
     field :type, :string
     field :fields, :json
     field :is_active, :boolean
+    field :is_default, :boolean
     field :inserted_at, :datetime
     field :updated_at, :datetime
 

--- a/test/glific_web/schema/profile_test.exs
+++ b/test/glific_web/schema/profile_test.exs
@@ -134,7 +134,7 @@ defmodule GlificWeb.Schema.ProfileTest do
     assert {:ok, query_data} = result
     assert length(get_in(query_data, [:data, "profiles"])) == 1
 
-    # returns the is_active field
+    # returns the is_active and is_default fields
 
     result =
       auth_query_gql_by(:list, user,
@@ -147,6 +147,7 @@ defmodule GlificWeb.Schema.ProfileTest do
 
     [profile | _] = get_in(query_data, [:data, "profiles"])
     assert profile["is_active"] == true
+    assert profile["is_default"] == false
 
     result =
       auth_query_gql_by(:list, user,


### PR DESCRIPTION

## Summary
 Target issue is #4235



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for activating and deactivating profiles, including tracking active and default profile status.
  - Introduced the ability to filter and display profiles based on their active status in the user interface and via GraphQL.
  - Added a new "Deactivate Profile Flow" to guide users through deactivating a profile.

- **Bug Fixes**
  - Ensured that the default profile cannot be deactivated and that switching profiles after deactivation behaves as expected.

- **Documentation**
  - Updated flow completion and profile documentation to reflect new fields and behaviors.

- **Tests**
  - Added and enhanced tests for profile activation, deactivation, switching, and GraphQL filtering.

- **Chores**
  - Updated database schema to include `is_active` and `is_default` fields for profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->