### PR TITLE
Revert "Cascade Delete Contact When Deleting Default Profile"

### DIFF
--- a/lib/glific/profiles.ex
+++ b/lib/glific/profiles.ex
@@ -116,16 +116,9 @@ defmodule Glific.Profiles do
       {:error, %Ecto.Changeset{}}
 
   """
-
   @spec delete_profile(Profile.t()) ::
-          {:ok, Profile.t()} | {:ok, Contact.t()} | {:error, Ecto.Changeset.t()}
-
-  def delete_profile(%Profile{is_default: true} = profile) do
-    contact = Repo.preload(profile, :contact).contact
-    Contacts.delete_contact(contact)
-  end
-
-  def delete_profile(%Profile{is_default: false} = profile) do
+          {:ok, Profile.t()} | {:error, Ecto.Changeset.t()}
+  def delete_profile(%Profile{} = profile) do
     Repo.delete(profile)
   end
 

--- a/priv/repo/migrations/20250711055838_add_index_contact_groups.exs
+++ b/priv/repo/migrations/20250711055838_add_index_contact_groups.exs
@@ -2,8 +2,6 @@ defmodule Glific.Repo.Migrations.AddIndexContactGroups do
   use Ecto.Migration
 
   def change do
-    create_if_not_exists index(:contacts_groups, [:group_id, :organization_id],
-                           name: "contacts_groups_group_id_organization_id_index"
-                         )
+    create_if_not_exists index(:contacts_groups, [:group_id, :organization_id], name: "contacts_groups_group_id_organization_id_index")
   end
 end

--- a/test/glific/profiles_test.exs
+++ b/test/glific/profiles_test.exs
@@ -108,18 +108,10 @@ defmodule Glific.ProfilesTest do
       assert profile == Profiles.get_profile!(profile.id)
     end
 
-    test "delete_profile/1 deletes the non default profile" do
+    test "delete_profile/1 deletes the profile" do
       profile = profile_fixture()
       assert {:ok, %Profile{}} = Profiles.delete_profile(profile)
       assert_raise Ecto.NoResultsError, fn -> Profiles.get_profile!(profile.id) end
-    end
-
-    test "deletes_profile/1 deletes the contact on trying to delete the default profile" do
-      profile = profile_fixture(%{"is_default" => true})
-      contact_id = profile.contact_id
-
-      assert {:ok, %Contact{}} = Profiles.delete_profile(profile)
-      assert_raise Ecto.NoResultsError, fn -> Contacts.get_contact!(contact_id) end
     end
 
     test "get_indexed_profile/1 returns all indexed profile for a contact", attrs do


### PR DESCRIPTION
Reverts glific/glific#4284

Reverting this since this PR is dependent on FE PR as mentioned https://github.com/glific/glific/pull/4284#issuecomment-3079094364