### PR TITLE
Onboarding: Deleting seed migrations if already exists

### DIFF
--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -558,8 +558,8 @@ defmodule Glific.Saas.Queries do
   defp delete_migration_if_exists(tenant) do
     query =
       from schema in "schema_seeds",
-        where: schema.tenant == ^tenant,
-        select: %{version: schema.version}
+        where: schema.tenant == ^tenant
+        # select: %{version: schema.version}
 
     Repo.delete_all(query, skip_organization_id: true)
   end

--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -104,6 +104,7 @@ defmodule Glific.Saas.Queries do
   @spec seed_data(map()) :: map()
 
   def seed_data(%{organization: organization} = results) when is_map(organization) do
+    delete_migration_if_exists(organization.shortcode)
     Seeder.seed(tenant: organization.shortcode, tenant_id: organization.id)
     results
   end
@@ -549,4 +550,14 @@ defmodule Glific.Saas.Queries do
   end
 
   defp validate_true(results, _, _key), do: results
+
+  @spec delete_migration_if_exists(String.t()) :: any()
+  defp delete_migration_if_exists(tenant) do
+    query =
+      from schema in "schema_seeds",
+        where: schema.tenant == ^tenant,
+        select: %{version: schema.version}
+
+    Repo.delete_all(query, skip_organization_id: true)
+  end
 end

--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -559,7 +559,6 @@ defmodule Glific.Saas.Queries do
     query =
       from schema in "schema_seeds",
         where: schema.tenant == ^tenant
-        # select: %{version: schema.version}
 
     Repo.delete_all(query, skip_organization_id: true)
   end

--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -104,6 +104,9 @@ defmodule Glific.Saas.Queries do
   @spec seed_data(map()) :: map()
 
   def seed_data(%{organization: organization} = results) when is_map(organization) do
+    # Sometime we delete an org and create new org with the same previous shortcode.
+    # But seeding won't work for the new org, since its already done(seeding is based on shortcode).
+    # so we delete existing migrations in that case.
     delete_migration_if_exists(organization.shortcode)
     Seeder.seed(tenant: organization.shortcode, tenant_id: organization.id)
     results

--- a/priv/gettext/error.pot
+++ b/priv/gettext/error.pot
@@ -11,43 +11,43 @@
 msgid ""
 msgstr ""
 
-#: lib/glific/saas/queries.ex:342
+#: lib/glific/saas/queries.ex:346
 #, elixir-autogen, elixir-format
 msgid "API Key or App Name is empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:471
+#: lib/glific/saas/queries.ex:475
 #, elixir-autogen, elixir-format
 msgid "Billing frequency cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:382
+#: lib/glific/saas/queries.ex:386
 #, elixir-autogen, elixir-format
 msgid "Email is not valid."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:136
-#: lib/glific/saas/queries.ex:158
+#: lib/glific/saas/queries.ex:140
+#: lib/glific/saas/queries.ex:162
 #, elixir-autogen, elixir-format
 msgid "Field cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:547
+#: lib/glific/saas/queries.ex:551
 #, elixir-autogen, elixir-format
 msgid "Field cannot be false."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:162
+#: lib/glific/saas/queries.ex:166
 #, elixir-autogen, elixir-format
 msgid "Field cannot be less than %{length} letters."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:169
+#: lib/glific/saas/queries.ex:173
 #, elixir-autogen, elixir-format
 msgid "Field cannot be more than %{length} letters."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:394
+#: lib/glific/saas/queries.ex:398
 #, elixir-autogen, elixir-format
 msgid "Phone is not valid."
 msgstr ""
@@ -62,17 +62,17 @@ msgstr ""
 msgid "Registration doesn't exist for given registration ID."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:360
+#: lib/glific/saas/queries.ex:364
 #, elixir-autogen, elixir-format
 msgid "Shortcode cannot be empty."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:367
+#: lib/glific/saas/queries.ex:371
 #, elixir-autogen, elixir-format
 msgid "Shortcode has already been taken."
 msgstr ""
 
-#: lib/glific/saas/queries.ex:475
+#: lib/glific/saas/queries.ex:479
 #, elixir-autogen, elixir-format
 msgid "Value should be one of Monthly , Quarterly, Half-Yearly, Annually."
 msgstr ""

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -19,6 +19,8 @@ defmodule Glific.OnboardTest do
     Seeds.SeedsDev
   }
 
