### PR TITLE
feat: implement organization eval access request feature 

### DIFF
--- a/assets/gql/ai_evaluations/get_org_eval_access_request.gql
+++ b/assets/gql/ai_evaluations/get_org_eval_access_request.gql
@@ -1,0 +1,5 @@
+query getOrgEvalAccessRequest {
+  orgEvalAccessRequest {
+    status
+  }
+}

--- a/assets/gql/ai_evaluations/request_ai_evaluation_access.gql
+++ b/assets/gql/ai_evaluations/request_ai_evaluation_access.gql
@@ -1,0 +1,8 @@
+mutation requestAiEvaluationAccess {
+  requestAiEvaluationAccess {
+    status
+    errors {
+      message
+    }
+  }
+}

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -245,7 +245,6 @@ defmodule Glific.AIEvaluations do
     end
   end
 
-
   @doc """
   Returns the eval access request for an organization, or nil if none exists.
   """

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -9,8 +9,11 @@ defmodule Glific.AIEvaluations do
   alias Glific.{
     AIEvaluations.AIEvaluation,
     AIEvaluations.GoldenQA,
+    AIEvaluations.OrganizationEvalRequest,
+    Mails.EvalAccessRequestMail,
     Metrics,
     Notifications,
+    Partners,
     Repo,
     ThirdParty.Kaapi
   }
@@ -214,6 +217,42 @@ defmodule Glific.AIEvaluations do
         where(query, [e], ilike(e.name, ^"%#{name}%"))
     end)
   end
+
+  @doc """
+  Requests access to the AI Evaluations feature for an organization.
+  Idempotent: if a request already exists for the org, returns the existing one.
+  """
+  @spec request_eval_access(non_neg_integer()) ::
+          {:ok, OrganizationEvalRequest.t()} | {:error, Ecto.Changeset.t()}
+  def request_eval_access(organization_id) do
+    case Repo.fetch_by(OrganizationEvalRequest, %{organization_id: organization_id}) do
+      {:ok, existing} ->
+        {:ok, existing}
+
+      {:error, _} ->
+        result =
+          %OrganizationEvalRequest{}
+          |> OrganizationEvalRequest.changeset(%{organization_id: organization_id})
+          |> Repo.insert()
+
+        with {:ok, _request} <- result do
+          organization_id
+          |> Partners.organization()
+          |> EvalAccessRequestMail.send_eval_access_request_mail()
+        end
+
+        result
+    end
+  end
+
+
+  @doc """
+  Returns the eval access request for an organization, or nil if none exists.
+  """
+  @spec get_eval_access_request(non_neg_integer()) ::
+          {:ok, OrganizationEvalRequest.t()} | {:error, any()}
+  def get_eval_access_request(organization_id),
+    do: Repo.fetch_by(OrganizationEvalRequest, %{organization_id: organization_id})
 
   @spec filter_golden_qas(Ecto.Query.t(), map()) :: Ecto.Query.t()
   defp filter_golden_qas(query, filter) do

