### PR TITLE
Search: Only WABA contacts will be returned in the search api

### DIFF
--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -1050,30 +1050,22 @@ defmodule Glific.Contacts do
   @spec get_contact_update_attrs(Contact.t(), map()) :: map() | nil
   defp get_contact_update_attrs(
          %Contact{contact_type: "WABA"} = _contact,
-         %{name: sender_name, contact_type: "WA"} = _sender
+         %{contact_type: "WA"} = sender
        ) do
-    %{name: sender_name, contact_type: "WABA+WA"}
-  end
-
-  defp get_contact_update_attrs(
-         %Contact{contact_type: "WABA"} = _contact,
-         %{contact_type: "WA"} = _sender
-       ) do
-    %{contact_type: "WABA+WA"}
+    case Map.get(sender, :name) do
+      nil -> %{contact_type: "WABA+WA"}
+      sender_name -> %{name: sender_name, contact_type: "WABA+WA"}
+    end
   end
 
   defp get_contact_update_attrs(
          %Contact{contact_type: "WA"} = _contact,
-         %{name: sender_name, contact_type: "WABA"} = _sender
+         %{contact_type: "WABA"} = sender
        ) do
-    %{name: sender_name, contact_type: "WABA+WA"}
-  end
-
-  defp get_contact_update_attrs(
-         %Contact{contact_type: "WA"} = _contact,
-         %{contact_type: "WABA"} = _sender
-       ) do
-    %{contact_type: "WABA+WA"}
+    case Map.get(sender, :name) do
+      nil -> %{contact_type: "WABA+WA"}
+      sender_name -> %{name: sender_name, contact_type: "WABA+WA"}
+    end
   end
 
   defp get_contact_update_attrs(%Contact{name: name} = _contact, %{name: sender_name} = _sender)

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -1062,7 +1062,6 @@ defmodule Glific.Contacts do
     %{contact_type: "WABA+WA"}
   end
 
-  @spec get_contact_update_attrs(Contact.t(), map()) :: map() | nil
   defp get_contact_update_attrs(
          %Contact{contact_type: "WA"} = _contact,
          %{name: sender_name, contact_type: "WABA"} = _sender

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -1062,6 +1062,21 @@ defmodule Glific.Contacts do
     %{contact_type: "WABA+WA"}
   end
 
+  @spec get_contact_update_attrs(Contact.t(), map()) :: map() | nil
+  defp get_contact_update_attrs(
+         %Contact{contact_type: "WA"} = _contact,
+         %{name: sender_name, contact_type: "WABA"} = _sender
+       ) do
+    %{name: sender_name, contact_type: "WABA+WA"}
+  end
+
+  defp get_contact_update_attrs(
+         %Contact{contact_type: "WA"} = _contact,
+         %{contact_type: "WABA"} = _sender
+       ) do
+    %{contact_type: "WABA+WA"}
+  end
+
   defp get_contact_update_attrs(%Contact{name: name} = _contact, %{name: sender_name} = _sender)
        when name != sender_name do
     %{name: sender_name}

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -458,7 +458,7 @@ defmodule Glific.Contacts do
         end
 
       contact ->
-        # If either the sender name have changed or the provider is maytapi we need to update the contact
+        # If either the sender name have changed or if we need to update contact_type, we need to update the contact
         case get_contact_update_attrs(contact, sender) do
           nil ->
             {:ok, contact}

--- a/lib/glific/searches.ex
+++ b/lib/glific/searches.ex
@@ -176,6 +176,7 @@ defmodule Glific.Searches do
 
     query
     |> where([c], c.status != :blocked)
+    |> where([c], c.contact_type in ["WABA", "WABA+WA"])
     |> select([c], %{id: c.id, last_communication_at: c.last_communication_at})
     |> distinct(true)
     |> add_contact_opts(opts)

--- a/lib/glific/searches.ex
+++ b/lib/glific/searches.ex
@@ -255,6 +255,7 @@ defmodule Glific.Searches do
     |> add_message_clause(args)
     |> order_by([c: c], desc: c.last_communication_at, desc: c.id)
     |> where([c: c], c.status != :blocked)
+    |> where([c: c], c.contact_type in ["WABA", "WABA+WA"])
     |> group_by([c: c], c.id)
     |> Repo.add_permission(&Searches.add_permission/2)
   end

--- a/lib/glific/seeds/seeds_dev.ex
+++ b/lib/glific/seeds/seeds_dev.ex
@@ -91,7 +91,8 @@ if Code.ensure_loaded?(Faker) do
           optin_time: utc_now,
           optin_status: true,
           optin_method: "BSP",
-          bsp_status: :session_and_hsm
+          bsp_status: :session_and_hsm,
+          contact_type: "WABA"
         },
         %{
           name: "Adelle Cavin",
@@ -99,7 +100,8 @@ if Code.ensure_loaded?(Faker) do
           language_id: hi_in.id,
           bsp_status: :session_and_hsm,
           optin_time: utc_now,
-          optin_status: true
+          optin_status: true,
+          contact_type: "WABA"
         },
         %{
           name: "Margarita Quinteros",
@@ -107,7 +109,8 @@ if Code.ensure_loaded?(Faker) do
           language_id: hi_in.id,
           bsp_status: :session_and_hsm,
           optin_time: utc_now,
-          optin_status: true
+          optin_status: true,
+          contact_type: "WABA"
         },
         %{
           name: "Chrissy Cron",
@@ -115,7 +118,8 @@ if Code.ensure_loaded?(Faker) do
           language_id: en.id,
           bsp_status: :session_and_hsm,
           optin_time: utc_now,
-          optin_status: true
+          optin_status: true,
+          contact_type: "WABA"
         }
       ]
 

