### PR TITLE
Add migration to delete trial users from BigQuery jobs tabe for non saas org

### DIFF
--- a/priv/repo/migrations/20260505000000_delete_trial_users_bigquery_jobs_for_non_saas_orgs.exs
+++ b/priv/repo/migrations/20260505000000_delete_trial_users_bigquery_jobs_for_non_saas_orgs.exs
@@ -1,0 +1,15 @@
+defmodule Glific.Repo.Migrations.DeleteTrialUsersBigqueryJobsForNonSaasOrgs do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    DELETE FROM bigquery_jobs
+    WHERE "table" = 'trial_users'
+      AND organization_id NOT IN (
+        SELECT organization_id FROM saas WHERE name = 'Tides'
+      )
+    """)
+  end
+
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20260505000000_delete_trial_users_bigquery_jobs_for_non_saas_orgs.exs
+++ b/priv/repo/migrations/20260505000000_delete_trial_users_bigquery_jobs_for_non_saas_orgs.exs
@@ -1,7 +1,7 @@
 defmodule Glific.Repo.Migrations.DeleteTrialUsersBigqueryJobsForNonSaasOrgs do
   use Ecto.Migration
 
-  def up do
+  def change do
     execute("""
     DELETE FROM bigquery_jobs
     WHERE "table" = 'trial_users'
@@ -10,6 +10,4 @@ defmodule Glific.Repo.Migrations.DeleteTrialUsersBigqueryJobsForNonSaasOrgs do
       )
     """)
   end
-
-  def down, do: :ok
 end


### PR DESCRIPTION
…saas org



## Summary
  Migration (20260505000000_delete_trial_users_bigquery_jobs_for_non_saas_orgs.exs)                                                           
  - One-time cleanup :  deletes all trial_users rows from bigquery_jobs for orgs that are not the SaaS org, using a subquery against the saas table to avoid hardcoding org ID 2.   