### PR TITLE
fix: clone status in non legacy assistant 

### DIFF
--- a/lib/glific/third_party/kaapi/assistant_clone_worker.ex
+++ b/lib/glific/third_party/kaapi/assistant_clone_worker.ex
@@ -67,7 +67,7 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
          {:ok, %{data: %{id: kaapi_uuid, version: %{version: kaapi_config_version}}}} <-
            Kaapi.create_assistant_config(params, organization_id),
          :ok <- create_cloned_assistant(params, kb_version, kaapi_uuid, kaapi_config_version) do
-      update_clone_status(assistant, "")
+      update_clone_status(assistant, "completed")
 
       send_clone_notification(
         organization_id,

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -551,7 +551,7 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
       assert linked_kb_version_ids == [non_legacy_knowledge_base_version.id]
 
       refreshed = Repo.get!(Assistant, assistant.id)
-      assert refreshed.clone_status == ""
+      assert refreshed.clone_status == "completed"
     end
 
     test "auto-generates unique name with counter when clone name already exists", %{
@@ -670,7 +670,7 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
       assert linked_kb_version_ids == []
 
       refreshed = Repo.get!(Assistant, assistant_without_kb.id)
-      assert refreshed.clone_status == ""
+      assert refreshed.clone_status == "completed"
     end
 
     test "returns error when Kaapi config creation fails", %{


### PR DESCRIPTION

## Summary

When assistant cloning is completed, we now mark the status as complete. This status will be used by the frontend for polling, updating the UI, and sending notifications