### PR TITLE
Message: Proper handling of infinity loop for media only outbound session messages 

### DIFF
--- a/lib/glific/flows/contact_action.ex
+++ b/lib/glific/flows/contact_action.ex
@@ -203,7 +203,7 @@ defmodule Glific.Flows.ContactAction do
     attachment = Localization.get_translation(context, action, :attachments)
 
     # This will resolve expressions also to corresponding url value
-    {type, url} = get_attachement_details(attachment, context)
+    {type, url} = get_attachment_details(attachment, context)
 
     with {false, context} <- has_loops?(context, body, messages, url) do
       do_send_message(context, action, messages, %{
@@ -259,7 +259,7 @@ defmodule Glific.Flows.ContactAction do
   def get_media_from_attachment(attachment, caption, context, cid, attachment_type) do
     {type, url} =
       if is_nil(attachment_type) do
-        get_attachement_details(attachment, context)
+        get_attachment_details(attachment, context)
       else
         attachment_type
       end
@@ -491,8 +491,8 @@ defmodule Glific.Flows.ContactAction do
     end
   end
 
-  @spec get_attachement_details(String.t() | nil | map(), FlowContext.t()) :: {atom(), any()}
-  defp get_attachement_details(attachment, context) do
+  @spec get_attachment_details(String.t() | nil | map(), FlowContext.t()) :: {atom(), any()}
+  defp get_attachment_details(attachment, context) do
     if attachment == %{} or is_nil(attachment) do
       {:text, nil}
     else

--- a/lib/glific/flows/contact_action.ex
+++ b/lib/glific/flows/contact_action.ex
@@ -127,8 +127,8 @@ defmodule Glific.Flows.ContactAction do
 
   @spec has_loops?(FlowContext.t(), String.t(), [Message.t()]) ::
           {:ok, map(), any()} | {false, FlowContext.t()}
-  defp has_loops?(context, body, messages) do
-    {context, count} = check_recent_outbound_count(context, body)
+  defp has_loops?(context, body, messages, outbound_media \\ nil) do
+    {context, count} = check_recent_outbound_count(context, body, outbound_media)
 
     if count <= @max_loop_limit,
       do: {false, context},
@@ -158,15 +158,15 @@ defmodule Glific.Flows.ContactAction do
       }
     }
 
-  @spec check_recent_outbound_count(FlowContext.t(), String.t()) ::
+  @spec check_recent_outbound_count(FlowContext.t(), String.t(), String.t() | nil) ::
           {FlowContext.t(), non_neg_integer}
-  defp check_recent_outbound_count(context, body) do
+  defp check_recent_outbound_count(context, body, outbound_media) do
     # we'll mark that we came here and are planning to send it, even if
     # we don't end up sending it. This allows us to detect and abort infinite loops
 
     # count the number of times we sent the same message in the recent list
     # in the past 6 hours
-    count = FlowContext.match_outbound(context, body)
+    count = FlowContext.match_outbound(context, body, outbound_media)
     {context, count}
   end
 
@@ -200,12 +200,18 @@ defmodule Glific.Flows.ContactAction do
       text
       |> MessageVarParser.parse(message_vars)
 
-    with {false, context} <- has_loops?(context, body, messages) do
+    attachment = Localization.get_translation(context, action, :attachments)
+
+    # This will resolve expressions also to corresponding url value
+    {type, url} = get_attachement_details(attachment, context)
+
+    with {false, context} <- has_loops?(context, body, messages, url) do
       do_send_message(context, action, messages, %{
         cid: cid,
         body: body,
         text: text,
-        flow_label: action.labels
+        flow_label: action.labels,
+        attachment_details: {attachment, type, url}
       })
     end
   end
@@ -237,16 +243,26 @@ defmodule Glific.Flows.ContactAction do
   end
 
   @doc false
-  @spec get_media_from_attachment(any(), any(), FlowContext.t(), non_neg_integer() | nil) :: any()
-  def get_media_from_attachment(attachment, _, _, _)
+  @spec get_media_from_attachment(
+          any(),
+          any(),
+          FlowContext.t(),
+          non_neg_integer() | nil,
+          tuple() | nil
+        ) :: any()
+  def get_media_from_attachment(attachment, caption, context, cid, attachment_type \\ nil)
+
+  def get_media_from_attachment(attachment, _, _, _, _)
       when attachment == %{} or is_nil(attachment),
       do: {:text, nil}
 
-  def get_media_from_attachment(attachment, caption, context, cid) do
-    [type | _tail] = Map.keys(attachment)
-    url = String.trim(attachment[type])
-
-    {type, url} = handle_attachment_expression(context, type, url)
+  def get_media_from_attachment(attachment, caption, context, cid, attachment_type) do
+    {type, url} =
+      if is_nil(attachment_type) do
+        get_attachement_details(attachment, context)
+      else
+        attachment_type
+      end
 
     type = Glific.safe_string_to_atom(type)
 
@@ -356,14 +372,15 @@ defmodule Glific.Flows.ContactAction do
            body: body,
            text: text,
            cid: cid,
-           flow_label: flow_label
+           flow_label: flow_label,
+           attachment_details: attachment_details
          }
        ) do
     organization_id = context.organization_id
+    {attachment, type, url} = attachment_details
 
