### PR TITLE
feat: Add assistant_id filter with OR search to assistants list query

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -161,7 +161,7 @@ defmodule Glific.Assistants do
   def list_assistants(args) do
     assistants =
       args
-      |> Repo.list_filter_query(Assistant, &Repo.opts_with_inserted_at/2, &Repo.filter_with/2)
+      |> Repo.list_filter_query(Assistant, &Repo.opts_with_inserted_at/2, &filter_with/2)
       |> Repo.all()
       |> preload_assistant_associations()
 
@@ -174,8 +174,34 @@ defmodule Glific.Assistants do
   @spec count_assistants(map()) :: integer()
   def count_assistants(args) do
     args
-    |> Repo.list_filter_query(Assistant, nil, &Repo.filter_with/2)
+    |> Repo.list_filter_query(Assistant, nil, &filter_with/2)
     |> Repo.aggregate(:count)
+  end
+
+  @spec filter_with(Ecto.Queryable.t(), map()) :: Ecto.Queryable.t()
+  defp filter_with(query, filter) do
+    # When assistant_id is present, skip the name filter from Repo.filter_with so we can
+    # apply OR logic (name OR assistant_display_id) instead of AND.
+    base_filter =
+      if Map.has_key?(filter, :assistant_id),
+        do: Map.drop(filter, [:name]),
+        else: filter
+
+    query = Repo.filter_with(query, base_filter)
+
+    Enum.reduce(filter, query, fn
+      {:assistant_id, assistant_id}, query ->
+        name_term = Map.get(filter, :name, assistant_id)
+        name_pattern = "%#{name_term}%"
+        id_pattern = "%#{assistant_id}%"
+
+        from(a in query,
+          where: ilike(a.name, ^name_pattern) or ilike(a.assistant_display_id, ^id_pattern)
+        )
+
+      _, query ->
+        query
+    end)
   end
 
   @doc """

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -180,28 +180,31 @@ defmodule Glific.Assistants do
 
   @spec filter_with(Ecto.Queryable.t(), map()) :: Ecto.Queryable.t()
   defp filter_with(query, filter) do
-    # When assistant_id is present, skip the name filter from Repo.filter_with so we can
-    # apply OR logic (name OR assistant_display_id) instead of AND.
+    assistant_id = filter[:assistant_id]
+    name = filter[:name]
+
+    # Only apply OR logic when assistant_id is a non-blank string; otherwise let
+    # Repo.filter_with handle the name filter normally (or skip it if blank).
+    has_assistant_id? = not is_nil(assistant_id) and assistant_id != ""
+
     base_filter =
-      if Map.has_key?(filter, :assistant_id),
+      if has_assistant_id?,
         do: Map.drop(filter, [:name]),
         else: filter
 
     query = Repo.filter_with(query, base_filter)
 
-    Enum.reduce(filter, query, fn
-      {:assistant_id, assistant_id}, query ->
-        name_term = Map.get(filter, :name, assistant_id)
-        name_pattern = "%#{name_term}%"
-        id_pattern = "%#{assistant_id}%"
+    if has_assistant_id? do
+      name_term = if not is_nil(name) and name != "", do: name, else: assistant_id
+      name_pattern = "%#{name_term}%"
+      id_pattern = "%#{assistant_id}%"
 
-        from(a in query,
-          where: ilike(a.name, ^name_pattern) or ilike(a.assistant_display_id, ^id_pattern)
-        )
-
-      _, query ->
-        query
-    end)
+      from(a in query,
+        where: ilike(a.name, ^name_pattern) or ilike(a.assistant_display_id, ^id_pattern)
+      )
+    else
+      query
+    end
   end
 
   @doc """

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -180,31 +180,17 @@ defmodule Glific.Assistants do
 
   @spec filter_with(Ecto.Queryable.t(), map()) :: Ecto.Queryable.t()
   defp filter_with(query, filter) do
-    assistant_id = filter[:assistant_id]
-    name = filter[:name]
+    query = Repo.filter_with(query, filter)
 
-    # Only apply OR logic when assistant_id is a non-blank string; otherwise let
-    # Repo.filter_with handle the name filter normally (or skip it if blank).
-    has_assistant_id? = not is_nil(assistant_id) and assistant_id != ""
+    Enum.reduce(filter, query, fn
+      {:name_or_assistant_id, term}, query ->
+        from(a in query,
+          where: ilike(a.name, ^"%#{term}%") or ilike(a.assistant_display_id, ^"%#{term}%")
+        )
 
-    base_filter =
-      if has_assistant_id?,
-        do: Map.drop(filter, [:name]),
-        else: filter
-
-    query = Repo.filter_with(query, base_filter)
-
-    if has_assistant_id? do
-      name_term = if not is_nil(name) and name != "", do: name, else: assistant_id
-      name_pattern = "%#{name_term}%"
-      id_pattern = "%#{assistant_id}%"
-
-      from(a in query,
-        where: ilike(a.name, ^name_pattern) or ilike(a.assistant_display_id, ^id_pattern)
-      )
-    else
-      query
-    end
+      _, query ->
+        query
+    end)
   end
 
   @doc """

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -151,6 +151,9 @@ defmodule GlificWeb.Schema.AssistantTypes do
   input_object :assistant_filter do
     @desc "Match the name"
     field(:name, :string)
+
+    @desc "Match the assistant display ID"
+    field(:assistant_id, :string)
   end
 
   object :assistant_config_version_for_evals do

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -152,8 +152,8 @@ defmodule GlificWeb.Schema.AssistantTypes do
     @desc "Match the name"
     field(:name, :string)
 
-    @desc "Match the assistant display ID"
-    field(:assistant_id, :string)
+    @desc "Match the name or assistant display ID"
+    field(:name_or_assistant_id, :string)
   end
 
   object :assistant_config_version_for_evals do

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -1718,6 +1718,110 @@ defmodule Glific.AssistantsTest do
     end
   end
 
+  describe "list_assistants/1" do
+    setup do
+      organization_id = 1
+
+      {:ok, assistant1} =
+        %Assistant{}
+        |> Assistant.changeset(%{
+          name: "Alpha Assistant",
+          organization_id: organization_id,
+          assistant_display_id: "asst_alpha000000000000000001"
+        })
+        |> Repo.insert()
+
+      {:ok, config_version1} =
+        %AssistantConfigVersion{}
+        |> AssistantConfigVersion.changeset(%{
+          assistant_id: assistant1.id,
+          organization_id: organization_id,
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: "You are a helpful assistant",
+          settings: %{"temperature" => 1.0},
+          status: :ready
+        })
+        |> Repo.insert()
+
+      {:ok, assistant1} =
+        assistant1
+        |> Assistant.set_active_config_version_changeset(%{
+          active_config_version_id: config_version1.id
+        })
+        |> Repo.update()
+
+      {:ok, assistant2} =
+        %Assistant{}
+        |> Assistant.changeset(%{
+          name: "Beta Assistant",
+          organization_id: organization_id,
+          assistant_display_id: "asst_beta0000000000000000001"
+        })
+        |> Repo.insert()
+
+      {:ok, config_version2} =
+        %AssistantConfigVersion{}
+        |> AssistantConfigVersion.changeset(%{
+          assistant_id: assistant2.id,
+          organization_id: organization_id,
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: "You are a beta assistant",
+          settings: %{"temperature" => 0.5},
+          status: :ready
+        })
+        |> Repo.insert()
+
+      {:ok, assistant2} =
+        assistant2
+        |> Assistant.set_active_config_version_changeset(%{
+          active_config_version_id: config_version2.id
+        })
+        |> Repo.update()
+
+      Partners.organization(organization_id)
+
+      %{assistant1: assistant1, assistant2: assistant2}
+    end
+
+    test "returns all assistants when no filter is given" do
+      results = Assistants.list_assistants(%{})
+      names = Enum.map(results, & &1.name)
+      assert "Alpha Assistant" in names
+      assert "Beta Assistant" in names
+    end
+
+    test "filters by name only" do
+      results = Assistants.list_assistants(%{filter: %{name: "Alpha"}})
+      assert length(results) == 1
+      assert hd(results).name == "Alpha Assistant"
+    end
+
+    test "filters by assistant_id matching assistant_display_id" do
+      results = Assistants.list_assistants(%{filter: %{assistant_id: "asst_beta"}})
+      assert length(results) == 1
+      assert hd(results).name == "Beta Assistant"
+    end
+
+    test "filters with OR logic when both name and assistant_id are provided" do
+      # name matches assistant1, assistant_id matches assistant2 — should return both
+      results =
+        Assistants.list_assistants(%{
+          filter: %{name: "Alpha", assistant_id: "asst_beta"}
+        })
+
+      names = Enum.map(results, & &1.name)
+      assert "Alpha Assistant" in names
+      assert "Beta Assistant" in names
+    end
+
+    test "returns empty list when no assistant matches" do
+      results = Assistants.list_assistants(%{filter: %{assistant_id: "asst_nonexistent_xyz"}})
+      assert results == []
+    end
+  end
+
   describe "delete_assistant/1" do
     test "deletes assistant with kaapi_uuid ",
          %{organization_id: organization_id} do

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -1798,26 +1798,29 @@ defmodule Glific.AssistantsTest do
       assert hd(results).name == "Alpha Assistant"
     end
 
-    test "filters by assistant_id matching assistant_display_id" do
-      results = Assistants.list_assistants(%{filter: %{assistant_id: "asst_beta"}})
+    test "filters by name_or_assistant_id matching name" do
+      results = Assistants.list_assistants(%{filter: %{name_or_assistant_id: "Alpha"}})
+      assert length(results) == 1
+      assert hd(results).name == "Alpha Assistant"
+    end
+
+    test "filters by name_or_assistant_id matching assistant_display_id" do
+      results = Assistants.list_assistants(%{filter: %{name_or_assistant_id: "asst_beta"}})
       assert length(results) == 1
       assert hd(results).name == "Beta Assistant"
     end
 
-    test "filters with OR logic when both name and assistant_id are provided" do
-      # name matches assistant1, assistant_id matches assistant2 — should return both
-      results =
-        Assistants.list_assistants(%{
-          filter: %{name: "Alpha", assistant_id: "asst_beta"}
-        })
-
+    test "filters by name_or_assistant_id returns all matches across both fields" do
+      results = Assistants.list_assistants(%{filter: %{name_or_assistant_id: "Assistant"}})
       names = Enum.map(results, & &1.name)
       assert "Alpha Assistant" in names
       assert "Beta Assistant" in names
     end
 
-    test "returns empty list when no assistant matches" do
-      results = Assistants.list_assistants(%{filter: %{assistant_id: "asst_nonexistent_xyz"}})
+    test "returns empty list when no assistant matches name_or_assistant_id" do
+      results =
+        Assistants.list_assistants(%{filter: %{name_or_assistant_id: "asst_nonexistent_xyz"}})
+
       assert results == []
     end
   end


### PR DESCRIPTION
## Summary

Part of #4963

- Adds `assistant_id` field to the `AssistantFilter` GraphQL input type so the frontend can pass a search term targeting `assistant_display_id`
- Implements OR logic in `Assistants.filter_with/2` — when `assistant_id` is present, matches results where `name ILIKE` OR `assistant_display_id ILIKE`, following the existing `Enum.reduce` convention used across the codebase (e.g. `flows.ex`, `vector_store.ex`)
- Drops the duplicate `name` AND filter from `Repo.filter_with` when `assistant_id` is present to avoid negating the OR

## Test plan

- [ ] New `describe "list_assistants/1"` block with 5 tests covering: no filter, name-only filter, assistant_id-only filter, OR logic with both fields, and no-match case
- [ ] Run `mix test test/glific/assistants_test.exs:1721` — all 5 pass