### PR TITLE
feat: add unique constraint on AI evaluation name per organization 

### DIFF
--- a/config/.env.test
+++ b/config/.env.test
@@ -1,4 +1,4 @@
-DATABASE_URL=ecto://postgres:postgres@127.0.0.1:5433/glific_test
+DATABASE_URL=ecto://postgres:postgres@127.0.0.1:5432/glific_test
 HTTP_PORT=4002
 CACERT_PATH=/priv/cert/glific-CA.pem
 SIGNING_SALT=4htfH6BMHdxcuDKFHeSryT32amWvVvlX

--- a/config/.env.test
+++ b/config/.env.test
@@ -1,4 +1,4 @@
-DATABASE_URL=ecto://postgres:postgres@127.0.0.1:5432/glific_test
+DATABASE_URL=ecto://postgres:postgres@127.0.0.1:5433/glific_test
 HTTP_PORT=4002
 CACERT_PATH=/priv/cert/glific-CA.pem
 SIGNING_SALT=4htfH6BMHdxcuDKFHeSryT32amWvVvlX

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -18,7 +18,7 @@ defmodule Glific.AIEvaluations do
     ThirdParty.Kaapi
   }
 
-  @timeout_hours 1
+  @timeout_hours 6
 
   @doc """
   Returns the list of AI evaluations for an organization.

--- a/lib/glific/ai_evaluations/ai_evaluation.ex
+++ b/lib/glific/ai_evaluations/ai_evaluation.ex
@@ -70,5 +70,6 @@ defmodule Glific.AIEvaluations.AIEvaluation do
     |> validate_required(@required_fields)
     |> assoc_constraint(:organization)
     |> assoc_constraint(:golden_qa)
+    |> unique_constraint(:name, name: :ai_evaluations_name_organization_id_index)
   end
 end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -312,7 +312,13 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec create_evaluation(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}
   def create_evaluation(_, %{input: input}, %{context: %{current_user: user}}) do
-    with {:assistant_config_version, {:ok, config_version}} <-
+    with {:name, {:error, _}} <-
+           {:name,
+            Repo.fetch_by(AIEvaluation, %{
+              name: input.evaluation_name,
+              organization_id: user.organization_id
+            })},
+         {:assistant_config_version, {:ok, config_version}} <-
            {:assistant_config_version,
             Repo.fetch_by(AssistantConfigVersion, %{id: input.config_id})},
          config_version = Repo.preload(config_version, :assistant),
@@ -340,6 +346,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            }) do
       {:ok, %{evaluation: evaluation}}
     else
+      {:name, {:ok, _}} ->
+        {:error, "An evaluation with this name already exists. Please choose a different name."}
+
       {:assistant_config_version, {:error, _}} ->
         {:error, "The specified config version does not exist."}
 

--- a/priv/repo/migrations/20260513000000_add_unique_index_ai_evaluations_name.exs
+++ b/priv/repo/migrations/20260513000000_add_unique_index_ai_evaluations_name.exs
@@ -1,0 +1,7 @@
+defmodule Glific.Repo.Migrations.AddUniqueIndexAiEvaluationsName do
+  use Ecto.Migration
+
+  def change do
+    create unique_index(:ai_evaluations, [:name, :organization_id])
+  end
+end

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -115,13 +115,13 @@ defmodule Glific.AIEvaluationsTest do
       %{config_version: config_version}
     end
 
-    test "marks processing evaluation older than 1 hour as failed", %{
+    test "marks processing evaluation older than 6 hours as failed", %{
       organization_id: organization_id,
       config_version: config_version
     } do
       evaluation =
         create_evaluation(organization_id, config_version.id, %{status: :processing})
-        |> backdate_evaluation(2)
+        |> backdate_evaluation(7)
 
       notification_count =
         Notifications.count_notifications(%{filter: %{organization_id: organization_id}})
@@ -148,11 +148,11 @@ defmodule Glific.AIEvaluationsTest do
     } do
       completed =
         create_evaluation(organization_id, config_version.id, %{status: :completed})
-        |> backdate_evaluation(2)
+        |> backdate_evaluation(7)
 
       failed =
         create_evaluation(organization_id, config_version.id, %{status: :failed})
-        |> backdate_evaluation(2)
+        |> backdate_evaluation(7)
 
       AIEvaluations.poll_and_update(organization_id)
 

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -355,7 +355,7 @@ defmodule Glific.AIEvaluationsTest do
       Map.get_lazy(attrs, :golden_qa_id, fn -> create_golden_qa(organization_id).id end)
 
     base = %{
-      name: "test_eval",
+      name: "test_eval_#{System.unique_integer([:positive])}",
       status: :processing,
       golden_qa_id: golden_qa_id,
       kaapi_evaluation_id: 404,

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1083,6 +1083,39 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert reason == "Invalid dataset format"
     end
 
+    test "returns error when evaluation name already exists for the organization", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      name = "duplicate_eval_name"
+
+      {:ok, _} =
+        Glific.AIEvaluations.create_ai_evaluation(%{
+          name: name,
+          status: :processing,
+          kaapi_evaluation_id: 1,
+          golden_qa_id: golden_qa.id,
+          assistant_config_version_id: assistant_config_version.id,
+          organization_id: user.organization_id
+        })
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: name,
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, reason} = AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert reason ==
+               "An evaluation with this name already exists. Please choose a different name."
+    end
+
     test "returns error when Kaapi is not configured" do
       other_org = Glific.Fixtures.organization_fixture()
       Repo.put_organization_id(other_org.id)


### PR DESCRIPTION
## Summary
  -  Increase eval timeout from 1 hour to 6 hours
  - New migration: unique_index(:ai_evaluations, [:name, :organization_id])
  - Add unique_constraint(:name) to the changeset in lib/glific/ai_evaluations/ai_evaluation.ex