-    attachments = Localization.get_translation(context, action, :attachments)
-
-    {type, media_id} = get_media_from_attachment(attachments, text, context, cid)
+    {type, media_id} =
+      get_media_from_attachment(attachment, text, context, cid, {type, url})
 
     attrs = %{
       uuid: action.node_uuid,
@@ -471,6 +488,18 @@ defmodule Glific.Flows.ContactAction do
       {:ok, nil} -> 0
       {:ok, value} -> value
       _ -> 0
+    end
+  end
+
+  @spec get_attachement_details(String.t() | nil | map(), FlowContext.t()) :: {atom(), any()}
+  defp get_attachement_details(attachment, context) do
+    if attachment == %{} or is_nil(attachment) do
+      {:text, nil}
+    else
+      [type | _tail] = Map.keys(attachment)
+      url = String.trim(attachment[type])
+
+      handle_attachment_expression(context, type, url)
     end
   end
 end

--- a/lib/glific/flows/contact_action.ex
+++ b/lib/glific/flows/contact_action.ex
@@ -249,7 +249,7 @@ defmodule Glific.Flows.ContactAction do
           FlowContext.t(),
           non_neg_integer() | nil,
           tuple() | nil
-        ) :: any()
+        ) :: tuple()
   def get_media_from_attachment(attachment, caption, context, cid, attachment_type \\ nil)
 
   def get_media_from_attachment(attachment, _, _, _, _)

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -373,7 +373,6 @@ defmodule Glific.Flows.FlowContext do
 
     # since we are storing in DB and want to avoid hassle of atom <-> string conversion
     # we'll always use strings as keys
-
     messages =
       [
         %{
@@ -383,6 +382,8 @@ defmodule Glific.Flows.FlowContext do
           },
           "message" => msg.body,
           "message_id" => msg.id,
+          "message_type" => msg.type,
+          "message_media" => get_message_media(msg),
           "date" => now,
           "node_uuid" => context.node_uuid
         }
@@ -445,12 +446,10 @@ defmodule Glific.Flows.FlowContext do
   @doc """
   Count the number of times we have sent the same message in the recent past
   """
-  @spec match_outbound(FlowContext.t(), String.t(), integer) :: integer
-  def match_outbound(context, body, go_back \\ 6)
-  # If body of message is empty then that means it must have been an audio/video message
-  def match_outbound(_context, "", _), do: 0
+  @spec match_outbound(FlowContext.t(), String.t(), String.t() | nil, integer) :: integer
+  def match_outbound(context, body, outbound_media \\ nil, go_back \\ 6)
 
-  def match_outbound(context, body, go_back) do
+  def match_outbound(context, body, outbound_media, go_back) do
     since = Glific.go_back_time(go_back)
 
     Enum.filter(
@@ -458,15 +457,26 @@ defmodule Glific.Flows.FlowContext do
       fn item ->
         date = get_datetime(item)
 
-        # comparing node uuids is a lot more powerful than comparing message body
-        # but for webhooks, the function can return something different every time
-        # so we check for both node uuid and body
-        item["node_uuid"] == context.node_uuid and
-          item["message"] == body and
+        same_message?(context, item, body, outbound_media) and
           DateTime.compare(date, since) in [:gt, :eq]
       end
     )
     |> length()
+  end
+
+  # comparing node uuids is a lot more powerful than comparing message body
+  # but for webhooks, the function can return something different every time
+  # so we check for both node uuid and body.
+
+  # If the message is only media (audio, image etc..) then the message body will be empty
+  # in that case we check the outbound attachment instead of body
+  @spec same_message?(FlowContext.t(), map(), body :: String.t(), String.t()) :: boolean()
+  defp same_message?(context, item, "", outbound_media) do
+    item["node_uuid"] == context.node_uuid and item["message_media"] == outbound_media
+  end
+
+  defp same_message?(context, item, body, _outbound_media) do
+    item["node_uuid"] == context.node_uuid and item["message"] == body
   end
 
   @doc """
@@ -1127,4 +1137,11 @@ defmodule Glific.Flows.FlowContext do
   end
 
   defp validate_contact_and_wa_groups(changeset, _flow_context), do: changeset
+
+  @spec get_message_media(map()) :: String.t() | nil
+  defp get_message_media(%{media_id: media_id} = msg) when media_id != nil do
+    msg.media.url
+  end
+
+  defp get_message_media(_msg), do: nil
 end

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -446,7 +446,11 @@ defmodule Glific.Flows.FlowContext do
   Count the number of times we have sent the same message in the recent past
   """
   @spec match_outbound(FlowContext.t(), String.t(), integer) :: integer
-  def match_outbound(context, body, go_back \\ 6) do
+  def match_outbound(context, body, go_back \\ 6)
+  # If body of message is empty then that means it must have been an audio/video message
+  def match_outbound(_context, "", _), do: 0
+
+  def match_outbound(context, body, go_back) do
     since = Glific.go_back_time(go_back)
 
     Enum.filter(

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Unsupported node type"
 msgstr ""
 
-#: lib/glific/flows/flow_context.ex:487
+#: lib/glific/flows/flow_context.ex:497
 #, elixir-format, elixir-autogen
 msgid "We have finished the flow"
 msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -239,7 +239,7 @@ msgstr ""
 msgid "Unsupported node type"
 msgstr ""
 
-#: lib/glific/flows/flow_context.ex:483
+#: lib/glific/flows/flow_context.ex:487
 #, elixir-format, elixir-autogen
 msgid "We have finished the flow"
 msgstr ""


### PR DESCRIPTION

## Summary
 Target issue is https://github.com/glific/glific/issues/4324 

- Added `message_type` and `message_media` to recent_inbound and recent_outbound objects in flow_context.
- Check the distinctiveness of message by checking the outbound media attachments with `message_media` in flow_context instead of empty body.
- HSMs and interactive msgs require mandatory body, so we don't have to check for that.
