### PR TITLE
chore: add ecto metrics for db connection errors

### DIFF
--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -245,11 +245,12 @@ defmodule Glific.Appsignal do
 
   @spec classify_db_connection_error(DBConnection.ConnectionError.t()) :: String.t()
   defp classify_db_connection_error(%DBConnection.ConnectionError{reason: reason})
-       when is_atom(reason),
+       when is_atom(reason) and not is_nil(reason),
        do: Atom.to_string(reason)
 
-  defp classify_db_connection_error(%DBConnection.ConnectionError{reason: reason}),
-    do: to_string(reason)
+  defp classify_db_connection_error(%DBConnection.ConnectionError{reason: reason})
+       when not is_nil(reason),
+       do: to_string(reason)
 
   # Fallback clause if reason is not present in struct (legacy/older DBConnection)
   defp classify_db_connection_error(%DBConnection.ConnectionError{message: msg}) do

--- a/lib/glific/appsignal.ex
+++ b/lib/glific/appsignal.ex
@@ -114,10 +114,8 @@ defmodule Glific.Appsignal do
     maybe_add_distribution_metric(measurement, :query_time, "glific.repo.query_time", query_tags)
     maybe_add_distribution_metric(measurement, :idle_time, "glific.repo.idle_time", tags)
     maybe_add_distribution_metric(measurement, :queue_time, "glific.repo.queue_time", tags)
-
-    if measurement |> Map.has_key?(:query_time) do
-      Appsignal.increment_counter("glific.repo.query_count", 1, query_tags)
-    end
+    maybe_track_repo_query_count(measurement, query_tags)
+    maybe_track_db_connection_error(repo, meta[:result])
   end
 
   def handle_event(_, _, _, _), do: nil
@@ -234,6 +232,41 @@ defmodule Glific.Appsignal do
     |> @span.set_name("Tesla #{metadata.method} #{host}")
     |> @span.set_attribute("appsignal:category", "tesla.request")
   end
+
+  @spec maybe_track_db_connection_error(atom(), term()) :: :ok
+  defp maybe_track_db_connection_error(repo, {:error, %DBConnection.ConnectionError{} = err}) do
+    Appsignal.increment_counter("glific.repo.db_connection_error", 1, %{
+      repo: repo,
+      reason: classify_db_connection_error(err)
+    })
+  end
+
+  defp maybe_track_db_connection_error(_repo, _result), do: :ok
+
+  @spec classify_db_connection_error(DBConnection.ConnectionError.t()) :: String.t()
+  defp classify_db_connection_error(%DBConnection.ConnectionError{reason: reason})
+       when is_atom(reason),
+       do: Atom.to_string(reason)
+
+  defp classify_db_connection_error(%DBConnection.ConnectionError{reason: reason}),
+    do: to_string(reason)
+
+  # Fallback clause if reason is not present in struct (legacy/older DBConnection)
+  defp classify_db_connection_error(%DBConnection.ConnectionError{message: msg}) do
+    cond do
+      String.contains?(msg, "queue timeout") -> "queue_timeout"
+      String.contains?(msg, "checkout timeout") -> "checkout_timeout"
+      String.contains?(msg, "connection not available") -> "connection_not_available"
+      true -> "other"
+    end
+  end
+
+  @spec maybe_track_repo_query_count(map(), map()) :: :ok
+  defp maybe_track_repo_query_count(%{query_time: _} = _measurement, tags) do
+    Appsignal.increment_counter("glific.repo.query_count", 1, tags)
+  end
+
+  defp maybe_track_repo_query_count(_measurement, _tags), do: :ok
 
   @spec maybe_add_distribution_metric(map(), atom(), String.t(), map()) :: :ok
   defp maybe_add_distribution_metric(measurement, key, metric_name, tags) do

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -1,6 +1,8 @@
 defmodule Glific.AppsignalTest do
   use Glific.DataCase
 
+  import Mock
+
   alias Glific.Appsignal
 
   defp call_handle_event(args) do
@@ -57,44 +59,99 @@ defmodule Glific.AppsignalTest do
       )
     end
 
-    test "tracks queue_timeout DBConnection.ConnectionError in result" do
-      error = %DBConnection.ConnectionError{message: "queue timeout after 2999ms"}
-      assert query_event({:error, error}) == :ok
+    test "tracks DBConnection.ConnectionError atom reasons in result" do
+      error = %DBConnection.ConnectionError{
+        reason: :queue_timeout,
+        message: "queue timeout after 2999ms"
+      }
+
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        assert query_event({:error, error}) == :ok
+
+        assert called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, %{
+                   repo: :repo,
+                   reason: "queue_timeout"
+                 })
+               )
+      end
     end
 
-    test "tracks checkout_timeout DBConnection.ConnectionError in result" do
-      error = %DBConnection.ConnectionError{message: "checkout timeout after 1000ms"}
-      assert query_event({:error, error}) == :ok
+    test "tracks DBConnection.ConnectionError string reasons in result" do
+      error = %DBConnection.ConnectionError{reason: "custom_error", message: "custom error"}
+
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        assert query_event({:error, error}) == :ok
+
+        assert called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, %{
+                   repo: :repo,
+                   reason: "custom_error"
+                 })
+               )
+      end
     end
 
