### PR TITLE
Bugfix: Imported OpenAI assistants don't work with unified APIs

### DIFF
--- a/assets/gql/flows/import_flow.gql
+++ b/assets/gql/flows/import_flow.gql
@@ -3,6 +3,7 @@ mutation importFlow($flow: Json!) {
     status {
       flowName
       status
+      assistantNodeUuids
     }
   }
 }

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,9 +25,6 @@ config :glific, Glific.Repo, migration_timestamps: [type: :utc_datetime]
 # While we store everything in UTC, we need to respect the user's tz
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
-config :logger,
-  level: :error
-
 # Configure Oban, its queues and crontab entries
 
 oban_queues = [

--- a/config/config.exs
+++ b/config/config.exs
@@ -25,6 +25,9 @@ config :glific, Glific.Repo, migration_timestamps: [type: :utc_datetime]
 # While we store everything in UTC, we need to respect the user's tz
 config :elixir, :time_zone_database, Tzdata.TimeZoneDatabase
 
+config :logger,
+  level: :error
+
 # Configure Oban, its queues and crontab entries
 
 oban_queues = [

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -23,7 +23,6 @@ defmodule Glific.Flows do
     Templates.InteractiveTemplate,
     Templates.InteractiveTemplates,
     Templates.SessionTemplate,
-    ThirdParty.Kaapi,
     Users.User
   }
 
@@ -1035,7 +1034,7 @@ defmodule Glific.Flows do
                keywords: flow_revision["keywords"],
                organization_id: organization_id
              }),
-           {cleaned_definition, warnings} <-
+           {cleaned_definition, assistant_node_uuids} <-
              clean_flow_definition(
                flow_revision["definition"],
                interactive_template_list,
@@ -1051,29 +1050,26 @@ defmodule Glific.Flows do
         import_contact_field(import_flow, organization_id)
         import_groups(import_flow, organization_id)
 
-        status =
-          if Enum.empty?(warnings) do
-            "Successfully imported"
-          else
-            "Successfully imported with warnings: " <> Enum.join(warnings, "; ")
-          end
-
-        %{flow_name: flow.name, status: status}
+        %{
+          flow_name: flow.name,
+          status: "Successfully imported",
+          assistant_node_uuids: assistant_node_uuids
+        }
       else
         {:error, error} ->
           flow_name = Map.get(error.changes, :name)
           errors = hd(error.errors)
 
-          message =
+          error_message =
             case errors do
-              {:keywords, {message, _}} -> message
-              {:name, {message, _}} -> message
+              {:keywords, {msg, _}} -> msg
+              {:name, {msg, _}} -> msg
               _ -> "Something went wrong"
             end
 
-          Logger.error("Failed to import flow #{flow_name}: #{message}, #{inspect(errors)}")
+          Logger.error("Failed to import flow #{flow_name}: #{error_message}, #{inspect(errors)}")
 
-          %{flow_name: flow_name, status: message}
+          %{flow_name: flow_name, status: error_message, assistant_node_uuids: []}
       end
     end)
   end
@@ -1085,20 +1081,20 @@ defmodule Glific.Flows do
       flow_name: definition["name"]
     }
 
-    {nodes, warnings} =
+    {nodes, assistant_node_uuids} =
       definition
       |> Map.get("nodes", [])
       |> Enum.reduce(
         {[], []},
-        fn node, {nodes_acc, warnings_acc} ->
-          {processed_nodes, node_warnings} =
+        fn node, {nodes_acc, uuids_acc} ->
+          {processed_nodes, node_uuids} =
             process_node_actions(node, interactive_template_list, flow_info, organization_id)
 
-          {nodes_acc ++ processed_nodes, warnings_acc ++ node_warnings}
+          {nodes_acc ++ processed_nodes, uuids_acc ++ node_uuids}
         end
       )
 
-    {put_in(definition, ["nodes"], nodes), warnings}
+    {put_in(definition, ["nodes"], nodes), assistant_node_uuids}
   end
 
   @spec process_node_actions(map(), list(), map(), non_neg_integer()) :: {list(), list()}
@@ -1117,19 +1113,20 @@ defmodule Glific.Flows do
          flow_info,
          org_id
        ) do
