### PR TITLE
feat: :sparkles: Add WhatsappForm to tracked schemas in ex_audit config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -165,7 +165,8 @@ config :ex_audit,
   version_schema: Glific.Version,
   tracked_schemas: [
     Glific.Flows.Flow,
-    Glific.Triggers.Trigger
+    Glific.Triggers.Trigger,
+    Glific.WhatsappForms.WhatsappForm
   ],
   primitive_structs: [
     DateTime


### PR DESCRIPTION

## Summary
 Target issue is #4547  

 Adds WhatsappForm to ex_audit's tracked schemas to maintain an audit trail of who creates, edits, or deletes WhatsApp flows, including a history of form content changes.