--- a/lib/glific/seeds/seeds_migration.ex
+++ b/lib/glific/seeds/seeds_migration.ex
@@ -272,7 +272,8 @@ defmodule Glific.Seeds.SeedsMigration do
             attrs,
             %{
               name: "Glific Simulator " <> name,
-              phone: simulator_phone_prefix <> phone
+              phone: simulator_phone_prefix <> phone,
+              contact_type: "WABA"
             }
           )
         end

--- a/lib/glific_web/providers/gupshup/controllers/message_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_controller.ex
@@ -25,7 +25,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   def text(conn, params) do
     params
     |> Gupshup.Message.receive_text()
-    |> Map.put(:organization_id, conn.assigns[:organization_id])
+    |> update_message_params(%{organization_id: conn.assigns[:organization_id]})
     |> Communications.Message.receive_message()
 
     handler(conn, params, "text handler")
@@ -67,7 +67,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   defp media(conn, params, type) do
     params
     |> Gupshup.Message.receive_media()
-    |> Map.put(:organization_id, conn.assigns[:organization_id])
+    |> update_message_params(%{organization_id: conn.assigns[:organization_id]})
     |> Communications.Message.receive_message(type)
 
     handler(conn, params, "media handler")
@@ -91,7 +91,7 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   defp interactive(conn, params, type) do
     params
     |> Gupshup.Message.receive_interactive()
-    |> Map.put(:organization_id, conn.assigns[:organization_id])
+    |> update_message_params(%{organization_id: conn.assigns[:organization_id]})
     |> Communications.Message.receive_message(type)
 
     handler(conn, params, "interactive handler")
@@ -103,9 +103,16 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageController do
   def location(conn, params) do
     params
     |> Gupshup.Message.receive_location()
-    |> Map.put(:organization_id, conn.assigns[:organization_id])
+    |> update_message_params(%{organization_id: conn.assigns[:organization_id]})
     |> Communications.Message.receive_message(:location)
 
     handler(conn, params, "location handler")
+  end
+
+  @spec update_message_params(map(), map()) :: map()
+  defp update_message_params(message_payload, params) do
+    message_payload
+    |> Map.put(:organization_id, params.organization_id)
+    |> put_in([:sender, :contact_type], "WABA")
   end
 end

--- a/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
@@ -852,22 +852,22 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
            conn: conn,
            message_params: message_params
          } do
-      # handling a message from gupshup, so that the phone number will be already existing
+      # handling a message from maytapi, so that the phone number will be already existing
       # in contacts table.
       text_webhook_params =
         @media_message_webhook
         |> put_in(["user", "phone"], get_in(message_params, ["payload", "sender", "phone"]))
 
-      gupshup_conn = post(conn, "/maytapi", text_webhook_params)
+      maytapi_conn = post(conn, "/maytapi", text_webhook_params)
 
-      assert gupshup_conn.halted
+      assert maytapi_conn.halted
 
       bsp_message_id = get_in(text_webhook_params, ["message", "id"])
 
       {:ok, message} =
         Repo.fetch_by(WAMessage, %{
           bsp_id: bsp_message_id,
-          organization_id: gupshup_conn.assigns[:organization_id]
+          organization_id: maytapi_conn.assigns[:organization_id]
         })
 
       message = Repo.preload(message, [:media, :contact])
@@ -893,22 +893,22 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
            conn: conn,
            message_params: message_params
          } do
-      # handling a message from gupshup, so that the phone number will be already existing
+      # handling a message from maytapi, so that the phone number will be already existing
       # in contacts table.
       text_webhook_params =
         @media_message_webhook
         |> put_in(["user", "phone"], get_in(message_params, ["payload", "sender", "phone"]))
 
-      gupshup_conn = post(conn, "/maytapi", text_webhook_params)
+      maytapi_conn = post(conn, "/maytapi", text_webhook_params)
 
-      assert gupshup_conn.halted
+      assert maytapi_conn.halted
 
       bsp_message_id = get_in(text_webhook_params, ["message", "id"])
 
       {:ok, message} =
         Repo.fetch_by(WAMessage, %{
           bsp_id: bsp_message_id,
-          organization_id: gupshup_conn.assigns[:organization_id]
+          organization_id: maytapi_conn.assigns[:organization_id]
         })
 
       message = Repo.preload(message, [:media, :contact])