-    {updated_actions, warnings} =
-      Enum.reduce(actions, {[], []}, fn action, {actions_acc, warnings_acc} ->
+    {updated_actions, has_assistant?} =
+      Enum.reduce(actions, {[], false}, fn action, {actions_acc, has_assistant_acc} ->
         case process_action(action, node, interactive_template_list, flow_info, org_id) do
           {:ok, updated_action} ->
-            {actions_acc ++ [updated_action], warnings_acc}
+            {actions_acc ++ [updated_action], has_assistant_acc}
 
-          {:ok, updated_action, warning} ->
-            {actions_acc ++ [updated_action], warnings_acc ++ [warning]}
+          {:ok, updated_action, :assistant} ->
+            {actions_acc ++ [updated_action], true}
         end
       end)
 
     updated_node = Map.put(node, "actions", updated_actions)
-    {[updated_node], warnings}
+    node_uuids = if has_assistant?, do: [node["uuid"]], else: []
+    {[updated_node], node_uuids}
   end
 
   defp process_action(
@@ -1184,22 +1181,12 @@ defmodule Glific.Flows do
          %{"type" => "call_webhook"} = action,
          _node,
          _interactive_template_list,
-         flow_info,
-         org_id
+         _flow_info,
+         _org_id
        ) do
-    case handle_assistant_import(action, org_id, flow_info) do
-      :ok ->
-        {:ok, action}
-
-      {:error, assistant_id} ->
-        warning =
-          "Failed to import assistant\n\n" <>
-            "Assistant ID: #{assistant_id}"
-
-        {:ok, action, warning}
-
-      nil ->
-        {:ok, action}
+    case clear_assistant_id(action) do
+      {:ok, updated_action} -> {:ok, updated_action, :assistant}
+      :no_assistant -> {:ok, action}
     end
   end
 
@@ -1217,16 +1204,20 @@ defmodule Glific.Flows do
   defp process_action(action, _node, _interactive_template_list, _flow_info, _org_id),
     do: {:ok, action}
 
-  @spec handle_assistant_import(map(), non_neg_integer(), map()) ::
-          :ok | {:error, String.t()} | nil
-  defp handle_assistant_import(action, org_id, _flow_info) do
+  @spec clear_assistant_id(map()) :: {:ok, map()} | :no_assistant
+  defp clear_assistant_id(action) do
     with body when is_binary(body) <- action["body"],
          {:ok, decoded} <- Jason.decode(body),
-         assistant_id when not is_nil(assistant_id) <- decoded["assistant_id"] do
-      case Kaapi.ingest_ai_assistant(org_id, assistant_id) do
-        {:ok, _result} -> :ok
-        {:error, _} -> {:error, assistant_id}
-      end
+         assistant_id when is_binary(assistant_id) and assistant_id != "" <-
+           decoded["assistant_id"] do
+      updated_body =
+        Regex.replace(~r/"assistant_id"(\s*:\s*)"[^"]*"/, body, fn _full, spacing ->
+          ~s("assistant_id"#{spacing}"")
+        end)
+
+      {:ok, Map.put(action, "body", updated_body)}
+    else
+      _ -> :no_assistant
     end
   end
 

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -1125,9 +1125,14 @@ defmodule Glific.Flows do
       end)
 
     updated_node = Map.put(node, "actions", updated_actions)
-    node_uuids = if has_assistant?, do: [node["uuid"]], else: []
+    node_uuids = if has_assistant?, do: [node_label(node["uuid"])], else: []
     {[updated_node], node_uuids}
   end
