### PR TITLE
fix: handle nil assistant_id in lookup_kaapi_config 

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -760,8 +760,12 @@ defmodule Glific.Clients.CommonWebhook do
     }
   end
 
-  @spec lookup_kaapi_config(String.t(), non_neg_integer()) ::
+  @spec lookup_kaapi_config(String.t() | nil, non_neg_integer()) ::
           {:ok, {String.t(), non_neg_integer()}} | {:error, String.t()}
+  defp lookup_kaapi_config(assistant_display_id, _organization_id)
+       when is_nil(assistant_display_id),
+       do: {:error, "assistant_id is required"}
+
   defp lookup_kaapi_config(assistant_display_id, organization_id) do
     with {:ok, assistant} <-
            Repo.fetch_by(Assistant, %{

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1165,6 +1165,23 @@ defmodule Glific.Flows.CommonWebhookTest do
       :ok
     end
 
+    test "returns error when assistant_id is nil" do
+      fields = %{
+        "question" => "test",
+        "organization_id" => "1",
+        "flow_id" => "1",
+        "contact_id" => "2",
+        "webhook_log_id" => 1,
+        "result_name" => "response"
+      }
+
+      headers = [{"X-API-KEY", "sk_test_key"}]
+      result = CommonWebhook.webhook("unified-llm-call", fields, headers)
+
+      assert result[:success] == false
+      assert result[:reason] == "assistant_id is required"
+    end
+
     test "returns error when assistant not found" do
       fields = %{
         "assistant_id" => "nonexistent_id",


### PR DESCRIPTION
## Summary

- We were encountering this error on AppSignal. To fix it, I added a fallback condition.
- ArgumentError: ** (ArgumentError) nil given for :assistant_display_id. Comparison with nil is forbidden as it is unsafe. Instead write a query with is_nil/1, for example: is_nil(s.assistant_display_id)
lib/glific/repo.ex:11 in Glific.Repo.fetch_by/3
lib/glific/clients/common_webhook.ex:767 in Glific.Clients.CommonWebhook.lookup_kaapi_config/2
lib/glific/clients/common_webhook.ex:483 in Glific.Clients.CommonWebhook.do_unified_llm_call/4


### To Reproduce

 1. Create a flow that includes a `file-search_gpt` node.
2. In the payload, remove the assistant ID.
3. Run the flow locally and observe the error in the IEx server.