-    test "tracks connection_not_available DBConnection.ConnectionError in result" do
-      error = %DBConnection.ConnectionError{message: "connection not available and request was dropped"}
-      assert query_event({:error, error}) == :ok
-    end
+    test "tracks DBConnection.ConnectionError nil reasons in result" do
+      error = %DBConnection.ConnectionError{reason: nil, message: "queue timeout after 2999ms"}
 
-    test "tracks other DBConnection.ConnectionError in result" do
-      error = %DBConnection.ConnectionError{message: "some unexpected connection error"}
-      assert query_event({:error, error}) == :ok
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        assert query_event({:error, error}) == :ok
+
+        assert called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, %{
+                   repo: :repo,
+                   reason: "queue_timeout"
+                 })
+               )
+      end
     end
 
     test "does not track non-connection errors" do
-      assert query_event({:error, %Postgrex.Error{message: "syntax error"}}) == :ok
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        assert query_event({:error, %Postgrex.Error{message: "syntax error"}}) == :ok
+        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+      end
     end
 
     test "does not track successful results" do
-      assert query_event({:ok, %{rows: []}}) == :ok
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        assert query_event({:ok, %{rows: []}}) == :ok
+        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+      end
     end
 
     test "handles missing result key gracefully" do
-      result =
-        Appsignal.handle_event(
-          [:glific, :repo, :query],
-          %{queue_time: 1_000_000},
-          %{query: "SELECT 1"},
-          nil
-        )
+      with_mock Elixir.Appsignal,
+        [:passthrough],
+        add_distribution_value: fn _, _, _ -> :ok end,
+        increment_counter: fn _, _, _ -> :ok end do
+        result =
+          Appsignal.handle_event(
+            [:glific, :repo, :query],
+            %{queue_time: 1_000_000},
+            %{query: "SELECT 1"},
+            nil
+          )
 
-      assert result == :ok
+        assert result == :ok
+        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+      end
     end
   end
 

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -46,4 +46,56 @@ defmodule Glific.AppsignalTest do
       assert Appsignal.send_oban_queue_size() == :ok
     end
   end
+
+  describe "handle_event [:glific, :repo, :query] DBConnection error tracking" do
+    defp query_event(result) do
+      Appsignal.handle_event(
+        [:glific, :repo, :query],
+        %{queue_time: 1_000_000},
+        %{result: result, query: "SELECT 1"},
+        nil
+      )
+    end
+
+    test "tracks queue_timeout DBConnection.ConnectionError in result" do
+      error = %DBConnection.ConnectionError{message: "queue timeout after 2999ms"}
+      assert query_event({:error, error}) == :ok
+    end
+
+    test "tracks checkout_timeout DBConnection.ConnectionError in result" do
+      error = %DBConnection.ConnectionError{message: "checkout timeout after 1000ms"}
+      assert query_event({:error, error}) == :ok
+    end
+
+    test "tracks connection_not_available DBConnection.ConnectionError in result" do
+      error = %DBConnection.ConnectionError{message: "connection not available and request was dropped"}
+      assert query_event({:error, error}) == :ok
+    end
+
+    test "tracks other DBConnection.ConnectionError in result" do
+      error = %DBConnection.ConnectionError{message: "some unexpected connection error"}
+      assert query_event({:error, error}) == :ok
+    end
+
+    test "does not track non-connection errors" do
+      assert query_event({:error, %Postgrex.Error{message: "syntax error"}}) == :ok
+    end
+
+    test "does not track successful results" do
+      assert query_event({:ok, %{rows: []}}) == :ok
+    end
+
+    test "handles missing result key gracefully" do
+      result =
+        Appsignal.handle_event(
+          [:glific, :repo, :query],
+          %{queue_time: 1_000_000},
+          %{query: "SELECT 1"},
+          nil
+        )
+
+      assert result == :ok
+    end
+  end
+
 end


### PR DESCRIPTION
In #4958 we added Ecto query timing metrics, but those events are silent when `DBConnection.ConnectionError` is raised (pool exhaustion, dropped connections). This adds a counter for those errors.

Closes #5060

## Implementation

Ecto SQL emits a `[:glific, :repo, :query]` event after every query attempt with a `result` key in metadata — `{:error, %DBConnection.ConnectionError{}}` when the pool is exhausted. Refs: [Ecto.Adapters.SQL telemetry](https://hexdocs.pm/ecto_sql/Ecto.Adapters.SQL.html#module-telemetry-events), [DBConnection queue options](https://hexdocs.pm/db_connection/DBConnection.html#t:start_option/0).

The existing `[:glific, :repo, :query]` handler in `Glific.Appsignal` was extended to inspect `meta[:result]` and increment `glific.repo.db_connection_error` tagged by `repo` (`:repo` / `:repo_replica`) and `reason` (`queue_timeout`, `checkout_timeout`, `connection_not_available`, `other`). No new telemetry attachments needed.

## Test Plan

**Dev** — set `pool_size: 1, queue_target: 50` in `config/dev.exs`, then run concurrent queries in IEx to exhaust the pool:
```elixir
for _ <- 1..10, do: Task.async(fn ->
  Glific.Repo.put_organization_id(1)
  Glific.Repo.query("SELECT pg_sleep(1)", [])
end) |> Task.await_many(15_000)
```
Confirm `glific.repo.db_connection_error` counter appears in AppSignal with `reason: "queue_timeout"`.

**Staging** — deploy, trigger load, check AppSignal → Metrics for `glific.repo.db_connection_error`. Cross-reference with `DBConnection.ConnectionError` entries in the error log.