### PR TITLE
Improve AppSignal Tracing

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -160,7 +160,7 @@ config :glific, Glific.Erase,
 
 # Percent of total job metrics to be sent to appsignal
 config :glific,
-  appsignal_sampling_rate: env!("APPSIGNAL_SAMPLING_RATE", :integer, 10)
+  appsignal_sampling_rate: env!("APPSIGNAL_SAMPLING_RATE", :integer, 100)
 
 config :glific, Glific.ThirdParty.Kaapi.ApiClient,
   kaapi_endpoint: env!("KAAPI_ENDPOINT", :string, "This is not a secret"),

--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -53,6 +53,7 @@ defmodule Glific.Appsignal do
       System.convert_time_unit(measurement.duration, :native, :millisecond)
 
     status = meta.env.status
+    url = get_template_url(meta.env)
 
     if :rand.uniform() < sampling_rate * sampling_scale / 100 do
       cond do
@@ -61,7 +62,7 @@ defmodule Glific.Appsignal do
           Appsignal.increment_counter("tesla_request_error_count", 1, %{
             provider: meta[:provider],
             error: meta.error,
-            url: meta.env.url,
+            url: url,
             method: meta.env.method
           })
 
@@ -69,7 +70,7 @@ defmodule Glific.Appsignal do
           Appsignal.increment_counter("tesla_request_error_count", 1, %{
             provider: meta[:provider],
             error: status,
-            url: meta.env.url,
+            url: url,
             method: meta.env.method
           })
 
@@ -79,7 +80,7 @@ defmodule Glific.Appsignal do
             request_duration_milliseconds,
             %{
               method: meta.env.method,
-              url: meta.env.url,
+              url: url,
               provider: meta[:provider]
             }
           )
@@ -167,9 +168,17 @@ defmodule Glific.Appsignal do
     rows
   end
 
+  @spec get_template_url(Tesla.Env.t()) :: String.t()
+  defp get_template_url(%Tesla.Env{opts: opts, url: url}) do
+    case Keyword.get(opts, :req_url) do
+      nil -> url
+      req_url -> req_url
+    end
+  end
+
   @spec record_tesla_event(any(), any(), integer()) :: any()
   defp record_tesla_event(measurement, meta, time) do
-    metadata = %{method: meta.env.method, url: meta.env.url}
+    metadata = %{method: meta.env.method, url: get_template_url(meta.env)}
 
     request_duration_microseconds =
       System.convert_time_unit(measurement.duration, :native, :microsecond)

--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -15,6 +15,8 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
         {Tesla.Middleware.BaseUrl, base_url},
         {Tesla.Middleware.Headers, [{"X-API-KEY", api_key}]},
         {Tesla.Middleware.JSON, engine_opts: [keys: :atoms]},
+        Tesla.Middleware.KeepRequest,
+        Tesla.Middleware.PathParams,
         {Tesla.Middleware.Telemetry, metadata: %{provider: "Kaapi", sampling_scale: 10}}
       ] ++ Glific.get_tesla_retry_middleware()
     )
@@ -92,7 +94,9 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   def update_assistant(assistant_id, body, org_api_key) do
     org_api_key
     |> client()
-    |> Tesla.patch("/api/v1/assistant/#{assistant_id}", body)
+    |> Tesla.patch("/api/v1/assistant/:assistant_id", body,
+      opts: [path_params: [assistant_id: assistant_id]]
+    )
     |> parse_kaapi_response()
   end
 
@@ -103,7 +107,9 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   def delete_assistant(assistant_id, org_api_key) do
     org_api_key
     |> client()
-    |> Tesla.delete("/api/v1/assistant/#{assistant_id}")
+    |> Tesla.delete("/api/v1/assistant/:assistant_id",
+      opts: [path_params: [assistant_id: assistant_id]]
+    )
     |> parse_kaapi_response()
   end
 
@@ -125,7 +131,9 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   def create_config_version(config_id, body, org_api_key) do
     org_api_key
     |> client()
-    |> Tesla.post("/api/v1/configs/#{config_id}/versions", body)
+    |> Tesla.post("/api/v1/configs/:config_id/versions", body,
+      opts: [path_params: [config_id: config_id]]
+    )
     |> parse_kaapi_response()
   end
 
@@ -147,7 +155,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   def delete_config(uuid, org_api_key) do
     org_api_key
     |> client()
-    |> Tesla.delete("/api/v1/configs/#{uuid}")
+    |> Tesla.delete("/api/v1/configs/:uuid", opts: [path_params: [uuid: uuid]])
     |> parse_kaapi_response()
   end
 
