### PR TITLE
fix: Fix file metadata API endpoint and add FAILED status handling in AssistantCloneWorker

### DIFF
--- a/lib/glific/third_party/kaapi/assistant_clone_worker.ex
+++ b/lib/glific/third_party/kaapi/assistant_clone_worker.ex
@@ -230,7 +230,8 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
     )
 
     if succeeded == 0 and length(files) > 0 do
-      {:error, "#{length(failed_files)} file downloads failed for #{assistant_name}: #{Enum.join(failed_files, ", ")}"}
+      {:error,
+       "#{length(failed_files)} file downloads failed for #{assistant_name}: #{Enum.join(failed_files, ", ")}"}
     else
       :ok
     end
@@ -240,15 +241,13 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
   defp download_file(%{"id" => file_id} = _file, vector_store_id, assistant_name, organization_id) do
     Logger.info("Fetching metadata for #{file_id}")
 
-    case Req.get("#{@base_url}/vector_stores/#{vector_store_id}/files/#{file_id}",
-           headers: auth_headers()
-         ) do
+    case Req.get("#{@base_url}/files/#{file_id}", headers: auth_headers()) do
       {:ok, %{status: 200, body: %{"filename" => filename} = _meta}} ->
         fetch_and_save(file_id, filename, vector_store_id, assistant_name, organization_id)
 
-      {:ok, %{status: 200, body: meta}} ->
+      {:ok, %{status: 200}} ->
         # Fallback filename if "filename" key is missing
-        filename = meta["filename"] || "#{file_id}.md"
+        filename = "#{file_id}.md"
         fetch_and_save(file_id, filename, vector_store_id, assistant_name, organization_id)
 
       {:ok, %{status: status, body: body}} ->

--- a/lib/glific/third_party/kaapi/assistant_clone_worker.ex
+++ b/lib/glific/third_party/kaapi/assistant_clone_worker.ex
@@ -376,6 +376,13 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
 
         {:ok, kb_id}
 
+      {:ok, %{status: "FAILED", error_message: reason}} ->
+        Logger.error(
+          "AssistantCloneWorker: Collection creation failed for #{collection_job_id} for reason: #{reason}"
+        )
+
+        {:error, "Collection creation failed for #{collection_job_id}"}
+
       {:ok, %{status: status}} ->
         elapsed_ms = System.monotonic_time(:millisecond) - start_time_ms
 

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -196,7 +196,6 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         assert cloned_config.prompt == "You are a helpful assistant"
         assert cloned_config.status == :ready
       end
-
     end
 
     test "returns error when assistant not found" do
@@ -337,7 +336,6 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
                    organization_id: @org_id
                  })
       end
-
     end
 
     test "returns error when Kaapi config creation fails", %{assistant: assistant} do
@@ -400,7 +398,6 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
                    organization_id: @org_id
                  })
       end
-
     end
   end
 

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -486,7 +486,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         assert {:error, msg} =
                  perform_job(AssistantCloneWorker, %{
                    assistant_id: assistant.id,
-                   organization_id: @org_id
+                   organization_id: @org_id,
+                   version_id: 1,
+                   is_legacy: true
                  })
 
         assert msg =~ "Collection creation failed for job_failed_123"
@@ -539,7 +541,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         assert {:error, _} =
                  perform_job(AssistantCloneWorker, %{
                    assistant_id: assistant.id,
-                   organization_id: @org_id
+                   organization_id: @org_id,
+                   version_id: 1,
+                   is_legacy: true
                  })
       end
     end
@@ -617,7 +621,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         assert :ok =
                  perform_job(AssistantCloneWorker, %{
                    assistant_id: assistant.id,
-                   organization_id: @org_id
+                   organization_id: @org_id,
+                   version_id: 1,
+                   is_legacy: true
                  })
 
         assert Agent.get(call_counter, & &1) >= 2

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -441,7 +441,7 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
             if String.contains?(url, "collections/jobs/job_failed_123") do
               %Tesla.Env{
                 status: 200,
-                body: %{data: %{status: "FAILED", collection: nil}}
+                body: %{data: %{status: "FAILED", error_message: "Failed to create collection"}}
               }
             end
         end)

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -399,6 +399,193 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
                  })
       end
     end
