### PR TITLE
Added scripts that will make ffmpeg available in runtime

### DIFF
--- a/.gigalixir/releases/includes.txt
+++ b/.gigalixir/releases/includes.txt
@@ -1,0 +1,2 @@
+# .gigalixir/releases/includes.txt
+/.profile.d/*

--- a/.profile.d/001_fixup_apt.sh
+++ b/.profile.d/001_fixup_apt.sh
@@ -1,0 +1,8 @@
+# .profile.d/001_fixup_apt.sh
+APT_PATHS=$(find $HOME/.apt/usr/lib/x86_64-linux-gnu/ -type d | xargs echo | sed -e 's/ /:/g')
+
+export LD_LIBRARY_PATH="${APT_PATHS}:${LD_LIBRARY_PATH}"
+export LIBRARY_PATH="${APT_PATHS}:${LIBRARY_PATH}"
+export INCLUDE_PATH="${APT_PATHS}:${INCLUDE_PATH}"
+export CPATH="${INCLUDE_PATH}"
+export CPPPATH="${INCLUDE_PATH}"

--- a/.profile.d/002_ssh_profile_setup.sh
+++ b/.profile.d/002_ssh_profile_setup.sh
@@ -1,0 +1,3 @@
+# .profile.d/002_ssh_profile_setup.sh
+cp /app/.profile.d/000_apt.sh /etc/profile.d/ || true
+cp /app/.profile.d/001_fixup_ssh.sh /etc/profile.d || true


### PR DESCRIPTION
## Summary
 Target issue is #4327  

`.profile.d/001_fixup_apt.sh` file will make the custom installed apt libraries (like ffmpeg) available in runtime, by adding it to the paths.

`.profile.d/002_ssh_profile_setup.sh` -  does the auto-sourcing of above file.

`.gigalixir/releases/includes.txt` - Makes sure the first file is included while building the artifact.