+  import Ecto.Query
+
   @valid_attrs %{
     "name" => "First",
     "phone" => "+911234567890",
@@ -734,7 +736,12 @@ defmodule Glific.OnboardTest do
     assert result.organization.name == "First"
     assert result.organization.shortcode == "new_glific"
 
-    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    simulator_contacts =
+      Contacts.list_contacts(%{
+        filter: %{term: "Glific"},
+        organization_id: result.organization.id
+      })
+
     assert length(simulator_contacts) > 0
 
     {:ok, _} =
@@ -746,7 +753,12 @@ defmodule Glific.OnboardTest do
     assert result.organization.shortcode == "new_glific"
 
     # if we don't delete the existing migration, length of simulator_contacts here will be 0
-    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    simulator_contacts =
+      Contacts.list_contacts(%{
+        filter: %{term: "Glific"},
+        organization_id: result.organization.id
+      })
+
     assert length(simulator_contacts) > 0
   end
 

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -7,6 +7,7 @@ defmodule Glific.OnboardTest do
   alias Faker.Phone
 
   alias Glific.{
+    Contacts,
     Fixtures,
     Mails.NewPartnerOnboardedMail,
     Partners,
@@ -719,5 +720,66 @@ defmodule Glific.OnboardTest do
       |> Map.put("phone", "919917443995")
 
     assert %{is_valid: false} = Onboard.setup(attrs)
+  end
+
+  test "Seeding works even if we are creating a new org with an already present shortcode in seed migration" do
+    attrs =
+      @valid_attrs
+      |> Map.put("name", " First")
+      |> Map.put("shortcode", "NEW_Glific")
+      |> Map.put("phone", "919917443995")
+
+    result = Onboard.setup(attrs)
+
+    assert result.organization.name == "First"
+    assert result.organization.shortcode == "new_glific"
+
+    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    assert length(simulator_contacts) > 0
+
+    {:ok, _} =
+      Partners.get_organization!(result.organization.id) |> Partners.delete_organization()
+
+    result = Onboard.setup(attrs)
+
+    assert result.organization.name == "First"
+    assert result.organization.shortcode == "new_glific"
+
+    # if we don't delete the existing migration, length of simulator_contacts here will be 0
+    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    assert length(simulator_contacts) > 0
+  end
+
+  test "We don't delete the existing migrations if shortcode doesnt exist" do
+    attrs =
+      @valid_attrs
+      |> Map.put("name", " First")
+      |> Map.put("shortcode", "NEW_Glific")
+      |> Map.put("phone", "919917443995")
+
+    result = Onboard.setup(attrs)
+
+    assert result.organization.name == "First"
+    assert result.organization.shortcode == "new_glific"
+
+    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    assert length(simulator_contacts) > 0
+
+    result = Onboard.setup(attrs |> Map.merge(%{"shortcode" => "glific_b"}))
+
+    assert result.organization.name == "First"
+    assert result.organization.shortcode == "glific_b"
+
+    # if we don't delete the existing migration, length of simulator_contacts here will be 0
+    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
+    assert length(simulator_contacts) > 0
+
+    query =
+      from schema in "schema_seeds",
+        where: schema.tenant == "new_glific",
+        select: %{version: schema.version}
+
+    # making sure that migrations are still there for new_glific
+    assert length(Repo.all(query, skip_organization_id: true)) > 0
   end
 end

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -19,8 +19,6 @@ defmodule Glific.OnboardTest do
     Seeds.SeedsDev
   }
 
-  import Ecto.Query
-
   @valid_attrs %{
     "name" => "First",
     "phone" => "+911234567890",

--- a/test/glific/partners/onboard_test.exs
+++ b/test/glific/partners/onboard_test.exs
@@ -762,17 +762,10 @@ defmodule Glific.OnboardTest do
     assert result.organization.name == "First"
     assert result.organization.shortcode == "new_glific"
 
-    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
-    assert length(simulator_contacts) > 0
-
     result = Onboard.setup(attrs |> Map.merge(%{"shortcode" => "glific_b"}))
 
     assert result.organization.name == "First"
     assert result.organization.shortcode == "glific_b"
-
-    # if we don't delete the existing migration, length of simulator_contacts here will be 0
-    simulator_contacts = Contacts.list_contacts(%{filter: %{term: "Glific"}})
-    assert length(simulator_contacts) > 0
 
     query =
       from schema in "schema_seeds",


### PR DESCRIPTION

## Summary
 Target issue is  #4047 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of organization seeding to ensure previous migration records are removed when recreating an organization with the same shortcode.

* **Tests**
  * Added tests verifying migration and seeding behavior for organizations created, deleted, and recreated with the same or different shortcodes.

* **Chores**
  * Updated translation file metadata to reflect recent changes in source code line numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->