### PR TITLE
Add skip_organization_id option to vector store query

### DIFF
--- a/lib/glific/third_party/kaapi/unified_api_migration.ex
+++ b/lib/glific/third_party/kaapi/unified_api_migration.ex
@@ -260,7 +260,7 @@ defmodule Glific.ThirdParty.Kaapi.UnifiedApiMigration do
         on: v.id == a.vector_store_id,
         distinct: [v.id]
       )
-      |> Repo.all()
+      |> Repo.all(skip_organization_id: true)
 
     Task.Supervisor.async_stream_nolink(
       TaskSupervisor,


### PR DESCRIPTION
## Summary

- Adds `skip_organization_id: true` to the vector store query in `UnifiedApiMigration`, allowing it to fetch records across all organizations during migration instead of being scoped to a single tenant.

## Problem

The vector store query in the Kaapi unified API migration was using `Repo.all()` without `skip_organization_id: true`. Since Glific is multi-tenant, this caused the query to throw error and fail.

## Solution

Pass `skip_organization_id: true` to `Repo.all()` so the migration query fetches vector stores across all organizations as intended.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)