### PR TITLE
Template status

### DIFF
--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -632,6 +632,9 @@ defmodule Glific.Templates do
   end
 
   defp change_template_status("REJECTED", db_template, bsp_template) do
+    Logger.info(
+      "org_id:#{db_template.organization_id} template:#{db_template.shortcode} bsp_id:#{bsp_template["bsp_id"]} has been REJECTED"
+    )
     Notifications.create_notification(%{
       category: "Templates",
       message: "Template #{db_template.shortcode} has been rejected",
@@ -647,6 +650,28 @@ defmodule Glific.Templates do
 
     %{status: "REJECTED", reason: bsp_template["reason"]}
   end
+
+  defp change_template_status("FAILED", db_template, bsp_template) do
+    Logger.info(
+      "org_id:#{db_template.organization_id} template:#{db_template.shortcode} bsp_id:#{bsp_template["bsp_id"]} has been FAILED"
+    )
+    Notifications.create_notification(%{
+      category: "Templates",
+      message: "Template #{db_template.shortcode} has been failed",
+      severity: Notifications.types().info,
+      organization_id: db_template.organization_id,
+      entity: %{
+        id: db_template.id,
+        shortcode: db_template.shortcode,
+        label: db_template.label,
+        uuid: db_template.uuid
+      }
+    })
+
+    %{status: "FAILED", reason: bsp_template["reason"]}
+  end
+
+
 
   defp change_template_status(status, _db_template, _bsp_template), do: %{status: status}
 

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -592,22 +592,17 @@ defmodule Glific.Templates do
       db_templates[template["bsp_id"]]
 
     update_attrs =
-      if current_template.status != template["status"] do
         change_template_status(template["status"], current_template, template)
         |> Map.put(:category, template["category"])
         |> Map.put(:quality, template["quality"])
-      else
-        %{
-          status: template["status"],
-          category: template["category"],
-          quality: template["quality"]
-        }
-      end
+
 
     update_attrs =
-      if current_template.uuid,
-        do: Map.put(update_attrs, :uuid, current_template.uuid),
-        else: Map.put(update_attrs, :uuid, template["id"])
+      if current_template.uuid do
+        Map.put(update_attrs, :uuid, current_template.uuid)
+      else
+        Map.put(update_attrs, :uuid, template["id"])
+      end
 
     db_templates[template["bsp_id"]]
     |> SessionTemplate.changeset(update_attrs)

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -592,16 +592,16 @@ defmodule Glific.Templates do
       db_templates[template["bsp_id"]]
 
     update_attrs =
+      if current_template.status != template["status"] do
         change_template_status(template["status"], current_template, template)
         |> Map.put(:category, template["category"])
         |> Map.put(:quality, template["quality"])
-
-
-    update_attrs =
-      if current_template.uuid do
-        Map.put(update_attrs, :uuid, current_template.uuid)
       else
-        Map.put(update_attrs, :uuid, template["id"])
+        %{
+          status: template["status"],
+          category: template["category"],
+          quality: template["quality"]
+        }
       end
 
     db_templates[template["bsp_id"]]


### PR DESCRIPTION
**Summary**

- Target issue is #4107
- This pull request addresses an inconsistency in how template failures are handled when interacting with Gupshup.

**Motivation**

- Currently, if a template submission fails on Gupshup's end (i.e., it receives a "FAILED" status), the failure reason is not being saved to the database. As a result: 
- Users do not see any failure reason in the UI for failed templates.
- Notifications are not generated for "FAILED" templates, unlike how we handle "REJECTED" or "APPROVED" statuses.

This leads to a poor user experience and confusion about why a template failed.

**Solution**

- Added handling for the "FAILED" category to ensure the failure reason is persisted in the database when available from Gupshup's response.
- Included logic to trigger notifications for "FAILED" templates, similar to "REJECTED" ones, so users are clearly informed. 

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing
