### PR TITLE
fix: normalize dynamic URL segments in Tesla telemetry for remaining clients

### DIFF
--- a/lib/glific/providers/gupshup/whatsapp_forms/api_client.ex
+++ b/lib/glific/providers/gupshup/whatsapp_forms/api_client.ex
@@ -18,6 +18,8 @@ defmodule Glific.Providers.Gupshup.WhatsappForms.ApiClient do
         {Tesla.Middleware.BaseUrl, Keyword.fetch!(opts, :url)},
         {Tesla.Middleware.Headers, Keyword.fetch!(opts, :headers)},
         {Tesla.Middleware.JSON, engine_opts: [keys: :atoms]},
+        Tesla.Middleware.KeepRequest,
+        Tesla.Middleware.PathParams,
         {Tesla.Middleware.Telemetry,
          metadata: %{provider: "gupshup_whatsapp_forms", sampling_scale: 10}}
       ] ++ Glific.get_tesla_retry_middleware()
@@ -67,7 +69,7 @@ defmodule Glific.Providers.Gupshup.WhatsappForms.ApiClient do
 
     response =
       client(url: url, headers: headers)
-      |> Tesla.get("/flows/#{flow_id}/assets")
+      |> Tesla.get("/flows/:flow_id/assets", opts: [path_params: [flow_id: flow_id]])
       |> parse_response("get_whatsapp_form_assets")
 
     case response do
@@ -104,10 +106,10 @@ defmodule Glific.Providers.Gupshup.WhatsappForms.ApiClient do
         categories: Enum.map(params.categories, &String.upcase/1)
       }
 
-    opts = [adapter: [recv_timeout: 60_000]]
+    opts = [adapter: [recv_timeout: 60_000], path_params: [flow_id: meta_flow_id]]
 
     client(url: url, headers: headers)
-    |> Tesla.put("/flows/#{meta_flow_id}", payload, opts: opts)
+    |> Tesla.put("/flows/:flow_id", payload, opts: opts)
     |> parse_response("update_whatsapp_form")
   end
 
@@ -128,10 +130,10 @@ defmodule Glific.Providers.Gupshup.WhatsappForms.ApiClient do
         headers: [{"content-type", "application/json"}]
       )
 
-    opts = [adapter: [recv_timeout: 60_000]]
+    opts = [adapter: [recv_timeout: 60_000], path_params: [flow_id: form.meta_flow_id]]
 
     client(url: url, headers: headers)
-    |> Tesla.put("/flows/#{form.meta_flow_id}/assets", multipart, opts: opts)
+    |> Tesla.put("/flows/:flow_id/assets", multipart, opts: opts)
     |> parse_response("update_whatsapp_form_json")
   end
 
@@ -144,7 +146,9 @@ defmodule Glific.Providers.Gupshup.WhatsappForms.ApiClient do
     url = PartnerAPI.app_url!(organization_id)
     headers = PartnerAPI.headers(:app_token, org_id: organization_id)
 
-    Tesla.post(client(url: url, headers: headers), "/flows/#{flow_id}/publish", %{})
+    Tesla.post(client(url: url, headers: headers), "/flows/:flow_id/publish", %{},
+      opts: [path_params: [flow_id: flow_id]]
+    )
     |> parse_response("publish_whatsapp_form")
   end
 

--- a/lib/glific/third_party/openAI/chatGPT.ex
+++ b/lib/glific/third_party/openAI/chatGPT.ex
@@ -285,12 +285,12 @@ defmodule Glific.OpenAI.ChatGPT do
   def fetch_thread(%{thread_id: nil}), do: {:error, "No thread found with nil id."}
 
   def fetch_thread(%{thread_id: thread_id}) do
