### PR TITLE
Refactor assistant data structure and update file info input type

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -115,7 +115,8 @@ defmodule Glific.Assistants do
       end)
 
     %{
-      id: assistant.assistant_display_id,
+      id: assistant.id,
+      assistant_display_id: assistant.assistant_display_id,
       name: assistant.name,
       assistant_id: assistant.kaapi_uuid,
       temperature: get_in(active_config_version.settings || %{}, ["temperature"]),
@@ -486,7 +487,7 @@ defmodule Glific.Assistants do
   # Private
   @spec maybe_create_knowledge_base(map()) ::
           {:ok, KnowledgeBase.t()} | {:error, Ecto.Changeset.t()}
-  defp maybe_create_knowledge_base(%{id: id}), do: Repo.fetch(KnowledgeBase, id)
+  defp maybe_create_knowledge_base(%{id: id}) when not is_nil(id), do: Repo.fetch(KnowledgeBase, id)
 
   defp maybe_create_knowledge_base(params) do
     params = %{name: generate_knowledge_base_name(), organization_id: params[:organization_id]}

--- a/lib/glific_web/schema/filesearch_types.ex
+++ b/lib/glific_web/schema/filesearch_types.ex
@@ -91,6 +91,7 @@ defmodule GlificWeb.Schema.FilesearchTypes do
 
   object :unified_assistant do
     field :id, :id
+    field :assistant_display_id, :string
     field :name, :string
     field :assistant_id, :string
     field :model, :string
@@ -123,7 +124,7 @@ defmodule GlificWeb.Schema.FilesearchTypes do
   input_object :file_info_input do
     field :file_id, :string
     field :filename, :string
-    field :uploaded_at, :datetime
+    field :uploaded_at, :string
   end
 
   @desc "Filtering options for VectorStore"


### PR DESCRIPTION
- Expose both id and assistant_display_id: Previously the assistant map returned id: assistant.assistant_display_id, overwriting the actual database id. Now it correctly returns both:
    - id: assistant.id,
    - assistant_display_id: assistant.assistant_display_id,
This is the counterpart to the frontend PR https://github.com/glific/glific-frontend/pull/3779 where GET_ASSISTANT now aliases assistantDisplayId separately.

- Guard against nil id in maybe_create_knowledge_base: Added when not is_nil(id) guard so that passing %{id: nil} falls through to the next function clause (which creates a new knowledge base) instead of trying to fetch a knowledge base with a nil id.
- Added assistant_display_id field to the :unified_assistant GraphQL object type (so the frontend can query it).
Changed uploaded_at in :file_info_input from :datetime to :string — this avoids datetime parsing issues on the input side (the frontend sends it as a raw string).