### PR TITLE
whatsApp forms: Update WhatsApp form sync logic to include description in revision updates

### DIFF
--- a/lib/glific/whatsapp_forms.ex
+++ b/lib/glific/whatsapp_forms.ex
@@ -267,7 +267,6 @@ defmodule Glific.WhatsappForms do
       name: form["name"],
       status: normalize_status(form["status"]),
       categories: normalize_categories(form["categories"]),
-      description: Map.get(form, "description", ""),
       meta_flow_id: form["id"],
       definition: form_json,
       organization_id: organization_id
@@ -290,12 +289,9 @@ defmodule Glific.WhatsappForms do
               definition: form_json
             }
 
-            attrs_with_description =
-              Map.put(attrs, :description, existing_form.description)
-
             with {:ok, _revision} <-
                    WhatsappFormsRevisions.save_revision(revision_attrs, root_user) do
-              do_update_whatsapp_form(existing_form, attrs_with_description)
+              do_update_whatsapp_form(existing_form, attrs)
             end
         end
 


### PR DESCRIPTION
## Description

Since Meta does not include the description in the response when extracting each form, we will explicitly insert the description from the existing form before updating the value.

