### PR TITLE
Purging messages_broadcast_contacts

### DIFF
--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -114,7 +114,7 @@ defmodule Glific.Erase do
   @spec remove_old_records() :: any
   defp remove_old_records do
     [
-      {"message_broadcasts", "week"},
+      {"message_broadcast_contacts", "week"},
       {"notifications", "week"},
       {"webhook_logs", "week"},
       {"flow_contexts", "month"},


### PR DESCRIPTION
When we delete message_broadcasts we need to update the messages tables message_broadcast_id to null, and its a foreign-key in messages table. Since the messages table has millions of rows, the delete query was timing out.  So further db purging and vacuuming was not working for a month, resulting in increased db size.

Instead now we delete message_broadcast_contacts table (which can have millions of rows if not cleared weekly) and message broadcasts table will not grow exponentially.