### PR TITLE
Add footer to session template

### DIFF
--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -492,6 +492,7 @@ defmodule Glific.Messages do
     message_params = %{
       body: session_template.body,
       type: session_template.type,
+      footer: session_template.footer,
       template_id: session_template.id,
       media_id: session_template.message_media_id,
       sender_id: Partners.organization_contact_id(session_template.organization_id),

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -561,6 +561,7 @@ defmodule Glific.Messages do
       template_id: template_id,
       template_type: session_template.type,
       has_buttons: session_template.has_buttons,
+      footer: session_template.footer,
       params: parameters,
       media_id: media_id,
       is_optin_flow: Map.get(attrs, :is_optin_flow, false),

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -492,7 +492,6 @@ defmodule Glific.Messages do
     message_params = %{
       body: session_template.body,
       type: session_template.type,
-      footer: session_template.footer,
       template_id: session_template.id,
       media_id: session_template.message_media_id,
       sender_id: Partners.organization_contact_id(session_template.organization_id),
@@ -561,7 +560,6 @@ defmodule Glific.Messages do
       template_id: template_id,
       template_type: session_template.type,
       has_buttons: session_template.has_buttons,
-      footer: session_template.footer,
       params: parameters,
       media_id: media_id,
       is_optin_flow: Map.get(attrs, :is_optin_flow, false),

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -469,7 +469,7 @@ defmodule Glific.Providers.Gupshup.Template do
   Add footer to the  template_payload
   """
   @spec attach_footer(map(), map()) :: map()
-  def attach_footer(template_payload, attrs) do
+  defp attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do
       footer when footer in [nil, ""] -> template_payload
       footer -> Map.put(template_payload, :footer, footer)

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -465,6 +465,9 @@ defmodule Glific.Providers.Gupshup.Template do
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
+  @doc """
+  Add footer to the  template_payload
+  """
   @spec attach_footer(map(), map()) :: map()
   def attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -417,10 +417,11 @@ defmodule Glific.Providers.Gupshup.Template do
       category: attrs.category,
       vertical: attrs.label,
       templateType: String.upcase(Atom.to_string(attrs.type)),
-      content: maybe_append_footer(attrs.body, attrs[:footer]),
+      content: attrs.body,
       example: attrs.example,
       enableSample: true
     }
+    |> attach_footer(attrs.footer)
     |> attach_media_params(attrs)
     |> attach_button_param(attrs)
     |> attach_otp_params(attrs)
@@ -464,8 +465,8 @@ defmodule Glific.Providers.Gupshup.Template do
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
-  @spec maybe_append_footer(String.t(), String.t() | nil) :: String.t()
-  def maybe_append_footer(body, nil), do: body
-  def maybe_append_footer(body, ""), do: body
-  def maybe_append_footer(body, footer), do: body <> "\n\n" <> footer
+  @spec attach_footer(map(), String.t() | nil) :: map()
+  def attach_footer(template_payload, ""), do: template_payload
+  def attach_footer(template_payload, nil), do: template_payload
+  def attach_footer(template_payload, footer), do: Map.put(template_payload, :footer, footer)
 end

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -417,7 +417,7 @@ defmodule Glific.Providers.Gupshup.Template do
       category: attrs.category,
       vertical: attrs.label,
       templateType: String.upcase(Atom.to_string(attrs.type)),
-      content: attrs.body,
+      content: maybe_append_footer(attrs.body, attrs[:footer]),
       example: attrs.example,
       enableSample: true
     }
@@ -463,4 +463,9 @@ defmodule Glific.Providers.Gupshup.Template do
   end
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
+
+  @spec maybe_append_footer(String.t(), String.t() | nil) :: String.t()
+  def maybe_append_footer(body, nil), do: body
+  def maybe_append_footer(body, ""), do: body
+  def maybe_append_footer(body, footer), do: body <> "\n\n" <> footer
 end

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -468,8 +468,7 @@ defmodule Glific.Providers.Gupshup.Template do
   @spec attach_footer(map(), String.t() | nil) :: map()
   def attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do
-      "" -> template_payload
-      nil -> template_payload
+      footer when footer in [nil, ""] -> template_payload
       footer -> Map.put(template_payload, :footer, footer)
     end
   end

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -465,7 +465,7 @@ defmodule Glific.Providers.Gupshup.Template do
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
-  @spec attach_footer(map(), map() | nil) :: map()
+  @spec attach_footer(map(), map()) :: map()
   def attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do
       footer when footer in [nil, ""] -> template_payload

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -465,7 +465,7 @@ defmodule Glific.Providers.Gupshup.Template do
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
-  @spec attach_footer(map(), String.t() | nil) :: map()
+  @spec attach_footer(map(), map() | nil) :: map()
   def attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do
       footer when footer in [nil, ""] -> template_payload

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -421,7 +421,7 @@ defmodule Glific.Providers.Gupshup.Template do
       example: attrs.example,
       enableSample: true
     }
-    |> attach_footer(attrs.footer)
+    |> attach_footer(attrs)
     |> attach_media_params(attrs)
     |> attach_button_param(attrs)
     |> attach_otp_params(attrs)
@@ -466,7 +466,11 @@ defmodule Glific.Providers.Gupshup.Template do
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
   @spec attach_footer(map(), String.t() | nil) :: map()
-  def attach_footer(template_payload, ""), do: template_payload
-  def attach_footer(template_payload, nil), do: template_payload
-  def attach_footer(template_payload, footer), do: Map.put(template_payload, :footer, footer)
+  def attach_footer(template_payload, attrs) do
+    case Map.get(attrs, :footer) do
+      "" -> template_payload
+      nil -> template_payload
+      footer -> Map.put(template_payload, :footer, footer)
+    end
+  end
 end

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -465,9 +465,6 @@ defmodule Glific.Providers.Gupshup.Template do
 
   defp attach_otp_params(template_payload, _attrs), do: template_payload
 
-  @doc """
-  Add footer to the  template_payload
-  """
   @spec attach_footer(map(), map()) :: map()
   defp attach_footer(template_payload, attrs) do
     case Map.get(attrs, :footer) do

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -230,19 +230,25 @@ defmodule Glific.Templates do
   @spec validate_template_length(map()) :: :ok | {:error, [String.t()]}
   defp validate_template_length(%{body: body} = attrs) do
     buttons = Map.get(attrs, :buttons, [])
+    footer = Map.get(attrs, :footer, "")
 
     total_length =
       String.length(body || "") +
-        calculate_buttons_length(buttons)
+        calculate_buttons_length(buttons) +
+        String.length(footer)
 
-    if Enum.any?(buttons, fn %{"text" => text} -> String.length(text || "") > 20 end) do
-      {:error, ["Button Validation", "Buttons text cannot be greater than 20"]}
-    else
-      if total_length <= 1024 do
+    cond do
+      Enum.any?(buttons, fn %{"text" => text} -> String.length(text || "") > 20 end) ->
+        {:error, ["Button Validation", "Buttons text cannot be greater than 20"]}
+
+      String.length(footer) > 60 ->
+        {:error, ["Footer Validation", "Footer text cannot be greater than 60 characters"]}
+
+      total_length <= 1024 ->
         :ok
-      else
+
+      true ->
         {:error, ["Character Limit", "Exceeding character limit"]}
-      end
     end
   end
 

--- a/lib/glific/templates/session_templates.ex
+++ b/lib/glific/templates/session_templates.ex
@@ -21,6 +21,7 @@ defmodule Glific.Templates.SessionTemplate do
           body: String.t() | nil,
           type: String.t() | nil,
           shortcode: String.t() | nil,
+          footer: String.t() | nil,
           status: String.t() | nil,
           is_hsm: boolean(),
           number_parameters: non_neg_integer | nil,
@@ -77,7 +78,8 @@ defmodule Glific.Templates.SessionTemplate do
     :buttons,
     :bsp_id,
     :reason,
-    :quality
+    :quality,
+    :footer
   ]
 
   schema "session_templates" do
@@ -87,6 +89,7 @@ defmodule Glific.Templates.SessionTemplate do
     field(:type, MessageType)
     field(:shortcode, :string)
     field(:quality, :string)
+    field(:footer, :string)
 
     field(:status, :string)
     field(:is_hsm, :boolean, default: false)

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -57,6 +57,7 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :buttons, :json
     field :reason, :string
     field :quality, :string
+    field :footer, :string
 
     field :inserted_at, :datetime
     field :updated_at, :datetime
@@ -124,6 +125,9 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
 
     @desc "a static date range input field which will apply on updated at column."
     field(:date_range, :date_range_input)
+
+    @desc "Match the footer"
+    field(:footer, :string)
   end
 
   input_object :session_template_input do
@@ -143,6 +147,7 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :has_buttons, :boolean
     field :button_type, :template_button_type_enum
     field :buttons, :json
+    field :footer, :string
   end
 
   input_object :edit_approved_template_input do

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -125,9 +125,6 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
 
     @desc "a static date range input field which will apply on updated at column."
     field(:date_range, :date_range_input)
-
-    @desc "Match the footer"
-    field(:footer, :string)
   end
 
   input_object :session_template_input do

--- a/priv/repo/migrations/20250716033709_add_footer_to_session_templates.exs
+++ b/priv/repo/migrations/20250716033709_add_footer_to_session_templates.exs
@@ -1,0 +1,9 @@
+defmodule Glific.Repo.Migrations.AddFooterToSessionTemplates do
+  use Ecto.Migration
+
+  def change do
+    alter table(:session_templates) do
+      add :footer, :string
+    end
+  end
+end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2220,6 +2220,7 @@ defmodule Glific.TemplatesTest do
           "data" => "Your train ticket no. {{1}}",
           "elementName" => "ticket_update_status",
           "id" => whatspp_hsm_uuid,
+          "footer" => "footer",
           "languageCode" => "en",
           "languagePolicy" => "deterministic",
           "master" => true,

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2206,4 +2206,18 @@ defmodule Glific.TemplatesTest do
              "Template conference_ticket_status has been failed"
            ] = messages
   end
+
+  test "create_session_template/1 with footer adds it to the template", attrs do
+    language = language_fixture()
+
+    new_attrs =
+      attrs
+      |> Map.merge(@valid_attrs)
+      |> Map.merge(%{language_id: language.id, footer: "footer"})
+
+    assert {:ok, %SessionTemplate{} = session_template_data} =
+             Templates.create_session_template(new_attrs)
+
+    assert session_template_data.footer == "footer"
+  end
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2220,7 +2220,6 @@ defmodule Glific.TemplatesTest do
           "data" => "Your train ticket no. {{1}}",
           "elementName" => "ticket_update_status",
           "id" => whatspp_hsm_uuid,
-          "footer" => "footer",
           "languageCode" => "en",
           "languagePolicy" => "deterministic",
           "master" => true,

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2208,16 +2208,61 @@ defmodule Glific.TemplatesTest do
   end
 
   test "attach_footer adds the footer to the template if provided", attrs do
+    whatspp_hsm_uuid = "16e84186-97fa-454e-ac3b-8c9b94e53b4b"
+
+    body =
+      Jason.encode!(%{
+        "status" => "success",
+        "token" => "new_partner_token",
+        "template" => %{
+          "category" => "ACCOUNT_UPDATE",
+          "createdOn" => 1_595_904_220_495,
+          "data" => "Your train ticket no. {{1}}",
+          "elementName" => "ticket_update_status",
+          "id" => whatspp_hsm_uuid,
+          "languageCode" => "en",
+          "languagePolicy" => "deterministic",
+          "master" => true,
+          "meta" => "{\"example\":\"Your train ticket no. [1234]\"}",
+          "modifiedOn" => 1_595_904_220_495,
+          "status" => "PENDING",
+          "templateType" => "TEXT",
+          "vertical" => "ACTION_BUTTON"
+        }
+      })
+
+    Tesla.Mock.mock(fn
+      %{method: :post} ->
+        %Tesla.Env{
+          status: 200,
+          body: body
+        }
+
+      %{method: :get} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "Fake Token"}})
+        }
+    end)
+
     language = language_fixture()
 
-    new_attrs =
-      attrs
-      |> Map.merge(@valid_attrs)
-      |> Map.merge(%{language_id: language.id, footer: "footer"})
+    attrs = %{
+      body: "Your train ticket no. {{1}}",
+      label: "New Label",
+      language_id: language.id,
+      is_hsm: true,
+      footer: "footer",
+      type: :text,
+      shortcode: "ticket_update_status",
+      category: "ACCOUNT_UPDATE",
+      example: "Your train ticket no. [1234]",
+      organization_id: attrs.organization_id
+    }
 
-    assert {:ok, %SessionTemplate{} = session_template_data} =
-             Templates.create_session_template(new_attrs)
+    assert {:ok, %SessionTemplate{} = session_template} =
+             Templates.create_session_template(attrs)
 
-    assert session_template_data.footer == "footer"
+    assert session_template.footer == "footer"
   end
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2207,7 +2207,7 @@ defmodule Glific.TemplatesTest do
            ] = messages
   end
 
-  test "create_session_template/1 with footer adds it to the template", attrs do
+  test "attach_footer adds the footer to the template if provided", attrs do
     language = language_fixture()
 
     new_attrs =


### PR DESCRIPTION

## Summary
 Target issue is https://github.com/glific/glific/issues/4249
### Motivation

-  Gupshup supports an optional footer field in HSM templates for additional message context.
- Glific currently does not support the footer, limiting the ability to utilize this feature.
### Implementation

- Added footer column to the hsm_templates table as a nullable text field via migration.
- Updated GraphQL API to accept and return the optional footer field in create, update, and fetch operations.
- Maintained backward compatibility by making footer optional, ensuring existing templates continue to work unchanged.