### PR TITLE
feat: push ecto telemtry events to appsignal

### DIFF
--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -69,6 +69,9 @@ defmodule Glific.Application do
     # Add this :telemetry.attach/4 for Tesla success/failure call:
     attach_tesla_telemetry_event()
 
+    # Add this :telemetry.attach/4 for Ecto query timing:
+    attach_repo_telemetry_event()
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Glific.Supervisor]
@@ -159,6 +162,18 @@ defmodule Glific.Application do
       ],
       &Mailer.handle_event/4,
       nil
+    )
+  end
+
+  defp attach_repo_telemetry_event do
+    :telemetry.attach_many(
+      "repo-query-stop",
+      [
+        [:glific, :repo, :query],
+        [:glific, :repo_replica, :query]
+      ],
+      &Glific.Appsignal.handle_event/4,
+      []
     )
   end
 end

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -167,7 +167,7 @@ defmodule Glific.Application do
 
   defp attach_repo_telemetry_event do
     :telemetry.attach_many(
-      "repo-query-stop",
+      "repo-query",
       [
         [:glific, :repo, :query],
         [:glific, :repo_replica, :query]

--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -98,6 +98,19 @@ defmodule Glific.Appsignal do
     @tracer.close_span(span, end_time: time)
   end
 
+  def handle_event([:glific, repo, :query], measurement, _meta, _)
+      when repo in [:repo, :repo_replica] do
+    tags = %{repo: repo}
+
+    maybe_add_distribution_metric(measurement, :query_time, "glific.repo.query_time", tags)
+    maybe_add_distribution_metric(measurement, :idle_time, "glific.repo.idle_time", tags)
+    maybe_add_distribution_metric(measurement, :queue_time, "glific.repo.queue_time", tags)
+
+    if measurement |> Map.has_key?(:query_time) do
+      Appsignal.increment_counter("glific.repo.query_count", 1, tags)
+    end
+  end
+
   def handle_event(_, _, _, _), do: nil
 
   @doc """
@@ -191,5 +204,17 @@ defmodule Glific.Appsignal do
     )
     |> @span.set_name("Tesla #{metadata.method} #{host}")
     |> @span.set_attribute("appsignal:category", "tesla.request")
+  end
+
+  @spec maybe_add_distribution_metric(map(), atom(), String.t(), map()) :: :ok
+  defp maybe_add_distribution_metric(measurement, key, metric_name, tags) do
+    case Map.fetch(measurement, key) do
+      {:ok, value} ->
+        value_in_milliseconds = System.convert_time_unit(value, :native, :millisecond)
+        Appsignal.add_distribution_value(metric_name, value_in_milliseconds, tags)
+
+      :error ->
+        :ok
+    end
   end
 end

--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -105,16 +105,17 @@ defmodule Glific.Appsignal do
     @tracer.close_span(span, end_time: time)
   end
 
-  def handle_event([:glific, repo, :query], measurement, _meta, _)
+  def handle_event([:glific, repo, :query], measurement, meta, _)
       when repo in [:repo, :repo_replica] do
     tags = %{repo: repo}
+    query_tags = Map.put(tags, :command_type, get_command_type(meta))
 
-    maybe_add_distribution_metric(measurement, :query_time, "glific.repo.query_time", tags)
+    maybe_add_distribution_metric(measurement, :query_time, "glific.repo.query_time", query_tags)
     maybe_add_distribution_metric(measurement, :idle_time, "glific.repo.idle_time", tags)
     maybe_add_distribution_metric(measurement, :queue_time, "glific.repo.queue_time", tags)
 
     if measurement |> Map.has_key?(:query_time) do
-      Appsignal.increment_counter("glific.repo.query_count", 1, tags)
+      Appsignal.increment_counter("glific.repo.query_count", 1, query_tags)
     end
   end
 
@@ -222,6 +223,20 @@ defmodule Glific.Appsignal do
 
       :error ->
         :ok
+    end
+  end
+
+  @spec get_command_type(map()) :: String.t()
+  defp get_command_type(meta) do
+    meta
+    |> Map.get(:query, "")
+    |> String.trim_leading()
+    |> String.split(~r/\s+/, parts: 2)
+    |> List.first()
+    |> case do
+      nil -> "unknown"
+      "" -> "unknown"
+      command -> String.upcase(command)
     end
   end
 end

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -7,6 +7,8 @@ defmodule Glific.AppsignalTest do
   defp native_to_milliseconds(native),
     do: System.convert_time_unit(native, :native, :millisecond)
 
+  defp repo_tags(repo, command_type), do: %{repo: repo, command_type: command_type}
+
   describe "handle_event/4 repo query telemetry" do
     test "records distribution metrics and query count for :repo when timings are present" do
       measurement = %{
@@ -17,6 +19,8 @@ defmodule Glific.AppsignalTest do
 
       parent = self()
 
+      query = "SELECT * FROM contacts WHERE id = $1"
+
       with_mock Appsignal, [],
         add_distribution_value: fn name, value, tags ->
           send(parent, {:dist, name, value, tags})
@@ -26,17 +30,17 @@ defmodule Glific.AppsignalTest do
           send(parent, {:cnt, name, amount, tags})
           :ok
         end do
-        Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
+        Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{query: query}, nil)
       end
 
       expected_query_time_ms = native_to_milliseconds(measurement.query_time)
       expected_idle_time_ms = native_to_milliseconds(measurement.idle_time)
       expected_queue_time_ms = native_to_milliseconds(measurement.queue_time)
 
-      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo, command_type: "SELECT"}}
       assert_receive {:dist, "glific.repo.idle_time", ^expected_idle_time_ms, %{repo: :repo}}
       assert_receive {:dist, "glific.repo.queue_time", ^expected_queue_time_ms, %{repo: :repo}}
-      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
+      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo, command_type: "SELECT"}}
     end
 
     test "tags metrics with :repo_replica for replica repo events" do
@@ -48,6 +52,8 @@ defmodule Glific.AppsignalTest do
 
       parent = self()
 
+      query = "update contacts set name = $1 where id = $2"
+
       with_mock Appsignal, [],
         add_distribution_value: fn name, value, tags ->
           send(parent, {:dist, name, value, tags})
@@ -57,18 +63,24 @@ defmodule Glific.AppsignalTest do
           send(parent, {:cnt, name, amount, tags})
           :ok
         end do
-        Glific.Appsignal.handle_event([:glific, :repo_replica, :query], measurement, %{}, nil)
+        Glific.Appsignal.handle_event(
+          [:glific, :repo_replica, :query],
+          measurement,
+          %{query: query},
+          nil
+        )
       end
 
+      query_tags = repo_tags(:repo_replica, "UPDATE")
       tags = %{repo: :repo_replica}
 
-      assert_receive {:dist, "glific.repo.query_time", _, ^tags}
+      assert_receive {:dist, "glific.repo.query_time", _, ^query_tags}
       assert_receive {:dist, "glific.repo.idle_time", _, ^tags}
       assert_receive {:dist, "glific.repo.queue_time", _, ^tags}
-      assert_receive {:cnt, "glific.repo.query_count", 1, ^tags}
+      assert_receive {:cnt, "glific.repo.query_count", 1, ^query_tags}
     end
 
-    test "does not increment query count when query_time is absent" do
+    test "uses unknown command type and does not increment query count when query_time is absent" do
       measurement = %{
         idle_time: 1_000_000,
         queue_time: 500_000
@@ -95,7 +107,7 @@ defmodule Glific.AppsignalTest do
       refute_receive {:cnt, _, _, _}
     end
 
-    test "records only metrics for timings that are present" do
+    test "records only query metrics for timings that are present with unknown command type" do
       measurement = %{query_time: 3_000_000}
       parent = self()
 
@@ -113,8 +125,8 @@ defmodule Glific.AppsignalTest do
 
       expected_query_time_ms = native_to_milliseconds(measurement.query_time)
 
-      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo}}
-      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo, command_type: "unknown"}}
+      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo, command_type: "unknown"}}
       refute_receive {:dist, _, _, _}, 0
     end
 

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -4,9 +4,10 @@ defmodule Glific.AppsignalTest do
 
   # Avoid `alias Glific.Appsignal` — it would shadow the Appsignal dependency used in with_mock.
 
-  describe "handle_event/4 repo query telemetry" do
-    defp ms(native), do: System.convert_time_unit(native, :native, :millisecond)
+  defp native_to_milliseconds(native),
+    do: System.convert_time_unit(native, :native, :millisecond)
 
+  describe "handle_event/4 repo query telemetry" do
     test "records distribution metrics and query count for :repo when timings are present" do
       measurement = %{
         query_time: 2_000_000,
@@ -28,13 +29,13 @@ defmodule Glific.AppsignalTest do
         Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
       end
 
-      expected_qt = ms(measurement.query_time)
-      expected_it = ms(measurement.idle_time)
-      expected_queue = ms(measurement.queue_time)
+      expected_query_time_ms = native_to_milliseconds(measurement.query_time)
+      expected_idle_time_ms = native_to_milliseconds(measurement.idle_time)
+      expected_queue_time_ms = native_to_milliseconds(measurement.queue_time)
 
-      assert_receive {:dist, "glific.repo.query_time", ^expected_qt, %{repo: :repo}}
-      assert_receive {:dist, "glific.repo.idle_time", ^expected_it, %{repo: :repo}}
-      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.idle_time", ^expected_idle_time_ms, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue_time_ms, %{repo: :repo}}
       assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
     end
 
@@ -86,11 +87,11 @@ defmodule Glific.AppsignalTest do
         Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
       end
 
-      expected_it = ms(measurement.idle_time)
-      expected_queue = ms(measurement.queue_time)
+      expected_idle_time_ms = native_to_milliseconds(measurement.idle_time)
+      expected_queue_time_ms = native_to_milliseconds(measurement.queue_time)
 
-      assert_receive {:dist, "glific.repo.idle_time", ^expected_it, %{repo: :repo}}
-      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.idle_time", ^expected_idle_time_ms, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue_time_ms, %{repo: :repo}}
       refute_receive {:cnt, _, _, _}
     end
 
@@ -110,9 +111,9 @@ defmodule Glific.AppsignalTest do
         Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
       end
 
-      expected_qt = ms(measurement.query_time)
+      expected_query_time_ms = native_to_milliseconds(measurement.query_time)
 
-      assert_receive {:dist, "glific.repo.query_time", ^expected_qt, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.query_time", ^expected_query_time_ms, %{repo: :repo}}
       assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
       refute_receive {:dist, _, _, _}, 0
     end

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -1,0 +1,154 @@
+defmodule Glific.AppsignalTest do
+  use Glific.DataCase, async: true
+  import Mock
+
+  # Avoid `alias Glific.Appsignal` — it would shadow the Appsignal dependency used in with_mock.
+
+  describe "handle_event/4 repo query telemetry" do
+    defp ms(native), do: System.convert_time_unit(native, :native, :millisecond)
+
+    test "records distribution metrics and query count for :repo when timings are present" do
+      measurement = %{
+        query_time: 2_000_000,
+        idle_time: 1_000_000,
+        queue_time: 500_000
+      }
+
+      parent = self()
+
+      with_mock Appsignal, [],
+        add_distribution_value: fn name, value, tags ->
+          send(parent, {:dist, name, value, tags})
+          :ok
+        end,
+        increment_counter: fn name, amount, tags ->
+          send(parent, {:cnt, name, amount, tags})
+          :ok
+        end do
+        Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
+      end
+
+      expected_qt = ms(measurement.query_time)
+      expected_it = ms(measurement.idle_time)
+      expected_queue = ms(measurement.queue_time)
+
+      assert_receive {:dist, "glific.repo.query_time", ^expected_qt, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.idle_time", ^expected_it, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue, %{repo: :repo}}
+      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
+    end
+
+    test "tags metrics with :repo_replica for replica repo events" do
+      measurement = %{
+        query_time: 2_000_000,
+        idle_time: 1_000_000,
+        queue_time: 500_000
+      }
+
+      parent = self()
+
+      with_mock Appsignal, [],
+        add_distribution_value: fn name, value, tags ->
+          send(parent, {:dist, name, value, tags})
+          :ok
+        end,
+        increment_counter: fn name, amount, tags ->
+          send(parent, {:cnt, name, amount, tags})
+          :ok
+        end do
+        Glific.Appsignal.handle_event([:glific, :repo_replica, :query], measurement, %{}, nil)
+      end
+
+      tags = %{repo: :repo_replica}
+
+      assert_receive {:dist, "glific.repo.query_time", _, ^tags}
+      assert_receive {:dist, "glific.repo.idle_time", _, ^tags}
+      assert_receive {:dist, "glific.repo.queue_time", _, ^tags}
+      assert_receive {:cnt, "glific.repo.query_count", 1, ^tags}
+    end
+
+    test "does not increment query count when query_time is absent" do
+      measurement = %{
+        idle_time: 1_000_000,
+        queue_time: 500_000
+      }
+
+      parent = self()
+
+      with_mock Appsignal, [],
+        add_distribution_value: fn name, value, tags ->
+          send(parent, {:dist, name, value, tags})
+          :ok
+        end,
+        increment_counter: fn _, _, _ ->
+          flunk("increment_counter should not be called when query_time is missing")
+        end do
+        Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
+      end
+
+      expected_it = ms(measurement.idle_time)
+      expected_queue = ms(measurement.queue_time)
+
+      assert_receive {:dist, "glific.repo.idle_time", ^expected_it, %{repo: :repo}}
+      assert_receive {:dist, "glific.repo.queue_time", ^expected_queue, %{repo: :repo}}
+      refute_receive {:cnt, _, _, _}
+    end
+
+    test "records only metrics for timings that are present" do
+      measurement = %{query_time: 3_000_000}
+      parent = self()
+
+      with_mock Appsignal, [],
+        add_distribution_value: fn name, value, tags ->
+          send(parent, {:dist, name, value, tags})
+          :ok
+        end,
+        increment_counter: fn name, amount, tags ->
+          send(parent, {:cnt, name, amount, tags})
+          :ok
+        end do
+        Glific.Appsignal.handle_event([:glific, :repo, :query], measurement, %{}, nil)
+      end
+
+      expected_qt = ms(measurement.query_time)
+
+      assert_receive {:dist, "glific.repo.query_time", ^expected_qt, %{repo: :repo}}
+      assert_receive {:cnt, "glific.repo.query_count", 1, %{repo: :repo}}
+      refute_receive {:dist, _, _, _}, 0
+    end
+
+    test "does not record metrics when measurement is empty" do
+      with_mock Appsignal, [],
+        add_distribution_value: fn _, _, _ ->
+          flunk("add_distribution_value should not be called")
+        end,
+        increment_counter: fn _, _, _ ->
+          flunk("increment_counter should not be called")
+        end do
+        assert Glific.Appsignal.handle_event([:glific, :repo, :query], %{}, %{}, nil) == nil
+      end
+    end
+
+    test "does not record metrics for repo names other than :repo and :repo_replica" do
+      with_mock Appsignal, [],
+        add_distribution_value: fn _, _, _ ->
+          flunk("add_distribution_value should not be called")
+        end,
+        increment_counter: fn _, _, _ ->
+          flunk("increment_counter should not be called")
+        end do
+        assert Glific.Appsignal.handle_event(
+                 [:glific, :other, :query],
+                 %{query_time: 1},
+                 %{},
+                 nil
+               ) ==
+                 nil
+      end
+    end
+
+    test "returns nil for unrelated telemetry events" do
+      assert Glific.Appsignal.handle_event([:some, :other, :event], %{}, %{}, nil) == nil
+    end
+  end
+end


### PR DESCRIPTION
We want to increase oban queue sizes which means we'll need more db connections (https://hexdocs.pm/oban/defining_queues.html#queue-planning-guidelines). This PR adds ecto connection queue_time (and other metrics) to appsignal so that we can track how long connection requests are queued. If the number is low we can increase oban queue sizes without increasing the connection pool size which is set to 70 at the moment. 

**Note**
- Pushing metrics for every query does add a slight overhead to the request but its not significant (https://docs.appsignal.com/appsignal/how-appsignal-operates.html). If we notice a drop in performance we can considering sampling the requests.
- We are also sending query_count, query_time and idle_time metrics which could be useful in the future
- [Here](https://hexdocs.pm/ecto/Ecto.Repo.html#module-telemetry-events) are the telemetry events ecto sends

This is to help with investigation for #4955

## Testing
Apart from the tests, the change was tested on local by pushing data to appsignal directly for env:dev