### PR TITLE
AI rerouting: Use upsert for importing assistants

### DIFF
--- a/lib/glific/filesearch.ex
+++ b/lib/glific/filesearch.ex
@@ -221,18 +221,23 @@ defmodule Glific.Filesearch do
       vector_store_id = List.first(assistant_data.tool_resources.file_search.vector_store_ids)
 
       if is_nil(vector_store_id) do
-        Assistant.create_assistant(
-          %{
-            assistant_id: assistant_id,
-            inserted_at: DateTime.from_unix!(assistant_data.created_at),
-            organization_id: Repo.get_organization_id()
-          }
-          |> Map.merge(assistant_data)
-        )
+        create_assistant(assistant_id, assistant_data)
       else
         create_assistant_and_vector_store(vector_store_id, assistant_data)
       end
     end
+  end
+
+  @spec create_assistant(String.t(), map()) :: {:ok, map()} | {:error, any()}
+  defp create_assistant(assistant_id, assistant_data) do
+    Assistant.create_assistant(
+      %{
+        assistant_id: assistant_id,
+        inserted_at: DateTime.from_unix!(assistant_data.created_at),
+        organization_id: Repo.get_organization_id()
+      }
+      |> Map.merge(assistant_data)
+    )
   end
 
   @spec create_vector_store(map()) :: {:ok, map()} | {:error, any()}

--- a/lib/glific/filesearch.ex
+++ b/lib/glific/filesearch.ex
@@ -394,7 +394,7 @@ defmodule Glific.Filesearch do
   defp create_filesearch_artifacts_on_import(assistant_data, vector_store_data) do
     Multi.new()
     |> Multi.run(:create_vector_store, fn _, _ ->
-      VectorStore.create_vector_store(
+      VectorStore.upsert_vector_store(
         %{
           vector_store_id: vector_store_data.id,
           inserted_at: DateTime.from_unix!(vector_store_data.created_at),

--- a/lib/glific/filesearch/vector_store.ex
+++ b/lib/glific/filesearch/vector_store.ex
@@ -72,6 +72,21 @@ defmodule Glific.Filesearch.VectorStore do
   end
 
   @doc """
+  Upserts VectorStore
+  """
+  @spec upsert_vector_store(map()) :: {:ok, VectorStore.t()} | {:error, Ecto.Changeset.t()}
+  def upsert_vector_store(attrs) do
+    conflict_opts = [name: attrs.name, files: attrs.files, size: attrs.size, status: attrs.status]
+
+    %VectorStore{}
+    |> changeset(attrs)
+    |> Repo.insert(
+      on_conflict: [set: conflict_opts],
+      conflict_target: [:vector_store_id, :organization_id]
+    )
+  end
+
+  @doc """
     Retrieves a vector_store
   """
   @spec get_vector_store(integer()) :: {:ok, VectorStore.t()} | {:error, Ecto.Changeset.t()}


### PR DESCRIPTION

## Summary
 Target issue is #4403   

- Added a new upsert function that updates the vector store when instead of raising.
- Moved the create assistant logic from the import function to a private function.