### PR TITLE
Appsignal: sending latency in millisecond

### DIFF
--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -48,7 +48,7 @@ defmodule Glific.Appsignal do
     # For ex for openai api,  sampling_scale is 5. For a default of 10% sampling rate,
     # 50% of openai requests will go to appsignal
     sampling_scale = meta[:sampling_scale] || 1
-    request_duration_seconds = System.convert_time_unit(measurement.duration, :native, :millisecond)
+    request_duration_milliseconds = System.convert_time_unit(measurement.duration, :native, :millisecond)
 
     status = meta.env.status
 
@@ -72,7 +72,7 @@ defmodule Glific.Appsignal do
           })
 
         true ->
-          Appsignal.add_distribution_value("tesla_request_response", request_duration_seconds, %{
+          Appsignal.add_distribution_value("tesla_request_response", request_duration_milliseconds, %{
             method: meta.env.method,
             url: meta.env.url,
             provider: meta[:provider]


### PR DESCRIPTION

## Summary
Sending API response latency in milliseconds