+
+  # The flow editor labels each node with the last 4 chars of its UUID
+  @spec node_label(String.t() | nil) :: String.t()
+  defp node_label(uuid) when is_binary(uuid), do: String.slice(uuid, -4..-1//1)
+  defp node_label(_), do: ""
 
   defp process_action(
          %{"type" => "send_msg"} = action,

--- a/lib/glific_web/schema/flow_types.ex
+++ b/lib/glific_web/schema/flow_types.ex
@@ -46,6 +46,7 @@ defmodule GlificWeb.Schema.FlowTypes do
   object :import_flow_status do
     field :flow_name, non_null(:string)
     field :status, non_null(:string)
+    field :assistant_node_uuids, list_of(:string)
   end
 
   object :flow do

--- a/test/glific_web/schema/flow_test.exs
+++ b/test/glific_web/schema/flow_test.exs
@@ -846,88 +846,10 @@ defmodule GlificWeb.Schema.FlowTest do
     assert {:ok, %{data: _}} = result
   end
 
-  test "import flow with assistant should also import the assistant in kaapi", %{manager: user} do
-    organization_id = user.organization_id
-
-    # activate kaapi
-    enable_kaapi(%{organization_id: organization_id})
-
-    FunWithFlags.enable(:is_kaapi_enabled,
-      for_actor: %{organization_id: organization_id}
-    )
-
-    Tesla.Mock.mock(fn
-      %{method: :post} ->
-        %Tesla.Env{
-          status: 200,
-          body: %{
-            error: nil,
-            data: %{
-              id: 164,
-              name: "test_asst",
-              instructions: "you are a helpful assistant",
-              assistant_id: "asst_gzxxq",
-              model: "gpt-4o",
-              temperature: 0.0,
-              project_id: 86,
-              vector_store_ids: []
-            },
-            success: true,
-            metadata: nil
-          }
-        }
-    end)
-
-    [flow | _] = Flows.list_flows(%{filter: %{name: "call_and_wait"}})
-    flow_id = flow.id
-
-    Repo.fetch_by(FlowRevision, %{flow_id: flow_id, organization_id: organization_id})
-
-    result =
-      auth_query_gql_by(:export_flow, user, variables: %{"id" => flow.id})
-
-    assert {:ok, query_data} = result
-
-    export_data = get_in(query_data, [:data, "exportFlow", "export_data"])
-    data = Jason.decode!(export_data)
-
-    # Delete the flow before importing
-    Flows.list_flows(%{filter: %{id: flow.id}})
-    |> Enum.each(fn flow -> Flows.delete_flow(flow) end)
-
-    import_flow = Jason.encode!(data)
-    result = auth_query_gql_by(:import_flow, user, variables: %{"flow" => import_flow})
-    assert {:ok, query_data} = result
-
-    import_status =
-      get_in(query_data, [:data, "importFlow", "status", Access.at(0)])
-
-    assert import_status["flowName"] == "call_and_wait"
-    assert import_status["status"] == "Successfully imported"
-  end
-
-  test "import flow with failed assistant should add he warning in pop-up", %{
-    manager: user
-  } do
-    organization_id = user.organization_id
-
-    # activate kaapi
-    enable_kaapi(%{organization_id: organization_id})
-
-    FunWithFlags.enable(:is_kaapi_enabled,
-      for_actor: %{organization_id: organization_id}
-    )
-
-    Tesla.Mock.mock(fn
-      %{method: :post} ->
-        %Tesla.Env{
-          status: 404,
-          body: %{
-            error: "Assistant not found",
-            data: nil,
-            success: false
-          }
-        }
+  test "import flow with assistant returns the node uuids and message, without calling kaapi",
+       %{manager: user} do
+    Tesla.Mock.mock(fn _ ->
+      flunk("no HTTP calls should be made when importing a flow with an assistant")
     end)
 
     [flow | _] = Flows.list_flows(%{filter: %{name: "call_and_wait"}})
@@ -937,44 +859,58 @@ defmodule GlificWeb.Schema.FlowTest do
     export_data = get_in(query_data, [:data, "exportFlow", "export_data"])
     data = Jason.decode!(export_data)
 
+    expected_node_uuids =
+      data["flows"]
+      |> hd()
+      |> get_in(["definition", "nodes"])
+      |> Enum.filter(fn node ->
+        Enum.any?(node["actions"] || [], fn action ->
+          action["type"] == "call_webhook" and
+            is_binary(action["body"]) and
+            String.contains?(action["body"], "assistant_id")
+        end)
+      end)
+      |> Enum.map(& &1["uuid"])
+
+    assert expected_node_uuids != []
+
     # Delete the flow before importing
     Flows.list_flows(%{filter: %{id: flow.id}})
     |> Enum.each(fn flow -> Flows.delete_flow(flow) end)
 
     import_flow = Jason.encode!(data)
     result = auth_query_gql_by(:import_flow, user, variables: %{"flow" => import_flow})
-
     assert {:ok, query_data} = result
 
-    import_status =
-      get_in(query_data, [:data, "importFlow", "status", Access.at(0)])
+    import_status = get_in(query_data, [:data, "importFlow", "status", Access.at(0)])
 
-    assert import_status["status"] ==
-             "Successfully imported with warnings: Failed to import assistant\n\nAssistant ID: asst_pJMbE1OALvgWtZfGfDicrgAD"
-  end
+    assert import_status["flowName"] == "call_and_wait"
+    assert import_status["status"] == "Successfully imported"
+    assert Enum.sort(import_status["assistantNodeUuids"]) == Enum.sort(expected_node_uuids)
 
-  defp enable_kaapi(attrs) do
-    {:ok, credential} =
-      Partners.create_credential(%{
-        organization_id: attrs.organization_id,
-        shortcode: "kaapi",
-        keys: %{},
-        secrets: %{
-          "api_key" => "sk_test_key"
-        }
+    [imported_flow | _] = Flows.list_flows(%{filter: %{name: "call_and_wait"}})
+
+    {:ok, revision} =
+      Repo.fetch_by(FlowRevision, %{
+        flow_id: imported_flow.id,
+        organization_id: user.organization_id
       })
 
-    valid_update_attrs = %{
-      keys: %{},
-      secrets: %{
-        "api_key" => "sk_test_key"
-      },
-      is_active: true,
-      organization_id: attrs.organization_id,
-      shortcode: "kaapi"
-    }
+    imported_assistant_ids =
+      revision.definition
+      |> Map.get("nodes", [])
+      |> Enum.flat_map(fn node -> node["actions"] || [] end)
+      |> Enum.filter(fn action -> action["type"] == "call_webhook" end)
+      |> Enum.map(fn action ->
+        case Jason.decode(action["body"] || "") do
+          {:ok, decoded} -> decoded["assistant_id"]
+          _ -> nil
+        end
+      end)
+      |> Enum.reject(&is_nil/1)
 
-    Partners.update_credential(credential, valid_update_attrs)
+    assert imported_assistant_ids != []
+    assert Enum.all?(imported_assistant_ids, &(&1 == ""))
   end
 
   test "terminate inactive flows", attrs do

--- a/test/glific_web/schema/flow_test.exs
+++ b/test/glific_web/schema/flow_test.exs
@@ -870,7 +870,7 @@ defmodule GlificWeb.Schema.FlowTest do
             String.contains?(action["body"], "assistant_id")
         end)
       end)
-      |> Enum.map(& &1["uuid"])
+      |> Enum.map(fn node -> String.slice(node["uuid"], -4..-1//1) end)
 
     assert expected_node_uuids != []
 
@@ -890,11 +890,12 @@ defmodule GlificWeb.Schema.FlowTest do
 
     [imported_flow | _] = Flows.list_flows(%{filter: %{name: "call_and_wait"}})
 
-    {:ok, revision} =
-      Repo.fetch_by(FlowRevision, %{
-        flow_id: imported_flow.id,
-        organization_id: user.organization_id
-      })
+    revision =
+      FlowRevision
+      |> where([fr], fr.flow_id == ^imported_flow.id)
+      |> order_by([fr], desc: fr.inserted_at)
+      |> limit(1)
+      |> Repo.one!()
 
     imported_assistant_ids =
       revision.definition


### PR DESCRIPTION

## Summary
 Target issue is #4946 
 
 **Description:**
 
On flow import we now:
  - Skip the Kaapi assistant ingest call entirely
  - Clear the assistant_id value in webhook action bodies (preserving the rest of the JSON formatting)
  - Return the list of node UUIDs that referenced an assistant, so the FE can prompt the user to wire up their own
  
  [Frontend PR](https://github.com/glific/glific-frontend/pull/3920)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flow imports now identify and report which nodes contain AI assistant references, providing visibility into flows integrated with AI functionality.

* **Improvements**
  * Enhanced flow import process with improved handling and normalization of AI assistant configurations within imported workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->