### PR TITLE
Remove PPTX support from file upload validation to match Kaapi's supported formats

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -42,7 +42,6 @@ defmodule Glific.Assistants do
     "java",
     "md",
     "pdf",
-    "pptx",
     "txt"
   ]
 


### PR DESCRIPTION

## Summary

### Appsignal error
Glific.ThirdParty.Kaapi.Error: ** (Glific.ThirdParty.Kaapi.Error) Kaapi document upload failed for, filename=Avni Gramin Training Marathi.pptx reason: %{status: 400, body: %{error: "Unsupported file extension: .pptx", data: nil, metadata: nil, success: false, errors: nil}} organization_id: 2'
<img width="422" height="201" alt="Screenshot 2026-04-13 at 10 37 02 PM" src="https://github.com/user-attachments/assets/80076735-9b30-478c-8c9f-5c78df989469" />

