### PR TITLE
fix: make output_language optional in speech_to_text webhook

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -139,7 +139,8 @@ defmodule Glific.Clients.CommonWebhook do
   end
 
   # Generic Kaapi STT webhook (async — result delivered via flow_resume callback).
-  # Optional fields from flow node: provider, model, language (input language for transcription)
+  # Optional fields from flow node: provider, model, language (input language for transcription),
+  # output_language (if omitted, Kaapi transcribes in the input language without translation)
   def webhook("speech_to_text", fields, _headers) do
     {organization_id, flow_id, contact_id} = parse_flow_fields(fields)
 
@@ -148,14 +149,11 @@ defmodule Glific.Clients.CommonWebhook do
 
     request_metadata = Map.put(request_metadata, :call_type, "stt")
 
-    contact = Contacts.preload_contact_language(contact_id)
-    contact_language = contact.language.label |> String.downcase()
-
     stt_opts = %{
       provider: fields["provider"],
       model: fields["model"],
       language: fields["language"],
-      output_language: contact_language
+      output_language: fields["output_language"]
     }
 
     Glific.Metrics.increment("Kaapi STT Call", organization_id)

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -442,12 +442,10 @@ defmodule Glific.ThirdParty.Kaapi do
     output_language = opts[:output_language]
 
     params =
-      cond do
-        is_binary(output_language) and String.trim(output_language) != "" ->
-          Map.put(base_params, :output_language, output_language)
-
-        true ->
-          base_params
+      if is_binary(output_language) and String.trim(output_language) != "" do
+        Map.put(base_params, :output_language, output_language)
+      else
+        base_params
       end
 
     %{

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -434,6 +434,14 @@ defmodule Glific.ThirdParty.Kaapi do
 
   @spec stt_payload(String.t(), String.t(), map(), map()) :: map()
   defp stt_payload(encoded_audio, callback_url, request_metadata, opts) do
+    params =
+      %{model: opts[:model] || "gemini-2.5-pro", input_language: opts[:language] || "auto"}
+      |> then(fn p ->
+        if opts[:output_language],
+          do: Map.put(p, :output_language, opts[:output_language]),
+          else: p
+      end)
+
     %{
       query: %{
         input: %{
@@ -446,11 +454,7 @@ defmodule Glific.ThirdParty.Kaapi do
           completion: %{
             provider: opts[:provider] || "google",
             type: "stt",
-            params: %{
-              model: opts[:model] || "gemini-2.5-pro",
-              input_language: opts[:language] || "auto",
-              output_language: opts[:output_language] || "english"
-            }
+            params: params
           }
         }
       },

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -434,13 +434,21 @@ defmodule Glific.ThirdParty.Kaapi do
 
   @spec stt_payload(String.t(), String.t(), map(), map()) :: map()
   defp stt_payload(encoded_audio, callback_url, request_metadata, opts) do
+    base_params = %{
+      model: opts[:model] || "gemini-2.5-pro",
+      input_language: opts[:language] || "auto"
+    }
+
+    output_language = opts[:output_language]
+
     params =
-      %{model: opts[:model] || "gemini-2.5-pro", input_language: opts[:language] || "auto"}
-      |> then(fn p ->
-        if opts[:output_language],
-          do: Map.put(p, :output_language, opts[:output_language]),
-          else: p
-      end)
+      cond do
+        is_binary(output_language) and String.trim(output_language) != "" ->
+          Map.put(base_params, :output_language, output_language)
+
+        true ->
+          base_params
+      end
 
     %{
       query: %{

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1066,6 +1066,9 @@ defmodule Glific.Flows.CommonWebhookTest do
           assert get_in(decoded, ["config", "blob", "completion", "params", "input_language"]) ==
                    "auto"
 
+          params = get_in(decoded, ["config", "blob", "completion", "params"])
+          refute Map.has_key?(params, "output_language")
+
           metadata = decoded["request_metadata"]
           assert metadata["organization_id"] == 1
           assert metadata["flow_id"] == 1
@@ -1077,6 +1080,26 @@ defmodule Glific.Flows.CommonWebhookTest do
       end)
 
       result = CommonWebhook.webhook("speech_to_text", fields, [])
+      assert result.success == true
+    end
+
+    test "passes output_language to Kaapi when specified in fields", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{status: 200, body: "fake_audio_bytes"}
+
+        %{method: :post, body: body} ->
+          decoded = Jason.decode!(body)
+
+          assert get_in(decoded, ["config", "blob", "completion", "params", "output_language"]) ==
+                   "english"
+
+          %Tesla.Env{status: 200, body: %{"job_id" => "stt-456"}}
+      end)
+
+      result =
+        CommonWebhook.webhook("speech_to_text", Map.put(fields, "output_language", "english"), [])
+
       assert result.success == true
     end
   end

--- a/test/glific/third_party/kaapi/stt_tts_test.exs
+++ b/test/glific/third_party/kaapi/stt_tts_test.exs
@@ -155,6 +155,49 @@ defmodule Glific.ThirdParty.Kaapi.SttTtsTest do
         %{model: "custom-stt-model", language: "tamil"}
       )
     end
+
+    test "omits output_language from payload when not specified" do
+      mock(fn
+        %Tesla.Env{method: :get} ->
+          %Tesla.Env{status: 200, body: "audio"}
+
+        %Tesla.Env{method: :post, body: body} ->
+          decoded = Jason.decode!(body)
+          params = get_in(decoded, ["config", "blob", "completion", "params"])
+          refute Map.has_key?(params, "output_language")
+
+          %Tesla.Env{status: 200, body: %{"job_id" => "stt-789"}}
+      end)
+
+      Kaapi.speech_to_text(
+        "https://example.com/audio.wav",
+        @callback_url,
+        @request_metadata,
+        @org_id
+      )
+    end
+
+    test "includes output_language in payload when specified" do
+      mock(fn
+        %Tesla.Env{method: :get} ->
+          %Tesla.Env{status: 200, body: "audio"}
+
+        %Tesla.Env{method: :post, body: body} ->
+          decoded = Jason.decode!(body)
+          params = get_in(decoded, ["config", "blob", "completion", "params"])
+          assert params["output_language"] == "hindi"
+
+          %Tesla.Env{status: 200, body: %{"job_id" => "stt-999"}}
+      end)
+
+      Kaapi.speech_to_text(
+        "https://example.com/audio.wav",
+        @callback_url,
+        @request_metadata,
+        @org_id,
+        %{output_language: "hindi"}
+      )
+    end
   end
 
   describe "text_to_speech/5" do

--- a/test/glific/third_party/kaapi/stt_tts_test.exs
+++ b/test/glific/third_party/kaapi/stt_tts_test.exs
@@ -198,6 +198,28 @@ defmodule Glific.ThirdParty.Kaapi.SttTtsTest do
         %{output_language: "hindi"}
       )
     end
