### PR TITLE
GCS: Updating process state of replica in gcs worker

### DIFF
--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -27,7 +27,8 @@ defmodule Glific.GCS.GcsWorker do
     Messages,
     Messages.MessageMedia,
     Partners,
-    Repo
+    Repo,
+    RepoReplica
   }
 
   @provider_shortcode "google_cloud_storage"
@@ -200,7 +201,7 @@ defmodule Glific.GCS.GcsWorker do
     Logger.info("GCSWORKER: Performing gcs media for media id: #{media["id"]}")
 
     Repo.put_process_state(media["organization_id"])
-
+    RepoReplica.put_process_state(media["organization_id"])
     # We will download the file from internet and then upload it to gsc and then remove it.
     extension = get_media_extension(media["type"])
 


### PR DESCRIPTION
## Summary
GCS worker uses Bigquery worker to update the messages table on media url updation.
So missed this case. Added process state updation of repo replica in gcs worker too

