### PR TITLE
Remove sending username for onboarding to kaapi

### DIFF
--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -27,8 +27,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
 
     body = %{
       organization_name: params.organization_name,
-      project_name: params.project_name,
-      user_name: params.user_name
+      project_name: params.project_name
     }
 
     body =

--- a/lib/glific/third_party/kaapi/migration.ex
+++ b/lib/glific/third_party/kaapi/migration.ex
@@ -100,8 +100,7 @@ defmodule Glific.ThirdParty.Kaapi.Migration do
     params = %{
       organization_id: id,
       organization_name: organization_name,
-      project_name: org_name,
-      user_name: shortcode,
+      project_name: shortcode,
       openai_api_key: open_ai_key
     }
 


### PR DESCRIPTION
## Summary
- Update project_name to use shortcode instead of org_name.
- Remove user_name field from request body in both ApiClient and Migration
modules.