### PR TITLE
Bump version to 8.0.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Glific.MixProject do
   def project do
     [
       app: :glific,
-      version: "7.5.7",
+      version: "8.0.0",
       elixir: "~> 1.18.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [


### PR DESCRIPTION
- Did a major version bump because this could break deployments if the following ENV vars are no set:
   - `PRIMARY_CACERT_ENCODED`
   - `PRIMARY_DB_SERVER_NAME_INDICATION`
- Or `ENABLE_DB_SSL` should be set to `false`