+
+    test "treats blank output_language as absent" do
+      mock(fn
+        %Tesla.Env{method: :get} ->
+          %Tesla.Env{status: 200, body: "audio"}
+
+        %Tesla.Env{method: :post, body: body} ->
+          decoded = Jason.decode!(body)
+          params = get_in(decoded, ["config", "blob", "completion", "params"])
+          refute Map.has_key?(params, "output_language")
+
+          %Tesla.Env{status: 200, body: %{"job_id" => "stt-blank"}}
+      end)
+
+      Kaapi.speech_to_text(
+        "https://example.com/audio.wav",
+        @callback_url,
+        @request_metadata,
+        @org_id,
+        %{output_language: "   "}
+      )
+    end
   end
 
   describe "text_to_speech/5" do


### PR DESCRIPTION
## Summary
- Removes hardcoded `contact.language` as default for `output_language` in the Kaapi STT webhook
- When `output_language` is omitted, Kaapi now transcribes in the input language without translation
- NGOs can opt into translation by explicitly passing `output_language` as a flow field

## Behavior change
**Before:** Every voice note was force-translated into the contact's language (e.g. English audio → translated to Hindi for a Hindi-language contact), making STT output unpredictable.

**After:** The webhook passes `output_language` through to Kaapi only when set. With `output_language` omitted (the default), Kaapi auto-detects the input language and returns the transcription as-is. With it set (e.g. `"english"`), Kaapi translates to that language.

## Test plan
- [x] `mix test test/glific/third_party/kaapi/stt_tts_test.exs test/glific/flows/common_webhook_test.exs` passes
- [x] New test asserts `output_language` is omitted from Kaapi payload by default
- [x] New test asserts `output_language` is included in the payload when passed via flow fields
- [x] Manual: send a voice note in a flow node with no `output_language` and confirm transcription matches the spoken language
- [x] Manual: send a voice note with `output_language: "english"` set and confirm translation to English

Closes #5010

🤖 Generated with [Claude Code](https://claude.com/claude-code)