+    
+    test "returns error immediately when collection status is FAILED", %{assistant: assistant} do
+      clone_dir = Path.join(System.tmp_dir!(), "clone/#{@org_id}/#{assistant.name}")
+      File.mkdir_p!(clone_dir)
+      File.write!(Path.join(clone_dir, "doc.pdf"), "test content")
+
+      with_mock Req,
+        get: fn url, _opts ->
+          cond do
+            String.contains?(url, "/files/file_001/content") ->
+              {:ok, %{status: 200, body: %{"data" => [%{"type" => "text", "text" => "content"}]}}}
+
+            String.contains?(url, "/files/file_001") ->
+              {:ok, %{status: 200, body: %{"filename" => "doc.pdf"}}}
+
+            String.contains?(url, "/files") ->
+              {:ok,
+               %{status: 200, body: %{"data" => [%{"id" => "file_001"}], "has_more" => false}}}
+
+            true ->
+              {:ok, %{status: 404, body: %{}}}
+          end
+        end do
+        Tesla.Mock.mock(fn
+          %{method: :post, url: url} ->
+            cond do
+              String.contains?(url, "documents") ->
+                %Tesla.Env{
+                  status: 200,
+                  body: %{
+                    data: %{id: "doc_001", fname: "doc.pdf", inserted_at: "2026-03-23T12:00:00Z"}
+                  }
+                }
+
+              String.contains?(url, "collections") ->
+                %Tesla.Env{status: 200, body: %{data: %{job_id: "job_failed_123"}}}
+            end
+
+          %{method: :get, url: url} ->
+            if String.contains?(url, "collections/jobs/job_failed_123") do
+              %Tesla.Env{
+                status: 200,
+                body: %{data: %{status: "FAILED", collection: nil}}
+              }
+            end
+        end)
+
+        assert {:error, msg} =
+                 perform_job(AssistantCloneWorker, %{
+                   assistant_id: assistant.id,
+                   organization_id: @org_id
+                 })
+
+        assert msg =~ "Collection creation failed for job_failed_123"
+      end
+    end
+
+    test "returns error when get_collection_status API call fails", %{assistant: assistant} do
+      clone_dir = Path.join(System.tmp_dir!(), "clone/#{@org_id}/#{assistant.name}")
+      File.mkdir_p!(clone_dir)
+      File.write!(Path.join(clone_dir, "doc.pdf"), "test content")
+
+      with_mock Req,
+        get: fn url, _opts ->
+          cond do
+            String.contains?(url, "/files/file_001/content") ->
+              {:ok, %{status: 200, body: %{"data" => [%{"type" => "text", "text" => "content"}]}}}
+
+            String.contains?(url, "/files/file_001") ->
+              {:ok, %{status: 200, body: %{"filename" => "doc.pdf"}}}
+
+            String.contains?(url, "/files") ->
+              {:ok,
+               %{status: 200, body: %{"data" => [%{"id" => "file_001"}], "has_more" => false}}}
+
+            true ->
+              {:ok, %{status: 404, body: %{}}}
+          end
+        end do
+        Tesla.Mock.mock(fn
+          %{method: :post, url: url} ->
+            cond do
+              String.contains?(url, "documents") ->
+                %Tesla.Env{
+                  status: 200,
+                  body: %{
+                    data: %{id: "doc_001", fname: "doc.pdf", inserted_at: "2026-03-23T12:00:00Z"}
+                  }
+                }
+
+              String.contains?(url, "collections") ->
+                %Tesla.Env{status: 200, body: %{data: %{job_id: "job_err_123"}}}
+            end
+
+          %{method: :get, url: url} ->
+            if String.contains?(url, "collections/jobs/job_failed_123") do
+              %Tesla.Env{status: 503, body: %{error: "Service unavailable"}}
+            end
+        end)
+
+        assert {:error, _} =
+                 perform_job(AssistantCloneWorker, %{
+                   assistant_id: assistant.id,
+                   organization_id: @org_id
+                 })
+      end
+    end
+
+    test "retries polling when status is PROCESSING before becoming SUCCESSFUL", %{
+      assistant: assistant
+    } do
+      clone_dir = Path.join(System.tmp_dir!(), "clone/#{@org_id}/#{assistant.name}")
+      File.mkdir_p!(clone_dir)
+      File.write!(Path.join(clone_dir, "doc.pdf"), "test content")
+
+      {:ok, call_counter} = Agent.start_link(fn -> 0 end)
+
+      with_mock Req,
+        get: fn url, _opts ->
+          cond do
+            String.contains?(url, "/files/file_001/content") ->
+              {:ok, %{status: 200, body: %{"data" => [%{"type" => "text", "text" => "content"}]}}}
+
+            String.contains?(url, "/files/file_001") ->
+              {:ok, %{status: 200, body: %{"filename" => "doc.pdf"}}}
+
+            String.contains?(url, "/files") ->
+              {:ok,
+               %{status: 200, body: %{"data" => [%{"id" => "file_001"}], "has_more" => false}}}
+
+            true ->
+              {:ok, %{status: 404, body: %{}}}
+          end
+        end do
+        Tesla.Mock.mock(fn
+          %{method: :post, url: url} ->
+            cond do
+              String.contains?(url, "documents") ->
+                %Tesla.Env{
+                  status: 200,
+                  body: %{
+                    data: %{id: "doc_001", fname: "doc.pdf", inserted_at: "2026-03-23T12:00:00Z"}
+                  }
+                }
+
+              String.contains?(url, "collections") ->
+                %Tesla.Env{status: 200, body: %{data: %{job_id: "job_retry_123"}}}
+
+              String.contains?(url, "configs") ->
+                %Tesla.Env{
+                  status: 200,
+                  body: %{data: %{id: "cloned_kaapi_uuid", version: %{version: 1}}}
+                }
+            end
+
+          %{method: :get, url: url} ->
+            if String.contains?(url, "collections/jobs") do
+              count = Agent.get_and_update(call_counter, fn n -> {n, n + 1} end)
+
+              if count == 0 do
+                %Tesla.Env{
+                  status: 200,
+                  body: %{data: %{status: "PROCESSING", collection: nil}}
+                }
+              else
+                %Tesla.Env{
+                  status: 200,
+                  body: %{
+                    data: %{
+                      status: "SUCCESSFUL",
+                      collection: %{knowledge_base_id: "cloned_kb_retry"}
+                    }
+                  }
+                }
+              end
+            end
+        end)
+
+        assert :ok =
+                 perform_job(AssistantCloneWorker, %{
+                   assistant_id: assistant.id,
+                   organization_id: @org_id
+                 })
+
+        assert Agent.get(call_counter, & &1) >= 2
+      end
+    end
   end
 
   describe "clone_assistant/1 enqueues job" do


### PR DESCRIPTION
## Summary

- Fixed incorrect API endpoint for fetching file metadata — was using `/vector_stores/{id}/files/{file_id}` (which doesn't return `filename`), now correctly uses `/files/{file_id}`
- Added explicit handling for `FAILED` collection creation status, returning an error immediately instead of falling through to the generic status handler
- Added tests covering FAILED collection status, API errors during status polling, and PROCESSING→SUCCESSFUL retry flow

## Test plan

- [ ] Clone a legacy assistant and verify file names are copied correctly (not falling back to `{file_id}.md`)
- [ ] Verify clone job fails fast and logs clearly when collection creation returns `FAILED` status
- [ ] Run `mix test test/glific/third_party/kaapi/assistant_clone_worker_test.exs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)