--- a/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
+++ b/test/glific_web/providers/maytapi/controllers/message_controller_test.exs
@@ -847,6 +847,99 @@ defmodule GlificWeb.Providers.Maytapi.Controllers.MessageControllerTest do
       assert message.contact.contact_type == "WABA+WA"
     end
 
+    test "Updating the contact_type to WABA+WA due to sender contact already existing as a WA contact",
+         %{
+           conn: conn,
+           message_params: message_params
+         } do
+      # handling a message from gupshup, so that the phone number will be already existing
+      # in contacts table.
+      text_webhook_params =
+        @media_message_webhook
+        |> put_in(["user", "phone"], get_in(message_params, ["payload", "sender", "phone"]))
+
+      gupshup_conn = post(conn, "/maytapi", text_webhook_params)
+
+      assert gupshup_conn.halted
+
+      bsp_message_id = get_in(text_webhook_params, ["message", "id"])
+
+      {:ok, message} =
+        Repo.fetch_by(WAMessage, %{
+          bsp_id: bsp_message_id,
+          organization_id: gupshup_conn.assigns[:organization_id]
+        })
+
+      message = Repo.preload(message, [:media, :contact])
+
+      assert message.contact.contact_type == "WA"
+
+      gupshup_conn = post(conn, "/gupshup", message_params)
+      assert gupshup_conn.halted
+      bsp_message_id = get_in(message_params, ["payload", "id"])
+
+      {:ok, message} =
+        Repo.fetch_by(Message, %{
+          bsp_message_id: bsp_message_id,
+          organization_id: gupshup_conn.assigns[:organization_id]
+        })
+
+      message = Repo.preload(message, [:contact])
+      assert message.contact.contact_type == "WABA+WA"
+    end
+
+    test "Updating the contact_type to WABA+WA due to sender contact already existing as a WA contact, but no name update",
+         %{
+           conn: conn,
+           message_params: message_params
+         } do
+      # handling a message from gupshup, so that the phone number will be already existing
+      # in contacts table.
+      text_webhook_params =
+        @media_message_webhook
+        |> put_in(["user", "phone"], get_in(message_params, ["payload", "sender", "phone"]))
+
+      gupshup_conn = post(conn, "/maytapi", text_webhook_params)
+
+      assert gupshup_conn.halted
+
+      bsp_message_id = get_in(text_webhook_params, ["message", "id"])
+
+      {:ok, message} =
+        Repo.fetch_by(WAMessage, %{
+          bsp_id: bsp_message_id,
+          organization_id: gupshup_conn.assigns[:organization_id]
+        })
+
+      message = Repo.preload(message, [:media, :contact])
+
+      assert message.contact.contact_type == "WA"
+      name_a = message.contact.name
+
+      # deletes the name from the map
+      message_params = %{
+        message_params
+        | "payload" => %{
+            message_params["payload"]
+            | "sender" => Map.delete(message_params["payload"]["sender"], "name")
+          }
+      }
+
+      gupshup_conn = post(conn, "/gupshup", message_params)
+      assert gupshup_conn.halted
+      bsp_message_id = get_in(message_params, ["payload", "id"])
+
+      {:ok, message} =
+        Repo.fetch_by(Message, %{
+          bsp_message_id: bsp_message_id,
+          organization_id: gupshup_conn.assigns[:organization_id]
+        })
+
+      message = Repo.preload(message, [:contact])
+      assert message.contact.contact_type == "WABA+WA"
+      assert name_a == message.contact.name
+    end
+
     test "Incoming media message should be stored in the database, but group doesnt exist, so creates group",
          %{
            conn: conn

--- a/test/glific_web/schema/search_test.exs
+++ b/test/glific_web/schema/search_test.exs
@@ -234,7 +234,7 @@ defmodule GlificWeb.Schema.SearchTest do
     # search excludes the org contact id since that is the sender of all messages
     # this is no longer true, hence removing the -1
     assert length(get_in(query_data, [:data, "search"])) ==
-             get_contacts_count(user.organization_id) |> IO.inspect
+             get_contacts_count(user.organization_id)
   end
 
   test "search for conversations group", %{staff: user} = attrs do

--- a/test/glific_web/schema/search_test.exs
+++ b/test/glific_web/schema/search_test.exs
@@ -234,7 +234,7 @@ defmodule GlificWeb.Schema.SearchTest do
     # search excludes the org contact id since that is the sender of all messages
     # this is no longer true, hence removing the -1
     assert length(get_in(query_data, [:data, "search"])) ==
-             get_contacts_count(user.organization_id)
+             get_contacts_count(user.organization_id) |> IO.inspect
   end
 
   test "search for conversations group", %{staff: user} = attrs do


### PR DESCRIPTION
## Summary
 Target issue is https://github.com/glific/glific/issues/4285 

Before deploying this PR, we need to update contact_type of the simulator contacts in prod and staging to WABA, currently they are null
