### PR TITLE
HSM: added unique period to be 5 mins for sync jobs

### DIFF
--- a/lib/glific/templates/template_worker.ex
+++ b/lib/glific/templates/template_worker.ex
@@ -33,8 +33,8 @@ defmodule Glific.Templates.TemplateWorker do
   def create_hsm_sync_job(organization_id) do
     __MODULE__.new(%{"organization_id" => organization_id, "sync_hsm" => true},
       unique: [
-        # 10 mins
-        period: 60 * 10,
+        # 5 mins
+        period: 60 * 5,
         keys: [:organization_id],
         states: [:available, :scheduled, :executing]
       ]


### PR DESCRIPTION
## Summary

Since we were not putting any value to period, the default was 1 min. But for some org this can take more than 1 min in execution. So in that case new duplicate jobs can be enqueued again. So to be on safe side, changed the unique period to be 5 min.