### PR TITLE
fix: legacy clone status logic

### DIFF
--- a/lib/glific/third_party/kaapi/assistant_clone_worker.ex
+++ b/lib/glific/third_party/kaapi/assistant_clone_worker.ex
@@ -141,7 +141,7 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
              kaapi_uuid,
              kaapi_config_version
            ) do
-      update_clone_status(assistant, "")
+      update_clone_status(assistant, "completed")
 
       send_clone_notification(
         organization_id,

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -198,6 +198,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
         assert cloned_config.model == "gpt-4o"
         assert cloned_config.prompt == "You are a helpful assistant"
         assert cloned_config.status == :ready
+
+        refreshed = Repo.get!(Assistant, assistant.id)
+        assert refreshed.clone_status == "completed"
       end
     end
 

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -201,6 +201,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
 
         refreshed = Repo.get!(Assistant, assistant.id)
         assert refreshed.clone_status == "completed"
+
+        notification = Repo.one(from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1)
+        assert notification.message =~ "cloned successfully"
       end
     end
 
@@ -261,12 +264,25 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
           {:ok, %{status: 500, body: %{"error" => "Internal server error"}}}
         end do
         assert {:error, _} =
-                 perform_job(AssistantCloneWorker, %{
-                   assistant_id: assistant.id,
-                   version_id: assistant.active_config_version_id,
-                   organization_id: @org_id,
-                   is_legacy: true
-                 })
+                 perform_job(
+                   AssistantCloneWorker,
+                   %{
+                     assistant_id: assistant.id,
+                     version_id: assistant.active_config_version_id,
+                     organization_id: @org_id,
+                     is_legacy: true
+                   },
+                   attempt: 2
+                 )
+
+        refreshed = Repo.get!(Assistant, assistant.id)
+        assert refreshed.clone_status == "failed"
+
+        notif = Glific.Repo.one(
+          from n in Glific.Notifications.Notification, order_by: [desc: n.id], limit: 1
+        )
+        assert notif.message =~ "Assistant cloning failed"
+
       end
     end
 


### PR DESCRIPTION
Fix issue in #4959 where clone_status for legacy assistants was incorrectly updated to "none" causing the UI button to break. The fix is to keep the status as completed. 

Since the new UI does not uses the clone_status column the change is forwards compatible.