### PR TITLE
ci: add kaapi credentials to dev seeds

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -598,7 +598,6 @@ defmodule Glific.Assistants do
     |> Multi.update(:updated_assistant, fn %{
                                              config_version: config_version
                                            } ->
-
       organization = Partners.organization(kaapi_config.organization_id)
 
       attrs =

--- a/lib/glific/seeds/seeds_dev.ex
+++ b/lib/glific/seeds/seeds_dev.ex
@@ -52,7 +52,7 @@ if Code.ensure_loaded?(Faker) do
     alias Faker.Lorem.Shakespeare
 
     @doc false
-    @spec seed_kaapi_credential(Organization.t() | nil) :: :ok
+    @spec seed_kaapi_credential(Organization.t() | nil) :: :ok | {:error, String.t()}
     def seed_kaapi_credential(organization \\ nil) do
       organization = get_organization(organization)
       Repo.put_organization_id(organization.id)
@@ -67,36 +67,63 @@ if Code.ensure_loaded?(Faker) do
         Logger.info("Skipping Kaapi credential seed: KAAPI_API_KEY not set")
         :ok
       else
-        case Repo.fetch_by(Provider, %{shortcode: "kaapi"}) do
-          {:ok, _provider} ->
-            upsert_kaapi_credential(organization.id, api_key)
-            :ok
-
-          {:error, _reason} ->
+        with {:ok, _provider} <- Repo.fetch_by(Provider, %{shortcode: "kaapi"}),
+             {:ok, _credential} <- upsert_kaapi_credential(organization.id, api_key) do
+          :ok
+        else
+          {:error, reasons} when is_list(reasons) ->
             Logger.info("Skipping Kaapi credential seed: provider kaapi not found")
             :ok
+
+          {:error, _} = logged ->
+            logged
         end
       end
     end
 
+    @spec upsert_kaapi_credential(integer(), String.t()) ::
+            {:ok, Partners.Credential.t()} | {:error, String.t()}
     defp upsert_kaapi_credential(organization_id, api_key) do
+      attrs = %{secrets: %{"api_key" => api_key}, is_active: true}
+
       case Partners.get_credential(%{organization_id: organization_id, shortcode: "kaapi"}) do
         {:ok, credential} ->
-          Partners.update_credential(credential, %{
-            secrets: %{"api_key" => api_key},
-            is_active: true
-          })
+          case Partners.update_credential(credential, attrs) do
+            {:ok, updated} ->
+              {:ok, updated}
+
+            {:error, reason} ->
+              message =
+                "Kaapi credential seed: update failed: #{inspect_credential_error(reason)}"
+
+              Glific.log_error(message)
+          end
 
         {:error, _reason} ->
-          Partners.create_credential(%{
+          create_attrs = %{
             organization_id: organization_id,
             shortcode: "kaapi",
             keys: %{},
             secrets: %{"api_key" => api_key},
             is_active: true
-          })
+          }
+
+          case Partners.create_credential(create_attrs) do
+            {:ok, created} ->
+              {:ok, created}
+
+            {:error, reason} ->
+              message =
+                "Kaapi credential seed: create failed: #{inspect_credential_error(reason)}"
+
+              Glific.log_error(message)
+          end
       end
     end
+
+    defp inspect_credential_error(%Ecto.Changeset{} = changeset), do: inspect(changeset.errors)
+
+    defp inspect_credential_error(other), do: inspect(other)
 
     @doc """
     Smaller functions to seed various tables. This allows the test functions to call specific seeder functions.

--- a/lib/glific/seeds/seeds_dev.ex
+++ b/lib/glific/seeds/seeds_dev.ex
@@ -4,6 +4,8 @@ if Code.ensure_loaded?(Faker) do
     Script for populating the database. We can call this from tests and/or /priv/repo
     """
 
+    require Logger
+
     alias Faker.Phone
 
     alias Glific.{
@@ -26,6 +28,7 @@ if Code.ensure_loaded?(Faker) do
       Messages.MessageMedia,
       Notifications,
       Notifications.Notification,
+      Partners,
       Partners.Billing,
       Partners.Organization,
       Partners.Provider,
@@ -47,6 +50,53 @@ if Code.ensure_loaded?(Faker) do
     }
 
     alias Faker.Lorem.Shakespeare
+
+    @doc false
+    @spec seed_kaapi_credential(Organization.t() | nil) :: :ok
+    def seed_kaapi_credential(organization \\ nil) do
+      organization = get_organization(organization)
+      Repo.put_organization_id(organization.id)
+
+      api_key =
+        case System.get_env("KAAPI_API_KEY") do
+          nil -> nil
+          value when is_binary(value) -> String.trim(value)
+        end
+
+      if api_key in [nil, ""] do
+        Logger.info("Skipping Kaapi credential seed: KAAPI_API_KEY not set")
+        :ok
+      else
+        case Repo.fetch_by(Provider, %{shortcode: "kaapi"}) do
+          {:ok, _provider} ->
+            upsert_kaapi_credential(organization.id, api_key)
+            :ok
+
+          {:error, _reason} ->
+            Logger.info("Skipping Kaapi credential seed: provider kaapi not found")
+            :ok
+        end
+      end
+    end
+
+    defp upsert_kaapi_credential(organization_id, api_key) do
+      case Partners.get_credential(%{organization_id: organization_id, shortcode: "kaapi"}) do
+        {:ok, credential} ->
+          Partners.update_credential(credential, %{
+            secrets: %{"api_key" => api_key},
+            is_active: true
+          })
+
+        {:error, _reason} ->
+          Partners.create_credential(%{
+            organization_id: organization_id,
+            shortcode: "kaapi",
+            keys: %{},
+            secrets: %{"api_key" => api_key},
+            is_active: true
+          })
+      end
+    end
 
     @doc """
     Smaller functions to seed various tables. This allows the test functions to call specific seeder functions.
@@ -2021,6 +2071,8 @@ if Code.ensure_loaded?(Faker) do
       organization = get_organization()
 
       Repo.put_organization_id(organization.id)
+
+      seed_kaapi_credential(organization)
 
       seed_contacts(organization)
 

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -202,7 +202,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         refreshed = Repo.get!(Assistant, assistant.id)
         assert refreshed.clone_status == "completed"
 
-        notification = Repo.one(from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1)
+        notification =
+          Repo.one(from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1)
+
         assert notification.message =~ "cloned successfully"
       end
     end
@@ -278,11 +280,12 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         refreshed = Repo.get!(Assistant, assistant.id)
         assert refreshed.clone_status == "failed"
 
-        notif = Glific.Repo.one(
-          from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1
-        )
-        assert notif.message =~ "Assistant cloning failed"
+        notif =
+          Glific.Repo.one(
+            from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1
+          )
 
+        assert notif.message =~ "Assistant cloning failed"
       end
     end
 


### PR DESCRIPTION
This PR upserts the Kaapi credentials in dev seeds which is used for testing. It fetches the seeds from an env var `KAAPI_API_KEY`. If they env var is missing a warning log line is written and the process continues. 

This is necessary so that when running cypress-tests we can configure kaapi credentials in CI and test the E2E flows.

https://github.com/glific/cypress-testing/pull/219