### PR TITLE
fix: minor assistant version updates

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -38,9 +38,10 @@ defmodule Glific.Assistants do
     "csv",
     "doc",
     "docx",
+    "htm",
     "html",
-    "java",
     "md",
+    "markdown",
     "pdf",
     "txt"
   ]
@@ -466,9 +467,11 @@ defmodule Glific.Assistants do
 
   @spec mark_clone_in_progress(Assistant.t()) :: {:ok, Assistant.t()} | {:error, any()}
   defp mark_clone_in_progress(assistant) do
-    assistant
-    |> Ecto.Changeset.change(%{clone_status: "in_progress"})
-    |> Repo.update()
+    {1, _} =
+      from(a in Assistant, where: a.id == ^assistant.id)
+      |> Repo.update_all(set: [clone_status: "in_progress"])
+
+    {:ok, %{assistant | clone_status: "in_progress"}}
   end
 
   @doc """

--- a/lib/glific/third_party/kaapi/assistant_clone_worker.ex
+++ b/lib/glific/third_party/kaapi/assistant_clone_worker.ex
@@ -188,9 +188,9 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorker do
 
   @spec update_clone_status(Assistant.t(), String.t()) :: :ok
   defp update_clone_status(assistant, status) do
-    assistant
-    |> Ecto.Changeset.change(%{clone_status: status})
-    |> Repo.update!()
+    {1, _} =
+      from(a in Assistant, where: a.id == ^assistant.id)
+      |> Repo.update_all(set: [clone_status: status])
 
     :ok
   end

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -7,6 +7,7 @@ defmodule Glific.Assistants.AssistantTest do
   alias Glific.{
     Assistants,
     Assistants.Assistant,
+    Assistants.AssistantConfigVersion,
     Partners,
     Repo
   }
@@ -254,6 +255,35 @@ defmodule Glific.Assistants.AssistantTest do
   end
 
   describe "upload_file/2" do
+    test "validates assistant-supported file extensions", %{organization_id: organization_id} do
+      Tesla.Mock.mock(fn
+        %{method: :post, url: "This is not a secret/api/v1/documents/"} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              success: true,
+              data: %{
+                fname: "uploaded",
+                id: "d33539f6-2196-477c-a127-0f17f04ef133",
+                inserted_at: "2026-01-30T10:51:16.872363"
+              },
+              error: nil,
+              metadata: nil
+            }
+          }
+      end)
+
+      for extension <- ["csv", "doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"] do
+        upload = build_upload_for_extension(extension)
+        assert {:ok, _} = Assistants.upload_file(%{media: upload}, organization_id)
+      end
+
+      unsupported_upload = build_upload_for_extension("png")
+
+      assert {:error, "Files with extension '.png' not supported in Assistants"} =
+               Assistants.upload_file(%{media: unsupported_upload}, organization_id)
+    end
+
     test "uploads the file successfully to Kaapi", %{
       organization_id: organization_id,
       upload: upload
@@ -360,6 +390,77 @@ defmodule Glific.Assistants.AssistantTest do
       assert is_binary(error_message)
       assert error_message =~ "status 500"
     end
+  end
+
+  describe "mark_clone_in_progress/1" do
+    test "does not update updated_at when setting clone_status to in_progress", %{
+      organization_id: organization_id,
+      knowledge_base_version: knowledge_base_version
+    } do
+      {:ok, assistant} =
+        %Assistant{}
+        |> Assistant.changeset(%{
+          name: "Clone Status Test Assistant",
+          organization_id: organization_id
+        })
+        |> Repo.insert()
+
+      {:ok, config_version} =
+        %AssistantConfigVersion{}
+        |> AssistantConfigVersion.changeset(%{
+          assistant_id: assistant.id,
+          prompt: "Test prompt",
+          model: "gpt-4o-mini",
+          provider: "openai",
+          status: :ready,
+          settings: %{"temperature" => 0.2},
+          organization_id: organization_id
+        })
+        |> Repo.insert()
+
+      now = DateTime.utc_now()
+
+      Repo.insert_all("assistant_config_version_knowledge_base_versions", [
+        %{
+          assistant_config_version_id: config_version.id,
+          knowledge_base_version_id: knowledge_base_version.id,
+          organization_id: organization_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      {:ok, assistant} =
+        assistant
+        |> Assistant.set_active_config_version_changeset(%{
+          active_config_version_id: config_version.id
+        })
+        |> Repo.update()
+
+      original_updated_at = assistant.updated_at
+
+      {:ok, %{message: "Assistant clone initiated"}} = Assistants.clone_assistant(assistant.id)
+
+      refreshed = Repo.get!(Assistant, assistant.id)
+      assert refreshed.clone_status == "in_progress"
+      assert refreshed.updated_at == original_updated_at
+    end
+  end
+
+  defp build_upload_for_extension(extension) do
+    tmp_path =
+      Path.join(
+        System.tmp_dir!(),
+        "assistant_upload_#{extension}_#{System.unique_integer([:positive])}.#{extension}"
+      )
+
+    File.write!(tmp_path, "fake content for #{extension}")
+
+    %Plug.Upload{
+      path: tmp_path,
+      content_type: "application/octet-stream",
+      filename: "sample.#{extension}"
+    }
   end
 
   defp enable_kaapi(attrs) do

--- a/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
+++ b/test/glific/third_party/kaapi/assistant_clone_worker_test.exs
@@ -631,6 +631,67 @@ defmodule Glific.ThirdParty.Kaapi.AssistantCloneWorkerTest do
     end
   end
 
+  describe "update_clone_status/2" do
+    test "does not update updated_at when setting clone_status to completed", %{
+      assistant: assistant,
+      config_version: config_version
+    } do
+      original_updated_at = assistant.updated_at
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          if String.contains?(url, "configs") do
+            %Tesla.Env{
+              status: 200,
+              body: %{data: %{id: "cloned_kaapi_uuid", version: %{version: 1}}}
+            }
+          end
+      end)
+
+      assert :ok =
+               perform_job(AssistantCloneWorker, %{
+                 assistant_id: assistant.id,
+                 version_id: config_version.id,
+                 organization_id: @org_id,
+                 is_legacy: false
+               })
+
+      refreshed = Repo.get!(Assistant, assistant.id)
+      assert refreshed.clone_status == "completed"
+      assert refreshed.updated_at == original_updated_at
+    end
+
+    test "does not update updated_at when setting clone_status to failed", %{
+      assistant: assistant,
+      config_version: config_version
+    } do
+      original_updated_at = assistant.updated_at
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          if String.contains?(url, "configs") do
+            %Tesla.Env{status: 500, body: %{error: "Config creation failed"}}
+          end
+      end)
+
+      assert {:error, _} =
+               perform_job(
+                 AssistantCloneWorker,
+                 %{
+                   assistant_id: assistant.id,
+                   version_id: config_version.id,
+                   organization_id: @org_id,
+                   is_legacy: false
+                 },
+                 attempt: 2
+               )
+
+      refreshed = Repo.get!(Assistant, assistant.id)
+      assert refreshed.clone_status == "failed"
+      assert refreshed.updated_at == original_updated_at
+    end
+  end
+
   describe "clone_assistant/1 enqueues job" do
     test "returns success message for valid assistant", %{assistant: assistant} do
       assert {:ok, %{message: "Assistant clone initiated"}} =

--- a/test/glific_web/schema/export_test.exs
+++ b/test/glific_web/schema/export_test.exs
@@ -77,7 +77,7 @@ defmodule GlificWeb.Schema.ExportTest do
         roles: ["glific_admin"],
         organization_id: user.organization_id
       })
-    
+
     end_time = DateTime.utc_now()
     start_time = DateTime.add(end_time, -7, :day)
 

--- a/test/glific_web/schema/export_test.exs
+++ b/test/glific_web/schema/export_test.exs
@@ -3,6 +3,7 @@ defmodule GlificWeb.Schema.ExportTest do
   use Wormwood.GQLCase
 
   alias Glific.{
+    Fixtures,
     Seeds.SeedsDev
   }
 
@@ -77,6 +78,8 @@ defmodule GlificWeb.Schema.ExportTest do
         roles: ["glific_admin"],
         organization_id: user.organization_id
       })
+
+    Fixtures.flow_fixture()
 
     end_time = DateTime.utc_now()
     start_time = DateTime.add(end_time, -7, :day)

--- a/test/glific_web/schema/export_test.exs
+++ b/test/glific_web/schema/export_test.exs
@@ -3,7 +3,6 @@ defmodule GlificWeb.Schema.ExportTest do
   use Wormwood.GQLCase
 
   alias Glific.{
-    Fixtures,
     Seeds.SeedsDev
   }
 
@@ -78,9 +77,7 @@ defmodule GlificWeb.Schema.ExportTest do
         roles: ["glific_admin"],
         organization_id: user.organization_id
       })
-
-    Fixtures.flow_fixture()
-
+    
     end_time = DateTime.utc_now()
     start_time = DateTime.add(end_time, -7, :day)
 


### PR DESCRIPTION
**Changes**
- Ensure we allow the same set of files type that kaapi accepts
- Don't modify `updated_at` on assistants table when modifying clone_status