@@ -156,11 +164,11 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   """
   @spec ingest_ai_assistants(non_neg_integer, String.t()) :: {:ok, any()} | {:error, String.t()}
   def ingest_ai_assistants(org_api_key, assistant_id) do
-    opts = [adapter: [recv_timeout: 30_000]]
+    opts = [adapter: [recv_timeout: 30_000], path_params: [assistant_id: assistant_id]]
 
     org_api_key
     |> client()
-    |> Tesla.post("/api/v1/assistant/#{assistant_id}/ingest", %{}, opts: opts)
+    |> Tesla.post("/api/v1/assistant/:assistant_id/ingest", %{}, opts: opts)
     |> case do
       {:ok, %Tesla.Env{status: status}} when status in 200..299 ->
         {:ok, %{message: "Assistant synced successfully"}}


### PR DESCRIPTION
## Testing ss:

<img width="1512" height="826" alt="Screenshot 2026-03-10 at 4 27 11 PM" src="https://github.com/user-attachments/assets/040af189-db38-414b-990c-8e811cccc11d" />

<img width="919" height="786" alt="Screenshot 2026-03-10 at 6 51 33 PM" src="https://github.com/user-attachments/assets/efed27a8-caba-46e8-af62-a6f6b1184fe9" />



Sample data: 

Glific.ThirdParty.Kaapi.ApiClient.update_assistant("asst_111", %{name: "Test"}, org_api_key)             
 Glific.ThirdParty.Kaapi.ApiClient.update_assistant("asst_222", %{name: "Test"}, org_api_key)           
 Glific.ThirdParty.Kaapi.ApiClient.update_assistant("asst_333", %{name: "Test"}, org_api_key)           
 Glific.ThirdParty.Kaapi.ApiClient.delete_assistant("asst_444", org_api_key)                            
 Glific.ThirdParty.Kaapi.ApiClient.delete_config("uuid-999", org_api_key)

or 

 org_api_key = Application.get_env(:glific, Glific.ThirdParty.Kaapi.ApiClient)[:kaapi_api_key]

  ### Sample 1 
  Glific.ThirdParty.Kaapi.ApiClient.create_assistant(%{
    name: "StoryBot",
    instructions: "You are a story telling assistant",
    model: "gpt-4o",
    temperature: 0.8
  }, org_api_key)

  ### Sample 2 
  Glific.ThirdParty.Kaapi.ApiClient.create_assistant(%{
    name: "SupportBot",
    instructions: "You are a customer support assistant",
    model: "gpt-4o",
    temperature: 0.5
  }, org_api_key)

  ### Sample 3 
  Glific.ThirdParty.Kaapi.ApiClient.create_assistant(%{
    name: "EduBot",
    instructions: "You are an education assistant for students",
    model: "gpt-4o-mini",
    temperature: 0.3
  }, org_api_key)

  ### Sample 4 
  Glific.ThirdParty.Kaapi.ApiClient.create_assistant(%{
    name: "HealthBot",
    instructions: "You are a health awareness assistant",
    model: "gpt-4o-mini",
    temperature: 0.2
  }, 

## How to test 

1- Go to the appsignal dashboard and copy the push_api_key from setting (from dev account)
2- Paste push_api_key to our env.dev
3-Also in the env change APPSIGNAL_ACTIVE = true
4-run above sample directly to your local iex
5- Create two different charts: one for Tesla failures and one for Tesla successes. Observe the URLs in the graphs and verify the counts


## Description
 
 ### Referenced:- https://hexdocs.pm/tesla/Tesla.Middleware.PathParams.html

 ### Problem:                                                                                                         
 AppSignal's tesla_request_response and tesla_request_error_count metrics were tagging requests with    
 fully-resolved URLs like /api/v1/assistant/asst_1234. Every unique ID created a separate data point,   
 making the distribution chart noisy and unreadable.  

  ### Changes:
  
   - api_client.ex — Added Tesla.Middleware.KeepRequest and Tesla.Middleware.PathParams to the Kaapi      
  middleware stack before Telemetry. Converted all string-interpolated URLs (e.g.
  "/api/v1/assistant/#{id}") to path-param style (ex -  "/api/v1/assistant/:assistant_id") so PathParams  
  resolves the URL while KeepRequest saves the template. 
- appsignal.ex — Added get_template_url/1 which reads opts[:req_url] (saved by KeepRequest) to extract
  the template URL instead of the resolved one. All AppSignal metric tags now use the template URL. 
- Increased default APPSIGNAL_SAMPLING_RATE from 10 to 100.



