### PR TITLE
Add skip_organization_id flag to OpenAI assistant query in Unfied API Migration

### DIFF
--- a/lib/glific/third_party/kaapi/unified_api_migration.ex
+++ b/lib/glific/third_party/kaapi/unified_api_migration.ex
@@ -33,7 +33,7 @@ defmodule Glific.ThirdParty.Kaapi.UnifiedApiMigration do
       from(oa in OpenAIAssistant,
         preload: [:vector_store]
       )
-      |> Repo.all()
+      |> Repo.all(skip_organization_id: true)
 
     Logger.info("Starting migration for #{length(openai_assistants)} assistants")
 


### PR DESCRIPTION
## Summary

- Adds `skip_organization_id: true` to the assistants query in `UnifiedApiMigration`, allowing it to fetch records across all organizations during migration instead of being scoped to a single tenant.

## Problem

The OpenAI Assistants query in the Kaapi unified API migration was using `Repo.all()` without `skip_organization_id: true`. Since Glific is multi-tenant, this caused the query to error out.
## Solution

Pass `skip_organization_id: true` to `Repo.all()` so the migration query fetches OpenAI Assistants across all organizations as intended.