### PR TITLE
Add support_mail function  to notify Glific Support after partner onboarding

### DIFF
--- a/lib/glific/mails/new_partner_onboarded_mail.ex
+++ b/lib/glific/mails/new_partner_onboarded_mail.ex
@@ -9,38 +9,6 @@ defmodule Glific.Mails.NewPartnerOnboardedMail do
   }
 
   @doc false
-  @spec support_mail(Organization.t(), map()) :: Swoosh.Email.t()
-  def support_mail(org, login_details) do
-    subject = """
-    Glific: New Partner Onboarded - #{org.name}
-    """
-
-    body = """
-    Hello Glific Support Team,
-
-    A new partner organization has been successfully onboarded.
-
-    Organization Details:
-    ---------------------
-    Name: #{org.name}
-    Email: #{org.email}
-
-    Login Details:
-    --------------
-    Phone Number: #{login_details[:phnum]}
-    Password: #{login_details[:password]}
-
-    """
-
-    opts = [
-      send_to: Mailer.glific_support(),
-      ignore_cc_support: true
-    ]
-
-    Mailer.common_send(org, subject, body, opts)
-  end
-
-  @doc false
   @spec new_mail(Organization.t()) :: Swoosh.Email.t()
   def new_mail(org) do
     team = ""
@@ -56,6 +24,7 @@ defmodule Glific.Mails.NewPartnerOnboardedMail do
 
     Name: #{org.name}
     Email: #{org.email}
+    Login URL: https://#{org.shortcode}.glific.com
     """
 
     opts = [


### PR DESCRIPTION
## Summary
 Target issue https://github.com/glific/glific/issues/4343

