### PR TITLE
docs:Updated the HTTP link to SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Tested with Postgres versions:
 ## 2. Clone Backend Repository
 
 ```bash
-git clone https://github.com/glific/glific
+git clone git@github.com:glific/glific.git
 ```
 
 ## 3. Install certificate - Use SSL for frontend and backend


### PR DESCRIPTION

## Summary

This pull request updates the Git clone URL in the documentation from HTTPS to SSH format. Using the SSH URL helps developers with SSH keys avoid repeated authentication prompts and improves security when working with private repositories.