--- a/lib/glific/ai_evaluations/organization_eval_request.ex
+++ b/lib/glific/ai_evaluations/organization_eval_request.ex
@@ -1,0 +1,48 @@
+defmodule Glific.AIEvaluations.OrganizationEvalRequest do
+  @moduledoc """
+  Schema for organization-level requests to access the AI Evaluations feature.
+  One record per organization; status tracks the lifecycle of the request.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Glific.{
+    AIEvaluations.OrganizationEvalRequest,
+    Partners.Organization
+  }
+
+  @type t() :: %__MODULE__{
+          __meta__: Ecto.Schema.Metadata.t(),
+          id: non_neg_integer() | nil,
+          status: String.t(),
+          organization_id: non_neg_integer() | nil,
+          organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
+        }
+
+  @valid_statuses ~w(requested approved rejected)
+  @required_fields [:organization_id]
+  @optional_fields [:status]
+
+  schema "organization_eval_requests" do
+    field(:status, :string, default: "requested")
+    belongs_to(:organization, Organization)
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc """
+  Standard changeset for creating and updating organization eval requests.
+  """
+  @spec changeset(OrganizationEvalRequest.t(), map()) :: Ecto.Changeset.t()
+  def changeset(request, attrs) do
+    request
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_inclusion(:status, @valid_statuses)
+    |> assoc_constraint(:organization)
+    |> unique_constraint(:organization_id)
+  end
+end

--- a/lib/glific/mails/eval_access_request_mail.ex
+++ b/lib/glific/mails/eval_access_request_mail.ex
@@ -1,0 +1,40 @@
+defmodule Glific.Mails.EvalAccessRequestMail do
+  @moduledoc """
+  Sends an email to the Glific support team when an organization requests
+  access to the AI Evaluations feature.
+  """
+
+  alias Glific.Communications.Mailer
+  alias Glific.Partners.Organization
+
+  @doc """
+  Sends a notification to the Glific support team about a new eval access request.
+  """
+  @spec send_eval_access_request_mail(Organization.t()) :: {:ok, any()} | {:error, any()}
+  def send_eval_access_request_mail(organization) do
+    subject = "AI Evaluations Access Request - #{organization.name}"
+
+    body = """
+    An organization has requested access to the AI Evaluations feature.
+
+    Organization Details:
+    - Name: #{organization.name}
+    - Shortcode: #{organization.shortcode}
+    - Email: #{organization.email}
+    - Login URL: https://#{organization.shortcode}.#{Glific.base_domain()}
+
+    Please review and enable the AI Evaluations feature flag for this organization.
+    """
+
+    Mailer.common_send(
+      nil,
+      subject,
+      body,
+      send_to: Mailer.glific_support()
+    )
+    |> Mailer.send(%{
+      category: "AI Evaluations Access Request",
+      organization_id: organization.id
+    })
+  end
+end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -14,6 +14,32 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     ThirdParty.Kaapi
   }
 
+  @doc """
+  Request access to the AI Evaluations feature for the current user's organization.
+  Idempotent: repeated calls return success regardless of existing request state.
+  """
+  @spec request_ai_evaluation_access(map(), map(), map()) ::
+          {:ok, %{status: String.t()}} | {:error, Ecto.Changeset.t()}
+  def request_ai_evaluation_access(_, _, %{context: %{current_user: user}}) do
+    case AIEvaluations.request_eval_access(user.organization_id) do
+      {:ok, _request} -> {:ok, %{status: "requested"}}
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Returns the organization's eval access request status, or nil if no request has been made.
+  Used by the frontend to disable the "Request Access" button when a request already exists.
+  """
+  @spec get_org_eval_access_request(map(), map(), map()) ::
+          {:ok, %{status: String.t()} | nil}
+  def get_org_eval_access_request(_, _, %{context: %{current_user: user}}) do
+    case AIEvaluations.get_eval_access_request(user.organization_id) do
+      {:ok, request} -> {:ok, %{status: request.status}}
+      {:error, _} -> {:ok, nil}
+    end
+  end
+
   # 1MB
   @max_golden_qa_file_size 1 * 1024 * 1024
   @create_golden_qa_success_metric "Golden QA Create Success"

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -151,9 +151,32 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
       middleware(RequireFeatureFlag, {:ai_evaluations, "AI Evaluations"})
       resolve(&Resolvers.AIEvaluations.get_golden_qa/3)
     end
+
+    @desc "Get the organization's AI Evaluations access request status"
+    field :org_eval_access_request, :org_eval_access_request do
+      middleware(Authorize, :staff)
+      middleware(RequireFeatureFlag, {:ai_evaluations, "AI Evaluations"})
+      resolve(&Resolvers.AIEvaluations.get_org_eval_access_request/3)
+    end
+  end
+
+  object :org_eval_access_request do
+    field :status, :string
+  end
+
+  object :request_eval_access_result do
+    field :status, :string
+    field :errors, list_of(:result_error)
   end
 
   object :ai_evaluation_mutations do
+    @desc "Request access to the AI Evaluations feature"
+    field :request_ai_evaluation_access, :request_eval_access_result do
+      middleware(Authorize, :staff)
+      middleware(RequireFeatureFlag, {:ai_evaluations, "AI Evaluations"})
+      resolve(&Resolvers.AIEvaluations.request_ai_evaluation_access/3)
+    end
+
     @desc "Create Golden QA"
     field :create_golden_qa, :golden_qa_result do
       arg(:input, non_null(:golden_qa_input))

