### PR TITLE
Gupshup: Handling billing webhook changes

### DIFF
--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -194,7 +194,7 @@ defmodule Glific.Providers.Gupshup.Message do
       end
 
     message_conversation = %{
-      deduction_type: deductions["type"],
+      deduction_type: deductions["category"],
       is_billable: deductions["billable"],
       conversation_id: references["conversationId"],
       payload: params,

--- a/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/billing_event_controller.ex
@@ -31,7 +31,10 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventController do
   """
   @spec handle_billing_event(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def handle_billing_event(conn, params) do
-    with {:ok, message_conversation} <- Gupshup.Message.receive_billing_event(params) do
+    # Since we only get non-nil conversationId on free-entry messages, we only have to
+    # add entries where conversationId is not nil.
+    with {:ok, message_conversation} <- Gupshup.Message.receive_billing_event(params),
+         false <- is_nil(message_conversation.conversation_id) do
       message_conversation
       |> Map.put(:organization_id, conn.assigns[:organization_id])
       |> MessageConversations.create_message_conversation()

--- a/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
@@ -73,7 +73,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
           &Map.update(@billing_event_request_params, "payload", &1, fn _ ->
             %{
               "references" => &1,
-              "deductions" => @billing_event_request_params["payload"]["references"]
+              "deductions" => @billing_event_request_params["payload"]["deductions"]
             }
           end)
         )

--- a/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
+++ b/test/glific_web/providers/gupshup/controllers/billing_event_controller_test.exs
@@ -17,7 +17,8 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
         "billable" => true,
         "model" => "CBP",
         "source" => "whatsapp",
-        "type" => "UIC"
+        "type" => "regular",
+        "category" => "marketing"
       },
       "references" => %{
         "conversationId" => "c3dcdb2f4f227931248cc080c387e484",
@@ -40,7 +41,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
   end
 
   describe "status" do
-    test "handler should return nil data", %{conn: conn} do
+    test "When there is non-nil conversation_id", %{conn: conn} do
       [message | _] = Messages.list_messages(%{})
       contact = Contacts.get_contact!(message.contact_id)
 
@@ -58,8 +59,34 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.BillingEventControllerTest do
         })
 
       assert message_conversation.is_billable == true
-      assert message_conversation.deduction_type == "UIC"
+      assert message_conversation.deduction_type == "marketing"
       assert message_conversation.message_id == message.id
+    end
+
+    test "When conversation_id is nil", %{conn: conn} do
+      [message | _] = Messages.list_messages(%{})
+      contact = Contacts.get_contact!(message.contact_id)
+
+      billing_event_params =
+        Map.delete(@billing_event_request_params["payload"]["references"], "conversationId")
+        |> then(
+          &Map.update(@billing_event_request_params, "payload", &1, fn _ ->
+            %{
+              "references" => &1,
+              "deductions" => @billing_event_request_params["payload"]["references"]
+            }
+          end)
+        )
+        |> put_in(["payload", "references", "destination"], contact.phone)
+        |> put_in(["payload", "references", "gsId"], message.bsp_message_id)
+
+      conn = post(conn, "/gupshup", billing_event_params)
+      assert response(conn, 200) == ""
+
+      {:error, ["Elixir.Glific.Messages.MessageConversation", "Resource not found"]} =
+        Repo.fetch_by(MessageConversation, %{
+          conversation_id: "c3dcdb2f4f227931248cc080c387e484"
+        })
     end
   end
 end


### PR DESCRIPTION

## Summary
 Target issue is #4234   
According to [doc](https://support.gupshup.io/hc/en-us/articles/47379153369113-Gupshup-PMP-per-message-pricing-related-changes-for-July-2025), we will be using deduction.category for deduction_type in message_conversations and we only insert to DB if conversationId is nil.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of billing events by processing only those with a valid conversation ID.
  - Updated deduction type extraction to use the "category" field from billing event data.

- **Tests**
  - Enhanced test coverage to include scenarios with missing conversation ID.
  - Updated test data to reflect changes in billing event payload structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->