### PR TITLE
Cascade Delete Contact When Deleting Default Profile

### DIFF
--- a/lib/glific/profiles.ex
+++ b/lib/glific/profiles.ex
@@ -117,12 +117,6 @@ defmodule Glific.Profiles do
 
   """
 
-  # @spec delete_profile(Profile.t()) ::
-  #         {:ok, Profile.t()} | {:error, Ecto.Changeset.t()}
-  # def delete_profile(%Profile{} = profile) do
-  #   Repo.delete(profile)
-  # end
-
   @spec delete_profile(Profile.t()) ::
           {:ok, Profile.t()} | {:error, Ecto.Changeset.t()} | {:error, String.t()}
   def delete_profile(%Profile{} = profile) do

--- a/lib/glific/profiles.ex
+++ b/lib/glific/profiles.ex
@@ -116,10 +116,24 @@ defmodule Glific.Profiles do
       {:error, %Ecto.Changeset{}}
 
   """
+
+  # @spec delete_profile(Profile.t()) ::
+  #         {:ok, Profile.t()} | {:error, Ecto.Changeset.t()}
+  # def delete_profile(%Profile{} = profile) do
+  #   Repo.delete(profile)
+  # end
+
   @spec delete_profile(Profile.t()) ::
-          {:ok, Profile.t()} | {:error, Ecto.Changeset.t()}
+          {:ok, Profile.t()} | {:error, Ecto.Changeset.t()} | {:error, String.t()}
   def delete_profile(%Profile{} = profile) do
-    Repo.delete(profile)
+    case profile.is_default do
+      true ->
+        contact = Repo.preload(profile, :contact).contact
+        Contacts.delete_contact(contact)
+
+      false ->
+        Repo.delete(profile)
+    end
   end
 
   @doc """


### PR DESCRIPTION

## Summary
 Target issue is https://github.com/glific/glific/issues/4193

This change addresses the need to handle deletion of default profiles in a more consistent and user-safe manner. Currently, deleting a default profile only removes the profile, leaving the associated contact intact. Since a default profile is tightly coupled with its contact , it should be treated the same as deleting the contact itself.

This pull request ensures that:

  - When a default profile is deleted, the associated contact is also deleted.
  - When a non-default profile is deleted, only the profile is removed.
 




