### PR TITLE
feat: add configurable hackney pool size and default pool specification

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -103,7 +103,8 @@ config :tesla,
   adapter:
     {Tesla.Adapter.Hackney,
      ssl_options: [{:middlebox_comp_mode, false}, {:verify, :verify_none}],
-     pool: :glific_default_pool}
+     pool: :glific_default_pool,
+     connect_timeout: 5_000}
 
 config :glific, :max_rate_limit_request, 60
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -101,7 +101,9 @@ config :glific, Oban,
 # We will revisit it once we build a better understanding
 config :tesla,
   adapter:
-    {Tesla.Adapter.Hackney, ssl_options: [{:middlebox_comp_mode, false}, {:verify, :verify_none}]}
+    {Tesla.Adapter.Hackney,
+     ssl_options: [{:middlebox_comp_mode, false}, {:verify, :verify_none}],
+     pool: :glific_default_pool}
 
 config :glific, :max_rate_limit_request, 60
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -57,7 +57,7 @@ config :glific, Glific.RepoReplica,
   parameters: [plan_cache_mode: "force_custom_plan"]
 
 config :glific, :hackney_pool,
-  max_connections: env!("HACKNEY_POOL_SIZE", :integer, 75)
+  max_connections: env!("HACKNEY_POOL_SIZE", :integer, 50)
 
 check_origin = [env!("REQUEST_ORIGIN", :string!), env!("REQUEST_ORIGIN_WILDCARD", :string!)]
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -56,6 +56,9 @@ config :glific, Glific.RepoReplica,
   prepare: :named,
   parameters: [plan_cache_mode: "force_custom_plan"]
 
+config :glific, :hackney_pool,
+  max_connections: env!("HACKNEY_POOL_SIZE", :integer, 75)
+
 check_origin = [env!("REQUEST_ORIGIN", :string!), env!("REQUEST_ORIGIN_WILDCARD", :string!)]
 
 # Glific endpoint configs

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -59,8 +59,8 @@ defmodule Glific.Application do
       # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
       :hackney_pool.child_spec(:glific_default_pool,
         recv_timeout: 60_000,
-        connect_timeout: 15_000,
-        max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 75
+        connect_timeout: 5_000,
+        max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 50
       ),
 
       # Dedicated hackney pool for Kaapi document uploads

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -58,7 +58,7 @@ defmodule Glific.Application do
 
       # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
       :hackney_pool.child_spec(:glific_default_pool,
-        timeout: 60_000,
+        timeout: 50_000,
         max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 75
       ),
 

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -58,7 +58,8 @@ defmodule Glific.Application do
 
       # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
       :hackney_pool.child_spec(:glific_default_pool,
-        timeout: 50_000,
+        recv_timeout: 60_000,
+        connect_timeout: 15_000,
         max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 75
       ),
 

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -58,8 +58,7 @@ defmodule Glific.Application do
 
       # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
       :hackney_pool.child_spec(:glific_default_pool,
-        recv_timeout: 60_000,
-        connect_timeout: 5_000,
+        timeout: 60_000,
         max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 50
       ),
 

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -56,6 +56,12 @@ defmodule Glific.Application do
       ## Add Generic task supervisor
       {Task.Supervisor, name: Glific.TaskSupervisor},
 
+      # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
+      :hackney_pool.child_spec(:default,
+        timeout: 60_000,
+        max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 75
+      ),
+
       # Dedicated hackney pool for Kaapi document uploads
       :hackney_pool.child_spec(:kaapi_upload_pool, timeout: 60_000, max_connections: 50)
     ]

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -57,7 +57,7 @@ defmodule Glific.Application do
       {Task.Supervisor, name: Glific.TaskSupervisor},
 
       # Default hackney pool — size configurable via HACKNEY_POOL_SIZE env var
-      :hackney_pool.child_spec(:default,
+      :hackney_pool.child_spec(:glific_default_pool,
         timeout: 60_000,
         max_connections: Application.get_env(:glific, :hackney_pool, [])[:max_connections] || 75
       ),

--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -58,6 +58,13 @@ defmodule Glific.Appsignal do
     if :rand.uniform() < sampling_rate * sampling_scale / 100 do
       cond do
         # Errors like timeout from tesla etc, status will be nil
+        is_nil(status) && meta[:error] == :checkout_timeout ->
+          Appsignal.increment_counter("hackney_pool_checkout_error", 1, %{
+            provider: meta[:provider],
+            url: url,
+            method: meta.env.method
+          })
+
         is_nil(status) ->
           Appsignal.increment_counter("tesla_request_error_count", 1, %{
             provider: meta[:provider],


### PR DESCRIPTION

## Summary

### Reference-
-  https://hexdocs.pm/hackney/hackney_pool.html
- https://github.com/benoitc/hackney?tab=readme-ov-file#use-a-pool


### Changes 

- Make the default pool count configurable so that we can increase it without releasing code
- Current making it 75 if not passed 