-    url = @endpoint <> "/threads/#{thread_id}"
+    url = @endpoint <> "/threads/:thread_id"
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.get(url, opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.get(url, opts: [adapter: [recv_timeout: 120_000], path_params: [thread_id: thread_id]])
     |> case do
       {:ok, %Tesla.Env{status: 200, body: _body}} ->
         {:ok, thread_id}
@@ -309,7 +309,7 @@ defmodule Glific.OpenAI.ChatGPT do
   """
   @spec add_message_to_thread(map()) :: tuple()
   def add_message_to_thread(params) do
-    url = @endpoint <> "/threads/#{params.thread_id}/messages"
+    url = @endpoint <> "/threads/:thread_id/messages"
 
     payload =
       %{
@@ -321,7 +321,9 @@ defmodule Glific.OpenAI.ChatGPT do
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.post(url, payload, opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.post(url, payload,
+      opts: [adapter: [recv_timeout: 120_000], path_params: [thread_id: params.thread_id]]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         Jason.decode!(body)
@@ -336,12 +338,14 @@ defmodule Glific.OpenAI.ChatGPT do
   """
   @spec list_thread_messages(map()) :: map()
   def list_thread_messages(params) do
-    url = @endpoint <> "/threads/#{params.thread_id}/messages"
+    url = @endpoint <> "/threads/:thread_id/messages"
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.get(url, opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.get(url,
+      opts: [adapter: [recv_timeout: 120_000], path_params: [thread_id: params.thread_id]]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         Jason.decode!(body)
@@ -376,14 +380,16 @@ defmodule Glific.OpenAI.ChatGPT do
   @spec run_thread(map()) :: {:ok, String.t()} | {:error, String.t()}
   def run_thread(params) do
     re_run = Map.get(params, :re_run, false)
-    url = @endpoint <> "/threads/#{params.thread_id}/runs"
+    url = @endpoint <> "/threads/:thread_id/runs"
 
     payload = Jason.encode!(%{"assistant_id" => params.assistant_id})
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.post(url, payload, opts: [adapter: [recv_timeout: 20_000]])
+    |> Tesla.post(url, payload,
+      opts: [adapter: [recv_timeout: 20_000], path_params: [thread_id: params.thread_id]]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         run = Jason.decode!(body)
@@ -478,12 +484,14 @@ defmodule Glific.OpenAI.ChatGPT do
   """
   @spec cancel_run(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def cancel_run(thread_id, run_id) do
-    url = @endpoint <> "/threads/#{thread_id}/runs/#{run_id}/cancel"
+    url = @endpoint <> "/threads/:thread_id/runs/:run_id/cancel"
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.post(url, "", opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.post(url, "",
+      opts: [adapter: [recv_timeout: 120_000], path_params: [thread_id: thread_id, run_id: run_id]]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200}} ->
         {:ok, "run cancelled"}
@@ -498,12 +506,17 @@ defmodule Glific.OpenAI.ChatGPT do
   """
   @spec retrieve_run(map()) :: {:ok, map()} | {:error, String.t()}
   def retrieve_run(params) do
-    url = @endpoint <> "/threads/#{params.thread_id}/runs/#{params.run_id}"
+    url = @endpoint <> "/threads/:thread_id/runs/:run_id"
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.get(url, opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.get(url,
+      opts: [
+        adapter: [recv_timeout: 120_000],
+        path_params: [thread_id: params.thread_id, run_id: params.run_id]
+      ]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         {:ok, Jason.decode!(body)}
@@ -576,12 +589,14 @@ defmodule Glific.OpenAI.ChatGPT do
   """
   @spec retrieve_assistant(map()) :: {:ok, String.t()} | {:error, String.t()}
   def retrieve_assistant(assistant_id) do
-    url = @endpoint <> "/assistants/#{assistant_id}"
+    url = @endpoint <> "/assistants/:assistant_id"
 
     headers()
     |> get_tesla_middlewares()
     |> Tesla.client()
-    |> Tesla.get(url, opts: [adapter: [recv_timeout: 120_000]])
+    |> Tesla.get(url,
+      opts: [adapter: [recv_timeout: 120_000], path_params: [assistant_id: assistant_id]]
+    )
     |> case do
       {:ok, %Tesla.Env{status: 200, body: body}} ->
         response = Jason.decode!(body)
@@ -631,6 +646,8 @@ defmodule Glific.OpenAI.ChatGPT do
   @spec get_tesla_telemetry_middlewares :: list()
   defp get_tesla_telemetry_middlewares do
     [
+      Tesla.Middleware.KeepRequest,
+      Tesla.Middleware.PathParams,
       {Tesla.Middleware.Telemetry, metadata: %{provider: "openai", sampling_scale: 8}}
     ] ++ Glific.get_tesla_retry_middleware()
   end


### PR DESCRIPTION
## Summary

Closes #4969 — follow-up to #4831 (same fix as Kaapi, applied to remaining clients).

- **WhatsApp Forms** (`Glific.Providers.Gupshup.WhatsappForms.ApiClient`): Added `KeepRequest` + `PathParams` middleware; updated `/flows/{id}`, `/flows/{id}/assets`, `/flows/{id}/publish` calls to use path param templates
- **OpenAI ChatGPT** (`Glific.OpenAI.ChatGPT`): Added `KeepRequest` + `PathParams` to `get_tesla_telemetry_middlewares/0`; updated 6 calls with dynamic thread/run/assistant IDs to use templates (`:thread_id`, `:run_id`, `:assistant_id`)

AppSignal will now receive stable template URLs (e.g. `/flows/:flow_id/assets`, `/threads/:thread_id/runs`) instead of unique per-request IDs, keeping distribution charts readable.

## Test plan

- [ ] Existing tests pass: `mix test test/glific/third_party/openAI/chatGPT_test.exs test/glific/third_party/whatsapp_form/ test/glific_web/schema/whatsapp_form_test.exs`
- [ ] Verify AppSignal telemetry shows normalized URL templates after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)