### PR TITLE
feat: skip config version creation when only assistant name changes

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -501,7 +501,7 @@ defmodule Glific.Assistants do
         no_changes?(user_params, assistant, knowledge_base_version) ->
           get_assistant(assistant.id)
 
-        name_only_change?(user_params, assistant, knowledge_base_version) ->
+        name_only_change?(user_params) ->
           assistant
           |> Assistant.changeset(%{name: user_params[:name]})
           |> Repo.update()
@@ -594,18 +594,10 @@ defmodule Glific.Assistants do
       kb_unchanged
   end
 
-  @spec name_only_change?(map(), Assistant.t(), KnowledgeBaseVersion.t() | nil) :: boolean()
-  defp name_only_change?(user_params, assistant, knowledge_base_version) do
-    current_kb_id = assistant.active_config_version.knowledge_base_versions |> List.first() |> kb_id()
-    new_kb_id = kb_id(knowledge_base_version)
-
+  @spec name_only_change?(map()) :: boolean()
+  defp name_only_change?(user_params) do
     not is_nil(user_params[:name]) and
-      user_params[:name] != assistant.name and
-      is_nil(user_params[:instructions]) and
-      is_nil(user_params[:model]) and
-      is_nil(user_params[:temperature]) and
-      is_nil(user_params[:knowledge_base_version_id]) and
-      current_kb_id == new_kb_id
+      not Enum.any?([:instructions, :model, :temperature, :knowledge_base_version_id], &Map.has_key?(user_params, &1))
   end
 
   @spec kb_id(KnowledgeBaseVersion.t() | nil) :: non_neg_integer() | nil

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -511,44 +511,50 @@ defmodule Glific.Assistants do
           end
 
         true ->
-          previous_knowledge_base_version =
-            List.first(assistant.active_config_version.knowledge_base_versions)
-
-          needs_active_config_link =
-            is_nil(previous_knowledge_base_version) and
-              not is_nil(user_params[:knowledge_base_version_id])
-
-          previous_kb_id = kb_id(previous_knowledge_base_version)
-          new_kb_id = kb_id(knowledge_base_version)
-
-          knowledge_base_changed =
-            previous_kb_id != nil and new_kb_id != nil and previous_kb_id != new_kb_id
-
-          {:ok, config_params} = build_kaapi_config(user_params, knowledge_base_version)
-
-          with true <-
-                 knowledge_base_changed and knowledge_base_version.status != :completed,
-               {:ok, _config_version} <-
-                 deferred_update_transaction(assistant, config_params, knowledge_base_version) do
-            format_assistant_result(assistant)
-          else
-            false ->
-              with {:ok, updated_assistant, config_version} <-
-                     update_assistant_transaction(
-                       assistant,
-                       config_params,
-                       knowledge_base_version,
-                       needs_active_config_link
-                     ),
-                   {:ok, _} <-
-                     create_kaapi_config_version(updated_assistant, config_version, config_params) do
-                format_assistant_result(updated_assistant)
-              end
-
-            {:error, reason} ->
-              {:error, reason}
-          end
+          do_update_assistant_config(assistant, user_params, knowledge_base_version)
       end
+    end
+  end
+
+  @spec do_update_assistant_config(Assistant.t(), map(), KnowledgeBaseVersion.t() | nil) ::
+          {:ok, map()} | {:error, any()}
+  defp do_update_assistant_config(assistant, user_params, knowledge_base_version) do
+    previous_knowledge_base_version =
+      List.first(assistant.active_config_version.knowledge_base_versions)
+
+    needs_active_config_link =
+      is_nil(previous_knowledge_base_version) and
+        not is_nil(user_params[:knowledge_base_version_id])
+
+    previous_kb_id = kb_id(previous_knowledge_base_version)
+    new_kb_id = kb_id(knowledge_base_version)
+
+    knowledge_base_changed =
+      previous_kb_id != nil and new_kb_id != nil and previous_kb_id != new_kb_id
+
+    {:ok, config_params} = build_kaapi_config(user_params, knowledge_base_version)
+
+    with true <-
+           knowledge_base_changed and knowledge_base_version.status != :completed,
+         {:ok, _config_version} <-
+           deferred_update_transaction(assistant, config_params, knowledge_base_version) do
+      format_assistant_result(assistant)
+    else
+      false ->
+        with {:ok, updated_assistant, config_version} <-
+               update_assistant_transaction(
+                 assistant,
+                 config_params,
+                 knowledge_base_version,
+                 needs_active_config_link
+               ),
+             {:ok, _} <-
+               create_kaapi_config_version(updated_assistant, config_version, config_params) do
+          format_assistant_result(updated_assistant)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -501,6 +501,15 @@ defmodule Glific.Assistants do
         no_changes?(user_params, assistant, knowledge_base_version) ->
           get_assistant(assistant.id)
 
+        name_only_change?(user_params, assistant, knowledge_base_version) ->
+          assistant
+          |> Assistant.changeset(%{name: user_params[:name]})
+          |> Repo.update()
+          |> case do
+            {:ok, _} -> get_assistant(assistant.id)
+            error -> error
+          end
+
         true ->
           previous_knowledge_base_version =
             List.first(assistant.active_config_version.knowledge_base_versions)
@@ -583,6 +592,20 @@ defmodule Glific.Assistants do
       user_params[:model] == active_config.model and
       user_params[:temperature] == get_in(active_config.settings || %{}, ["temperature"]) and
       kb_unchanged
+  end
+
+  @spec name_only_change?(map(), Assistant.t(), KnowledgeBaseVersion.t() | nil) :: boolean()
+  defp name_only_change?(user_params, assistant, knowledge_base_version) do
+    current_kb_id = assistant.active_config_version.knowledge_base_versions |> List.first() |> kb_id()
+    new_kb_id = kb_id(knowledge_base_version)
+
+    not is_nil(user_params[:name]) and
+      user_params[:name] != assistant.name and
+      is_nil(user_params[:instructions]) and
+      is_nil(user_params[:model]) and
+      is_nil(user_params[:temperature]) and
+      is_nil(user_params[:knowledge_base_version_id]) and
+      current_kb_id == new_kb_id
   end
 
   @spec kb_id(KnowledgeBaseVersion.t() | nil) :: non_neg_integer() | nil

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -456,6 +456,12 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+
+      {:ok, updated_assistant} =
+        Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
+
+      updated_assistant = Repo.preload(updated_assistant, :active_config_version)
+      assert updated_assistant.active_config_version.kaapi_version_number == 2
     end
 
     test "creates a new config version when temperature changes",

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -407,7 +407,34 @@ defmodule Glific.AssistantsTest do
       assert initial_config_count == final_config_count
     end
 
-    test "creates a new config version and updates the assistant when name changes",
+    test "updates the assistant name without creating a new config version",
+         %{organization_id: organization_id, assistant: assistant, config_version: config_version} do
+      initial_config_count =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> Repo.aggregate(:count, :id)
+
+      assert {:ok, result} =
+               Assistants.update_assistant(assistant.id, %{
+                 name: "Updated Name",
+                 organization_id: organization_id
+               })
+
+      assert result.name == "Updated Name"
+
+      final_config_count =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> Repo.aggregate(:count, :id)
+
+      assert initial_config_count == final_config_count
+
+      # active config version remains unchanged
+      {:ok, updated_assistant} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
+      assert updated_assistant.active_config_version_id == config_version.id
+    end
+
+    test "creates a new config version when name and another field change",
          %{organization_id: organization_id, assistant: assistant} do
       Tesla.Mock.mock(fn
         %{method: :post} ->
@@ -417,6 +444,7 @@ defmodule Glific.AssistantsTest do
       assert {:ok, result} =
                Assistants.update_assistant(assistant.id, %{
                  name: "Updated Name",
+                 temperature: 0.9,
                  organization_id: organization_id
                })
 
@@ -428,12 +456,6 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
-
-      {:ok, updated_assistant} =
-        Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
-
-      updated_assistant = Repo.preload(updated_assistant, :active_config_version)
-      assert updated_assistant.active_config_version.kaapi_version_number == 2
     end
 
     test "creates a new config version when temperature changes",
@@ -675,6 +697,7 @@ defmodule Glific.AssistantsTest do
       assert {:error, _} =
                Assistants.update_assistant(assistant.id, %{
                  name: "Updated Name",
+                 instructions: "Updated instructions",
                  organization_id: organization_id
                })
     end
@@ -2714,6 +2737,7 @@ defmodule Glific.AssistantsTest do
       assert {:ok, _result} =
                Assistants.update_assistant(assistant.id, %{
                  name: "Flag On Update",
+                 instructions: "Updated instructions",
                  organization_id: organization_id
                })
 
@@ -2739,6 +2763,7 @@ defmodule Glific.AssistantsTest do
       assert {:ok, _result} =
                Assistants.update_assistant(assistant.id, %{
                  name: "Flag Off Update",
+                 instructions: "Updated instructions",
                  organization_id: organization_id
                })
 


### PR DESCRIPTION
## Summary

- Adds a `name_only_change?` check in `update_assistant/2` — when the only change is the assistant `name` (no `instructions`, `model`, `temperature`, or `knowledge_base` changes), the assistant row is updated directly via changeset without creating a new config version
- Updates existing tests that passed only `name` expecting Kaapi/config-version behavior — those now include an additional config field to correctly exercise the full update path
- Adds a new test asserting name-only updates preserve the existing config version count and active config version

## Test plan

- [ ] New test: name-only update does not create a new config version and active config version is unchanged
- [ ] New test: name + config field change still creates a new config version via Kaapi
- [ ] Run `mix test test/glific/assistants_test.exs` — all 77 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)