### PR TITLE
Gid issue

### DIFF
--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -182,11 +182,12 @@ defmodule Glific.Sheets do
     gid_param = uri.fragment
 
     export_url =
-       if gid_param do
-           sheet_url <> "export?format=csv&" <> gid_param
-       else
-           sheet_url <> "export?format=csv"
-       end
+      with gid when is_binary(gid) <- uri.fragment do
+        sheet_url <> "export?format=csv&" <> gid
+      else
+        _ -> sheet_url <> "export?format=csv"
+      end
+
 
 
     SheetData

--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -179,8 +179,15 @@ defmodule Glific.Sheets do
     {:ok, uri} = URI.new(sheet.url)
     # https://developers.google.com/sheets/api/guides/concepts#spreadsheet_id
 
-    gid_params = uri.fragment || "gid=0"
-    export_url = sheet_url <> "export?format=csv&" <> gid_params
+    gid_param = uri.fragment
+
+    export_url =
+       if gid_param do
+           sheet_url <> "export?format=csv&" <> gid_param
+       else
+           sheet_url <> "export?format=csv"
+       end
+
 
     SheetData
     |> where([sd], sd.sheet_id == ^sheet.id)

--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -188,8 +188,6 @@ defmodule Glific.Sheets do
         _ -> sheet_url <> "export?format=csv"
       end
 
-
-
     SheetData
     |> where([sd], sd.sheet_id == ^sheet.id)
     |> Repo.delete_all()


### PR DESCRIPTION

 **Summary**

 Target issue is #https://github.com/glific/glific/issues/4252

This PR fixes a bug where syncing a Google Sheet without a gid in the shared URL causes a failure during CSV export. When such a URL is used, the system previously defaulted to appending gid=0, which results in an HTML error page instead of a proper CSV. This breaks the sync functionality and the CSV parser.

- To address this, we update the export_url logic to: 
- Append the gid only if it is present and is a valid binary.
- Fall back to exporting the first/default sheet when no gid is found.

This makes the integration more robust and ensures syncing works even with basic shareable Google Sheet links.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases. 
- [x] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing



