### PR TITLE
feat: include vector_store in assistant versions API response

### DIFF
--- a/assets/gql/assistants/assistant_versions.gql
+++ b/assets/gql/assistants/assistant_versions.gql
@@ -16,6 +16,11 @@ query AssistantVersions($assistant_id: ID!) {
       status
       legacy
       size
+      files {
+        id
+        name
+        uploaded_at
+      }
     }
     inserted_at
     updated_at

--- a/assets/gql/assistants/assistant_versions.gql
+++ b/assets/gql/assistants/assistant_versions.gql
@@ -8,6 +8,15 @@ query AssistantVersions($assistant_id: ID!) {
     status
     is_live
     description
+    vector_store {
+      id
+      knowledge_base_version_id
+      vector_store_id
+      name
+      status
+      legacy
+      size
+    }
     inserted_at
     updated_at
   }

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -88,6 +88,7 @@ defmodule Glific.Assistants do
           order_by: [desc: v.version_number]
         )
         |> Repo.all()
+        |> Repo.preload(knowledge_base_versions: :knowledge_base)
 
       {:ok,
        Enum.map(versions, fn version ->
@@ -100,6 +101,7 @@ defmodule Glific.Assistants do
            status: version.status,
            is_live: version.id == assistant.active_config_version_id,
            description: version.description,
+           vector_store_data: build_vector_store_data(version),
            inserted_at: version.inserted_at,
            updated_at: version.updated_at
          }

--- a/lib/glific_web/resolvers/filesearch.ex
+++ b/lib/glific_web/resolvers/filesearch.ex
@@ -137,11 +137,15 @@ defmodule GlificWeb.Resolvers.Filesearch do
   end
 
   @doc """
-  Resolves the vector_store field on an assistant.
+  Resolves the vector_store field on an assistant or assistant config version.
   """
   @spec resolve_vector_store(map(), map(), map()) :: {:ok, map() | nil}
   def resolve_vector_store(%{vector_store_data: vs_data}, _args, _context) do
     {:ok, vs_data}
+  end
+
+  def resolve_vector_store(_parent, _args, _context) do
+    {:ok, nil}
   end
 
   @doc """

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -78,6 +78,11 @@ defmodule GlificWeb.Schema.AssistantTypes do
     field :status, :string
     field :is_live, :boolean
     field :description, :string
+
+    field :vector_store, :vector_store do
+      resolve(&Resolvers.Filesearch.resolve_vector_store/3)
+    end
+
     field :inserted_at, :datetime
     field :updated_at, :datetime
   end

--- a/test/glific_web/resolvers/assistants_test.exs
+++ b/test/glific_web/resolvers/assistants_test.exs
@@ -482,6 +482,78 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
       # is_live reflects active_config_version_id
       live_version = Enum.find(versions, & &1["is_live"])
       assert live_version["id"] == to_string(v1.id)
+
+      # versions without a linked knowledge base have no vector_store
+      assert Enum.all?(versions, fn v -> is_nil(v["vector_store"]) end)
+    end
+
+    test "returns vector_store linked to each version", %{
+      staff: user,
+      organization_id: organization_id
+    } do
+      {:ok, assistant} =
+        %Assistant{}
+        |> Assistant.changeset(%{name: "VS Assistant", organization_id: organization_id})
+        |> Repo.insert()
+
+      {:ok, v1} =
+        %AssistantConfigVersion{}
+        |> AssistantConfigVersion.changeset(%{
+          assistant_id: assistant.id,
+          organization_id: organization_id,
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: "Prompt v1",
+          settings: %{},
+          status: :ready,
+          version_number: 1
+        })
+        |> Repo.insert()
+
+      {:ok, kb} =
+        Assistants.create_knowledge_base(%{name: "Test KB", organization_id: organization_id})
+
+      {:ok, kb_version} =
+        Assistants.create_knowledge_base_version(%{
+          knowledge_base_id: kb.id,
+          organization_id: organization_id,
+          status: :completed,
+          llm_service_id: "vs_test_abc",
+          size: 50,
+          files: %{}
+        })
+
+      now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+      Repo.insert_all("assistant_config_version_knowledge_base_versions", [
+        %{
+          assistant_config_version_id: v1.id,
+          knowledge_base_version_id: kb_version.id,
+          organization_id: organization_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      ])
+
+      {:ok, _assistant} =
+        assistant
+        |> Assistant.set_active_config_version_changeset(%{active_config_version_id: v1.id})
+        |> Repo.update()
+
+      {:ok, query_data} =
+        auth_query_gql_by(:assistant_versions, user, variables: %{"assistant_id" => assistant.id})
+
+      versions = query_data.data["assistantVersions"]
+      assert length(versions) == 1
+
+      vs = hd(versions)["vector_store"]
+      assert vs != nil
+      assert vs["id"] == to_string(kb.id)
+      assert vs["knowledge_base_version_id"] == to_string(kb_version.id)
+      assert vs["vector_store_id"] == "vs_test_abc"
+      assert vs["name"] == "Test KB"
+      assert vs["status"] == "completed"
+      assert vs["size"] == "50 B"
     end
 
     test "returns empty versions for a non-existent assistant", %{staff: user} do


### PR DESCRIPTION
## Summary

- Preload `knowledge_base_versions` (with `knowledge_base`) for each config version in `list_assistant_config_versions/1`
- Add `vector_store_data` to each version map, reusing the existing `build_vector_store_data/1` helper
- Expose a `vector_store` field on the `:assistant_config_version` GraphQL type using the same resolver already used by `:assistant`
- Add a catch-all clause to `resolve_vector_store/3` to safely return `nil` when the parent has no `vector_store_data` key

## Test plan

- [ ] Existing `assistant_versions/3` tests still pass (ordering, `is_live` flag, non-existent assistant)
- [ ] New test: version with a linked knowledge base returns correct `vector_store` fields (`id`, `knowledge_base_version_id`, `vector_store_id`, `name`, `status`, `size`)
- [ ] New assertion: versions without a linked KB return `null` for `vector_store`
- [ ] Run `mix test test/glific_web/resolvers/assistants_test.exs` — all 13 tests pass