--- a/priv/repo/migrations/20260511000000_create_organization_eval_requests.exs
+++ b/priv/repo/migrations/20260511000000_create_organization_eval_requests.exs
@@ -1,0 +1,18 @@
+defmodule Glific.Repo.Migrations.CreateOrganizationEvalRequests do
+  use Ecto.Migration
+
+  def up do
+    create table(:organization_eval_requests) do
+      add(:status, :string, null: false, default: "requested")
+      add(:organization_id, references(:organizations, on_delete: :delete_all), null: false)
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create(unique_index(:organization_eval_requests, [:organization_id]))
+  end
+
+  def down do
+    drop(table(:organization_eval_requests))
+  end
+end

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -4,12 +4,16 @@ defmodule Glific.AIEvaluationsTest do
 
   import Ecto.Query
 
+  import Swoosh.TestAssertions
+
   alias Glific.{
     AIEvaluations,
     AIEvaluations.AIEvaluation,
     AIEvaluations.GoldenQA,
+    AIEvaluations.OrganizationEvalRequest,
     Assistants.Assistant,
     Assistants.AssistantConfigVersion,
+    Communications.Mailer,
     Notifications,
     Notifications.Notification,
     Partners,
@@ -375,6 +379,49 @@ defmodule Glific.AIEvaluationsTest do
 
     {:ok, updated_eval} = Repo.fetch_by(AIEvaluation, %{id: evaluation.id})
     updated_eval
+  end
+
+  describe "request_eval_access/1" do
+    test "creates a new request with status requested", %{organization_id: organization_id} do
+      assert {:ok, %OrganizationEvalRequest{status: "requested"}} =
+               AIEvaluations.request_eval_access(organization_id)
+    end
+
+    test "sends email to glific support on new request", %{organization_id: organization_id} do
+      AIEvaluations.request_eval_access(organization_id)
+
+      assert_email_sent(fn email ->
+        email.subject =~ "AI Evaluations Access Request" and
+          email.to == [Mailer.glific_support()]
+      end)
+    end
+
+    test "returns existing request and does not send email when request already exists", %{
+      organization_id: organization_id
+    } do
+      {:ok, first} = AIEvaluations.request_eval_access(organization_id)
+      {:ok, second} = AIEvaluations.request_eval_access(organization_id)
+
+      assert first.id == second.id
+      assert_email_sent(subject: ~r/AI Evaluations Access Request/)
+      refute_email_sent(subject: ~r/AI Evaluations Access Request/)
+    end
+  end
+
+  describe "get_eval_access_request/1" do
+    test "returns error tuple when no request exists", %{organization_id: organization_id} do
+      assert {:error, _} = AIEvaluations.get_eval_access_request(organization_id)
+    end
+
+    test "returns the request when it exists", %{organization_id: organization_id} do
+      {:ok, created} = AIEvaluations.request_eval_access(organization_id)
+
+      assert {:ok, %OrganizationEvalRequest{} = fetched} =
+               AIEvaluations.get_eval_access_request(organization_id)
+
+      assert fetched.id == created.id
+      assert fetched.status == "requested"
+    end
   end
 
   defp enable_kaapi(organization_id) do

--- a/test/glific/communications_test.exs
+++ b/test/glific/communications_test.exs
@@ -523,21 +523,9 @@ defmodule Glific.CommunicationsTest do
     end
 
     test "EvalAccessRequestMail sends access request notification to glific support", attrs do
-      mail_attrs = %{
-        category: "AI Evaluations Access Request",
-        organization_id: attrs.organization_id
-      }
-
-      eval_access_request_email =
-        Partners.organization(attrs.organization_id)
-        |> EvalAccessRequestMail.send_eval_access_request_mail()
-
-      assert {:ok, _} = eval_access_request_email
-
-      assert_email_sent(fn email ->
-        email.subject =~ "AI Evaluations Access Request" and
-          email.to == [Communications.Mailer.glific_support()]
-      end)
+      assert {:ok, _} =
+               Partners.organization(attrs.organization_id)
+               |> EvalAccessRequestMail.send_eval_access_request_mail()
 
       assert MailLog.count_mail_logs(%{
                filter: Map.merge(attrs, %{category: "AI Evaluations Access Request"})

--- a/test/glific/communications_test.exs
+++ b/test/glific/communications_test.exs
@@ -455,6 +455,7 @@ defmodule Glific.CommunicationsTest do
     alias Glific.{
       Fixtures,
       Mails.BalanceAlertMail,
+      Mails.EvalAccessRequestMail,
       Mails.MailLog,
       Mails.NewPartnerOnboardedMail,
       Mails.NotificationMail,
@@ -518,6 +519,28 @@ defmodule Glific.CommunicationsTest do
 
       assert MailLog.count_mail_logs(%{
                filter: Map.merge(attrs, %{category: "low_bsp_balance"})
+             }) == 1
+    end
+
+    test "EvalAccessRequestMail sends access request notification to glific support", attrs do
+      mail_attrs = %{
+        category: "AI Evaluations Access Request",
+        organization_id: attrs.organization_id
+      }
+
+      eval_access_request_email =
+        Partners.organization(attrs.organization_id)
+        |> EvalAccessRequestMail.send_eval_access_request_mail()
+
+      assert {:ok, _} = eval_access_request_email
+
+      assert_email_sent(fn email ->
+        email.subject =~ "AI Evaluations Access Request" and
+          email.to == [Communications.Mailer.glific_support()]
+      end)
+
+      assert MailLog.count_mail_logs(%{
+               filter: Map.merge(attrs, %{category: "AI Evaluations Access Request"})
              }) == 1
     end
   end

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1261,4 +1261,38 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
     %{golden_qa: golden_qa}
   end
+
+  describe "request_ai_evaluation_access/3" do
+    test "creates an eval access request and returns status requested", %{staff: user} do
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{status: "requested"}} =
+               AIEvaluations.request_ai_evaluation_access(nil, %{}, resolution)
+    end
+
+    test "returns existing request status if one already exists", %{staff: user} do
+      resolution = %{context: %{current_user: user}}
+      AIEvaluations.request_ai_evaluation_access(nil, %{}, resolution)
+
+      assert {:ok, %{status: "requested"}} =
+               AIEvaluations.request_ai_evaluation_access(nil, %{}, resolution)
+    end
+  end
+
+  describe "get_org_eval_access_request/3" do
+    test "returns nil when no request exists", %{staff: user} do
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, nil} =
+               AIEvaluations.get_org_eval_access_request(nil, %{}, resolution)
+    end
+
+    test "returns status after a request has been made", %{staff: user} do
+      resolution = %{context: %{current_user: user}}
+      AIEvaluations.request_ai_evaluation_access(nil, %{}, resolution)
+
+      assert {:ok, %{status: "requested"}} =
+               AIEvaluations.get_org_eval_access_request(nil, %{}, resolution)
+    end
+  end
 end


### PR DESCRIPTION
## Summary                                                                                                                         
                                                                                                                                              
  1. Migration — 20260511000000_create_organization_eval_requests.exs                                                                         
                                                                                                                                              
      Creates organization_eval_requests table with:                                                                                              
        - organization_id (FK → organizations, unique — one request per org)                                                                        
        - status string (default "requested")                                                                                                       
        - timestamps                                                                                                                              
                                                                                                                                              
  2. Schema — lib/glific/ai_evaluations/organization_eval_request.ex                                                                        
                                                                                                                                              
        - Ecto schema with validate_inclusion on status (requested | approved | rejected) and a unique constraint on organization_id.                 
  
  3. Context — lib/glific/ai_evaluations.ex                                                                                                   
                                                                                                                                            
      Two new functions:                                                                                                                          
       - request_eval_access/1 — idempotent: creates the record if it doesn't exist, returns the existing one if it does                         
       - get_eval_access_request/1 — for future use (admin panels, checks)                                                                         
  
  4. GraphQL mutation — lib/glific_web/schema/ai_evaluation_types.ex                                                                          
                                                                                                                                            
     -  mutation {                                                                                                                                  
    requestAiEvaluationAccess {                                                                                                             
      status                                                                                                                                  
      errors { message }
    }                                                                                                                                         
  }                                                                                                                                         
     -  No RequireFeatureFlag middleware (intentional — org doesn't have the flag yet). Only Authorize :staff.
                                                                                                                                              
  5. Resolver — lib/glific_web/resolvers/ai_evaluations.ex
                                                                                                                                              
     - Returns %{status: "requested"} on success. Repeated calls are safe — the idempotency is in the context layer.                               
                                                                                                                  
