### PR TITLE
Structure Gemini STT/TTS error reporting for AppSignal grouping

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -49,7 +49,7 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :appsignal, :config,
   otp_app: :glific,
-  active: true,
+  active: false,
   env: :dev
 
 config :glific, Glific.Communications.Mailer, adapter: Swoosh.Adapters.Local

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -49,7 +49,7 @@ config :phoenix, :plug_init_mode, :runtime
 
 config :appsignal, :config,
   otp_app: :glific,
-  active: false,
+  active: true,
   env: :dev
 
 config :glific, Glific.Communications.Mailer, adapter: Swoosh.Adapters.Local

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -900,15 +900,26 @@ defmodule Glific.Clients.CommonWebhook do
     report_webhook_failure(webhook_name, org_id, status, reason)
   end
 
+  defp maybe_report_webhook_failure({:error, status}, webhook_name, org_id)
+       when is_integer(status) do
+    report_webhook_failure(webhook_name, org_id, status, nil)
+  end
+
+  defp maybe_report_webhook_failure({:error, reason}, webhook_name, org_id)
+       when is_binary(reason) do
+    report_webhook_failure(webhook_name, org_id, nil, reason)
+  end
+
   defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok
 
   # Picks an HTTP status (when present) and a human-readable reason out of the
-  # webhook result map. STT failures historically stuff either an integer
-  # status code or an error string into `asr_response_text`; other shapes carry
-  # a `:reason` field.
+  # webhook result map. STT failures stuff either an integer status code or an
+  # error string into `asr_response_text`. TTS surfaces the status as
+  # `:http_status`. Other shapes carry a `:reason` field.
   @spec extract_status_and_reason(map()) :: {integer() | nil, String.t() | nil}
   defp extract_status_and_reason(result) do
     case result do
+      %{http_status: s} when is_integer(s) -> {s, nil}
       %{asr_response_text: s} when is_integer(s) -> {s, nil}
       %{asr_response_text: s} when is_binary(s) -> {nil, s}
       %{reason: s} when is_binary(s) -> {nil, s}

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -898,7 +898,7 @@ defmodule Glific.Clients.CommonWebhook do
       %{asr_response_text: s} when is_integer(s) -> {s, nil}
       %{asr_response_text: s} when is_binary(s) -> {nil, s}
       %{reason: s} when is_binary(s) -> {nil, s}
-      _ -> {nil, nil}
+      other -> {nil, inspect(other)}
     end
   end
 
@@ -917,7 +917,9 @@ defmodule Glific.Clients.CommonWebhook do
     # detail lands on the AppSignal sample as filterable tags (the 2-arg form
     # records only class + message and drops struct fields).
     Appsignal.send_error(exception, [], fn span ->
-      Appsignal.Span.set_sample_data(span, "tags", %{
+      span
+      |> Appsignal.Span.set_namespace("flow_webhooks")
+      |> Appsignal.Span.set_sample_data("tags", %{
         organization_id: org_id,
         webhook_name: webhook_name,
         http_status: http_status,

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -8,12 +8,12 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.Certificates.Certificate
   alias Glific.Certificates.CertificateTemplate
   alias Glific.Contacts
+  alias Glific.Flows.Webhook.SystemError
   alias Glific.Groups.WAGroup
   alias Glific.OpenAI.ChatGPT
   alias Glific.Partners
   alias Glific.Providers.Maytapi
   alias Glific.Repo
-  alias Glific.Flows.Webhook.SystemError
   alias Glific.ThirdParty.Gemini
   alias Glific.ThirdParty.GoogleSlide.Slide
   alias Glific.ThirdParty.Kaapi
@@ -898,16 +898,6 @@ defmodule Glific.Clients.CommonWebhook do
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)
     report_webhook_failure(webhook_name, org_id, status, reason)
-  end
-
-  defp maybe_report_webhook_failure({:error, status}, webhook_name, org_id)
-       when is_integer(status) do
-    report_webhook_failure(webhook_name, org_id, status, nil)
-  end
-
-  defp maybe_report_webhook_failure({:error, reason}, webhook_name, org_id)
-       when is_binary(reason) do
-    report_webhook_failure(webhook_name, org_id, nil, reason)
   end
 
   defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -200,11 +200,23 @@ defmodule Glific.Clients.CommonWebhook do
 
         try do
           result = Gemini.speech_to_text(fields["speech"], contact.organization_id)
-          maybe_report_webhook_failure(result, "speech_to_text_with_bhasini", contact.organization_id)
+
+          maybe_report_webhook_failure(
+            result,
+            "speech_to_text_with_bhasini",
+            contact.organization_id
+          )
+
           result
         rescue
           exception ->
-            report_webhook_failure("speech_to_text_with_bhasini", contact.organization_id, nil)
+            report_webhook_failure(
+              "speech_to_text_with_bhasini",
+              contact.organization_id,
+              nil,
+              Exception.message(exception)
+            )
+
             reraise exception, __STACKTRACE__
         end
 
@@ -244,7 +256,13 @@ defmodule Glific.Clients.CommonWebhook do
       result
     rescue
       exception ->
-        report_webhook_failure("text_to_speech_with_bhasini", org_id, nil)
+        report_webhook_failure(
+          "text_to_speech_with_bhasini",
+          org_id,
+          nil,
+          Exception.message(exception)
+        )
+
         reraise exception, __STACKTRACE__
     end
   end
@@ -878,19 +896,33 @@ defmodule Glific.Clients.CommonWebhook do
   # entry points (STT, TTS) call the same reporting code.
   @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer()) :: :ok
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
-    status =
-      case result do
-        %{asr_response_text: s} when is_integer(s) -> s
-        _ -> nil
-      end
-
-    report_webhook_failure(webhook_name, org_id, status)
+    {status, reason} = extract_status_and_reason(result)
+    report_webhook_failure(webhook_name, org_id, status, reason)
   end
 
   defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok
 
-  @spec report_webhook_failure(String.t(), non_neg_integer() | nil, integer() | nil) :: :ok
-  defp report_webhook_failure(webhook_name, org_id, http_status) do
+  # Picks an HTTP status (when present) and a human-readable reason out of the
+  # webhook result map. STT failures historically stuff either an integer
+  # status code or an error string into `asr_response_text`; other shapes carry
+  # a `:reason` field.
+  @spec extract_status_and_reason(map()) :: {integer() | nil, String.t() | nil}
+  defp extract_status_and_reason(result) do
+    case result do
+      %{asr_response_text: s} when is_integer(s) -> {s, nil}
+      %{asr_response_text: s} when is_binary(s) -> {nil, s}
+      %{reason: s} when is_binary(s) -> {nil, s}
+      _ -> {nil, nil}
+    end
+  end
+
+  @spec report_webhook_failure(
+          String.t(),
+          non_neg_integer() | nil,
+          integer() | nil,
+          String.t() | nil
+        ) :: :ok
+  defp report_webhook_failure(webhook_name, org_id, http_status, reason) do
     exception = %SystemError{
       message: "Webhook system_error from #{webhook_name}",
       webhook_name: webhook_name,
@@ -900,14 +932,15 @@ defmodule Glific.Clients.CommonWebhook do
 
     Logger.error(Exception.message(exception))
 
-    # Use the 3-arg send_error with a span configurator so the per-occurrence
+    # Use the 3-arg send_error with a span configurator so per-occurrence
     # detail lands on the AppSignal sample as filterable tags (the 2-arg form
     # records only class + message and drops struct fields).
     Appsignal.send_error(exception, [], fn span ->
       Appsignal.Span.set_sample_data(span, "tags", %{
         organization_id: org_id,
         webhook_name: webhook_name,
-        http_status: http_status
+        http_status: http_status,
+        reason: reason
       })
     end)
 

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -198,27 +198,9 @@ defmodule Glific.Clients.CommonWebhook do
       {:ok, contact} ->
         Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
 
-        try do
-          result = Gemini.speech_to_text(fields["speech"], contact.organization_id)
-
-          maybe_report_webhook_failure(
-            result,
-            "speech_to_text_with_bhasini",
-            contact.organization_id
-          )
-
-          result
-        rescue
-          exception ->
-            report_webhook_failure(
-              "speech_to_text_with_bhasini",
-              contact.organization_id,
-              nil,
-              Exception.message(exception)
-            )
-
-            reraise exception, __STACKTRACE__
-        end
+        with_failure_reporting("speech_to_text_with_bhasini", contact.organization_id, fn ->
+          Gemini.speech_to_text(fields["speech"], contact.organization_id)
+        end)
 
       {:error, error} ->
         error
@@ -234,37 +216,23 @@ defmodule Glific.Clients.CommonWebhook do
     source_language = contact.language.label |> String.downcase()
     speech_engine = Map.get(fields, "speech_engine", "")
 
-    try do
-      result =
-        cond do
-          speech_engine == "open_ai" ->
-            ChatGPT.text_to_speech_with_open_ai(org_id, text)
+    with_failure_reporting("text_to_speech_with_bhasini", org_id, fn ->
+      cond do
+        speech_engine == "open_ai" ->
+          ChatGPT.text_to_speech_with_open_ai(org_id, text)
 
-          speech_engine == "bhashini" ->
-            Glific.Metrics.increment("Gemini TTS Call", org_id)
-            Gemini.text_to_speech(org_id, text)
+        speech_engine == "bhashini" ->
+          Glific.Metrics.increment("Gemini TTS Call", org_id)
+          Gemini.text_to_speech(org_id, text)
 
-          source_language == "english" ->
-            ChatGPT.text_to_speech_with_open_ai(org_id, text)
+        source_language == "english" ->
+          ChatGPT.text_to_speech_with_open_ai(org_id, text)
 
-          true ->
-            Glific.Metrics.increment("Gemini TTS Call", org_id)
-            Gemini.text_to_speech(org_id, text)
-        end
-
-      maybe_report_webhook_failure(result, "text_to_speech_with_bhasini", org_id)
-      result
-    rescue
-      exception ->
-        report_webhook_failure(
-          "text_to_speech_with_bhasini",
-          org_id,
-          nil,
-          Exception.message(exception)
-        )
-
-        reraise exception, __STACKTRACE__
-    end
+        true ->
+          Glific.Metrics.increment("Gemini TTS Call", org_id)
+          Gemini.text_to_speech(org_id, text)
+      end
+    end)
   end
 
   @doc """
@@ -351,13 +319,15 @@ defmodule Glific.Clients.CommonWebhook do
     target_language = normalize_language(fields["target_language"])
     speech_engine = Map.get(fields, "speech_engine", "")
 
-    if source_language == target_language do
-      handle_tts_only(source_language, org_id, text, speech_engine)
-    else
-      do_nmt_tts_with_bhasini(source_language, target_language, org_id, text,
-        speech_engine: speech_engine
-      )
-    end
+    with_failure_reporting("nmt_tts_with_bhasini", org_id, fn ->
+      if source_language == target_language do
+        handle_tts_only(source_language, org_id, text, speech_engine)
+      else
+        do_nmt_tts_with_bhasini(source_language, target_language, org_id, text,
+          speech_engine: speech_engine
+        )
+      end
+    end)
   end
 
   def webhook("detect_language", fields) do
@@ -891,9 +861,24 @@ defmodule Glific.Clients.CommonWebhook do
     end
   end
 
+  # Wraps a webhook entry point body so any failure — predictable
+  # (%{success: false} return) or unexpected (raised exception) — is
+  # reported to AppSignal before propagating. The function passed in runs
+  # exactly the work the entry point would have done inline; the helper
+  # is observability only and does not change behaviour for the caller.
+  @spec with_failure_reporting(String.t(), non_neg_integer() | nil, (-> any())) :: any()
+  defp with_failure_reporting(webhook_name, org_id, fun) do
+    result = fun.()
+    maybe_report_webhook_failure(result, webhook_name, org_id)
+    result
+  rescue
+    exception ->
+      report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
+      reraise exception, __STACKTRACE__
+  end
+
   # Inspects a webhook result map and emits a SystemError when the call
-  # reported failure but did not raise. Pulled out as a helper so the two
-  # entry points (STT, TTS) call the same reporting code.
+  # reported failure but did not raise.
   @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer()) :: :ok
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -923,12 +923,7 @@ defmodule Glific.Clients.CommonWebhook do
           String.t() | nil
         ) :: :ok
   defp report_webhook_failure(webhook_name, org_id, http_status, reason) do
-    exception = %SystemError{
-      message: "Webhook system_error from #{webhook_name}",
-      webhook_name: webhook_name,
-      organization_id: org_id,
-      http_status: http_status
-    }
+    exception = %SystemError{message: "Webhook system_error from #{webhook_name}"}
 
     Logger.error(Exception.message(exception))
 

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -13,6 +13,7 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.Partners
   alias Glific.Providers.Maytapi
   alias Glific.Repo
+  alias Glific.Flows.Webhook.SystemError
   alias Glific.ThirdParty.Gemini
   alias Glific.ThirdParty.GoogleSlide.Slide
   alias Glific.ThirdParty.Kaapi
@@ -196,7 +197,16 @@ defmodule Glific.Clients.CommonWebhook do
     case Bhasini.validate_params(fields) do
       {:ok, contact} ->
         Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
-        Gemini.speech_to_text(fields["speech"], contact.organization_id)
+
+        try do
+          result = Gemini.speech_to_text(fields["speech"], contact.organization_id)
+          maybe_report_webhook_failure(result, "speech_to_text_with_bhasini", contact.organization_id)
+          result
+        rescue
+          exception ->
+            report_webhook_failure("speech_to_text_with_bhasini", contact.organization_id, nil)
+            reraise exception, __STACKTRACE__
+        end
 
       {:error, error} ->
         error
@@ -212,20 +222,30 @@ defmodule Glific.Clients.CommonWebhook do
     source_language = contact.language.label |> String.downcase()
     speech_engine = Map.get(fields, "speech_engine", "")
 
-    cond do
-      speech_engine == "open_ai" ->
-        ChatGPT.text_to_speech_with_open_ai(org_id, text)
+    try do
+      result =
+        cond do
+          speech_engine == "open_ai" ->
+            ChatGPT.text_to_speech_with_open_ai(org_id, text)
 
-      speech_engine == "bhashini" ->
-        Glific.Metrics.increment("Gemini TTS Call", org_id)
-        Gemini.text_to_speech(org_id, text)
+          speech_engine == "bhashini" ->
+            Glific.Metrics.increment("Gemini TTS Call", org_id)
+            Gemini.text_to_speech(org_id, text)
 
-      source_language == "english" ->
-        ChatGPT.text_to_speech_with_open_ai(org_id, text)
+          source_language == "english" ->
+            ChatGPT.text_to_speech_with_open_ai(org_id, text)
 
-      true ->
-        Glific.Metrics.increment("Gemini TTS Call", org_id)
-        Gemini.text_to_speech(org_id, text)
+          true ->
+            Glific.Metrics.increment("Gemini TTS Call", org_id)
+            Gemini.text_to_speech(org_id, text)
+        end
+
+      maybe_report_webhook_failure(result, "text_to_speech_with_bhasini", org_id)
+      result
+    rescue
+      exception ->
+        report_webhook_failure("text_to_speech_with_bhasini", org_id, nil)
+        reraise exception, __STACKTRACE__
     end
   end
 
@@ -851,5 +871,31 @@ defmodule Glific.Clients.CommonWebhook do
       {:error, reason} ->
         %{success: false, reason: reason}
     end
+  end
+
+  # Inspects a webhook result map and emits a SystemError when the call
+  # reported failure but did not raise. Pulled out as a helper so the two
+  # entry points (STT, TTS) call the same reporting code.
+  @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer()) :: :ok
+  defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
+    status =
+      case result do
+        %{asr_response_text: s} when is_integer(s) -> s
+        _ -> nil
+      end
+
+    report_webhook_failure(webhook_name, org_id, status)
+  end
+
+  defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok
+
+  @spec report_webhook_failure(String.t(), non_neg_integer() | nil, integer() | nil) :: :ok
+  defp report_webhook_failure(webhook_name, org_id, http_status) do
+    Glific.log_exception(%SystemError{
+      message: "Webhook system_error from #{webhook_name}",
+      webhook_name: webhook_name,
+      organization_id: org_id,
+      http_status: http_status
+    })
   end
 end

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -862,10 +862,6 @@ defmodule Glific.Clients.CommonWebhook do
   end
 
   # Wraps a webhook entry point body so any failure — predictable
-  # (%{success: false} return) or unexpected (raised exception) — is
-  # reported to AppSignal before propagating. The function passed in runs
-  # exactly the work the entry point would have done inline; the helper
-  # is observability only and does not change behaviour for the caller.
   @spec with_failure_reporting(String.t(), non_neg_integer() | nil, (-> any())) :: any()
   defp with_failure_reporting(webhook_name, org_id, fun) do
     result = fun.()
@@ -877,8 +873,6 @@ defmodule Glific.Clients.CommonWebhook do
       reraise exception, __STACKTRACE__
   end
 
-  # Inspects a webhook result map and emits a SystemError when the call
-  # reported failure but did not raise.
   @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer()) :: :ok
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)
@@ -887,10 +881,6 @@ defmodule Glific.Clients.CommonWebhook do
 
   defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok
 
-  # Picks an HTTP status (when present) and a human-readable reason out of the
-  # webhook result map. STT failures stuff either an integer status code or an
-  # error string into `asr_response_text`. TTS surfaces the status as
-  # `:http_status`. Other shapes carry a `:reason` field.
   @spec extract_status_and_reason(map()) :: {integer() | nil, String.t() | nil}
   defp extract_status_and_reason(result) do
     case result do

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -891,11 +891,26 @@ defmodule Glific.Clients.CommonWebhook do
 
   @spec report_webhook_failure(String.t(), non_neg_integer() | nil, integer() | nil) :: :ok
   defp report_webhook_failure(webhook_name, org_id, http_status) do
-    Glific.log_exception(%SystemError{
+    exception = %SystemError{
       message: "Webhook system_error from #{webhook_name}",
       webhook_name: webhook_name,
       organization_id: org_id,
       http_status: http_status
-    })
+    }
+
+    Logger.error(Exception.message(exception))
+
+    # Use the 3-arg send_error with a span configurator so the per-occurrence
+    # detail lands on the AppSignal sample as filterable tags (the 2-arg form
+    # records only class + message and drops struct fields).
+    Appsignal.send_error(exception, [], fn span ->
+      Appsignal.Span.set_sample_data(span, "tags", %{
+        organization_id: org_id,
+        webhook_name: webhook_name,
+        http_status: http_status
+      })
+    end)
+
+    :ok
   end
 end

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -47,15 +47,7 @@ defmodule Glific.Flows.Webhook do
     into one incident; per-occurrence detail (org, status) goes in struct
     fields and is recorded as tags.
     """
-    defexception [
-      :message,
-      :organization_id,
-      :flow_id,
-      :webhook_name,
-      :url,
-      :http_status,
-      :webhook_log_id
-    ]
+    defexception [:message, :organization_id, :webhook_name, :http_status]
   end
 
   @non_unique_urls [

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -39,30 +39,13 @@ defmodule Glific.Flows.Webhook do
     defexception [:message, :reason, :organization_id]
   end
 
-  defmodule ConfigError do
-    @moduledoc """
-    Webhook failure attributable to org configuration: 4xx HTTP responses,
-    malformed URL, missing credentials. Keep the `:message` field
-    low-cardinality so AppSignal groups identical failures into one incident;
-    per-occurrence detail (org, flow, status) goes in the struct fields.
-    """
-    defexception [
-      :message,
-      :organization_id,
-      :flow_id,
-      :webhook_name,
-      :url,
-      :http_status,
-      :webhook_log_id
-    ]
-  end
-
   defmodule SystemError do
     @moduledoc """
-    Webhook failure attributable to downstream/system issues: 5xx HTTP
-    responses, transport errors (DNS, connection refused, timeout),
-    unexpected response shapes. Keep the `:message` field low-cardinality
-    so AppSignal groups identical failures into one incident.
+    Webhook failure: 4xx/5xx HTTP responses, transport errors (DNS,
+    connection refused, timeout), unexpected response shapes. Keep the
+    `:message` field low-cardinality so AppSignal groups identical failures
+    into one incident; per-occurrence detail (org, status) goes in struct
+    fields and is recorded as tags.
     """
     defexception [
       :message,

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -44,10 +44,11 @@ defmodule Glific.Flows.Webhook do
     Webhook failure: 4xx/5xx HTTP responses, transport errors (DNS,
     connection refused, timeout), unexpected response shapes. Keep the
     `:message` field low-cardinality so AppSignal groups identical failures
-    into one incident; per-occurrence detail (org, status) goes in struct
-    fields and is recorded as tags.
+    into one incident; per-occurrence detail (org, status, reason) is
+    attached as AppSignal tags via `Span.set_sample_data` at the report
+    site, not on the struct.
     """
-    defexception [:message, :organization_id, :webhook_name, :http_status]
+    defexception [:message]
   end
 
   @non_unique_urls [

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -39,6 +39,42 @@ defmodule Glific.Flows.Webhook do
     defexception [:message, :reason, :organization_id]
   end
 
+  defmodule ConfigError do
+    @moduledoc """
+    Webhook failure attributable to org configuration: 4xx HTTP responses,
+    malformed URL, missing credentials. Keep the `:message` field
+    low-cardinality so AppSignal groups identical failures into one incident;
+    per-occurrence detail (org, flow, status) goes in the struct fields.
+    """
+    defexception [
+      :message,
+      :organization_id,
+      :flow_id,
+      :webhook_name,
+      :url,
+      :http_status,
+      :webhook_log_id
+    ]
+  end
+
+  defmodule SystemError do
+    @moduledoc """
+    Webhook failure attributable to downstream/system issues: 5xx HTTP
+    responses, transport errors (DNS, connection refused, timeout),
+    unexpected response shapes. Keep the `:message` field low-cardinality
+    so AppSignal groups identical failures into one incident.
+    """
+    defexception [
+      :message,
+      :organization_id,
+      :flow_id,
+      :webhook_name,
+      :url,
+      :http_status,
+      :webhook_log_id
+    ]
+  end
+
   @non_unique_urls [
     "parse_via_gpt_vision",
     "parse_via_chat_gpt",

--- a/lib/glific/third_party/gemini.ex
+++ b/lib/glific/third_party/gemini.ex
@@ -161,6 +161,16 @@ defmodule Glific.ThirdParty.Gemini do
       |> Map.put(:media_url, media_meta.url)
       |> Map.put(:translated_text, text)
     else
+      {:error, status} when is_integer(status) ->
+        Metrics.increment("Gemini TTS Failure", organization_id)
+
+        %{
+          success: false,
+          media_url: nil,
+          translated_text: text,
+          http_status: status
+        }
+
       {:error, _} ->
         Metrics.increment("Gemini TTS Failure", organization_id)
         %{success: false, media_url: nil, translated_text: text}

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -43,7 +43,7 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
   Convert text to speech using Gemini API.
   """
   @spec text_to_speech(String.t(), non_neg_integer()) ::
-          {:ok, binary()} | {:error, integer() | nil}
+          {:ok, binary()} | {:error, integer() | atom() | nil}
   def text_to_speech(text, organization_id) do
     body = tts_request_body(text)
     path = "/#{gemini_config(:tts_model)}:generateContent"
@@ -67,8 +67,8 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
       {:error, %Tesla.Env{status: status}} ->
         {:error, status}
 
-      {:error, _reason} ->
-        {:error, nil}
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -3,15 +3,8 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
   Client for interacting with Gemini via APIs.
   """
   require Logger
+  alias Glific.Flows.Webhook.SystemError
   alias Glific.Metrics
-
-  defmodule Error do
-    @moduledoc """
-    Custom error module for Gemini API failures.
-    Reporting these failures to AppSignal lets us detect and fix issues.
-    """
-    defexception [:message, :status_code]
-  end
 
   @gemini_url "https://generativelanguage.googleapis.com/v1beta/models"
 
@@ -36,20 +29,16 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
 
         %{success: true, asr_response_text: text}
 
-      {:ok, %Tesla.Env{status: status_code, body: body}} ->
-        Glific.log_exception(%Error{
-          message: "Gemini STT Failure: #{inspect(body)}",
-          status_code: status_code
-        })
-
+      {:ok, %Tesla.Env{status: status_code}} ->
+        report_gemini_failure("gemini_stt", status_code, organization_id)
         %{success: false, asr_response_text: status_code}
 
       {:error, %Tesla.Env{body: error_reason}} ->
-        Glific.log_exception(%Error{message: "Gemini STT Failure: #{inspect(error_reason)}"})
+        report_gemini_failure("gemini_stt", nil, organization_id)
         %{success: false, asr_response_text: error_reason}
 
       {:error, reason} ->
-        Glific.log_exception(%Error{message: "Gemini STT Failure: #{inspect(reason)}"})
+        report_gemini_failure("gemini_stt", nil, organization_id)
         %{success: false, asr_response_text: reason}
     end
   end
@@ -75,25 +64,36 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         tts_gemini_usage_stats(metadata, organization_id)
         {:ok, decoded_audio}
 
-      {:ok, %Tesla.Env{status: status, body: body}} ->
-        Glific.log_exception(%Error{
-          message: "Gemini TTS Failure: #{inspect(body)}",
-          status_code: status
-        })
-
+      {:ok, %Tesla.Env{status: status}} ->
+        report_gemini_failure("gemini_tts", status, organization_id)
         {:error, nil}
 
-      {:error, %Tesla.Env{body: error_reason}} ->
-        Glific.log_exception(%Error{message: "Gemini TTS Failure: #{inspect(error_reason)}"})
+      {:error, %Tesla.Env{}} ->
+        report_gemini_failure("gemini_tts", nil, organization_id)
         {:error, nil}
 
-      {:error, reason} ->
-        Glific.log_exception(%Error{message: "Gemini TTS Failure: #{inspect(reason)}"})
+      {:error, _reason} ->
+        report_gemini_failure("gemini_tts", nil, organization_id)
         {:error, nil}
     end
   end
 
   # Private
+
+  # Reports a Gemini API failure to AppSignal via a structured exception.
+  # The `:message` field is kept low-cardinality so AppSignal groups identical
+  # failures into one incident; per-occurrence detail (org, status) goes in
+  # struct fields and is recorded as tags.
+  @spec report_gemini_failure(String.t(), integer() | nil, non_neg_integer()) :: :ok
+  defp report_gemini_failure(webhook_name, status, organization_id) do
+    Glific.log_exception(%SystemError{
+      message: "Webhook system_error from #{webhook_name}",
+      webhook_name: webhook_name,
+      organization_id: organization_id,
+      http_status: status
+    })
+  end
+
   @spec gemini_config() :: map()
   defp gemini_config, do: Application.fetch_env!(:glific, __MODULE__)
 

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -60,11 +60,11 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         tts_gemini_usage_stats(metadata, organization_id)
         {:ok, decoded_audio}
 
-      {:ok, %Tesla.Env{}} ->
-        {:error, nil}
+      {:ok, %Tesla.Env{status: status}} ->
+        {:error, status}
 
-      {:error, %Tesla.Env{}} ->
-        {:error, nil}
+      {:error, %Tesla.Env{status: status}} ->
+        {:error, status}
 
       {:error, _reason} ->
         {:error, nil}

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -33,8 +33,8 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         report_gemini_failure("gemini_stt", status_code, organization_id)
         %{success: false, asr_response_text: status_code}
 
-      {:error, %Tesla.Env{body: error_reason}} ->
-        report_gemini_failure("gemini_stt", nil, organization_id)
+      {:error, %Tesla.Env{status: status, body: error_reason}} ->
+        report_gemini_failure("gemini_stt", status, organization_id)
         %{success: false, asr_response_text: error_reason}
 
       {:error, reason} ->
@@ -68,8 +68,8 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         report_gemini_failure("gemini_tts", status, organization_id)
         {:error, nil}
 
-      {:error, %Tesla.Env{}} ->
-        report_gemini_failure("gemini_tts", nil, organization_id)
+      {:error, %Tesla.Env{status: status}} ->
+        report_gemini_failure("gemini_tts", status, organization_id)
         {:error, nil}
 
       {:error, _reason} ->

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -3,7 +3,6 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
   Client for interacting with Gemini via APIs.
   """
   require Logger
-  alias Glific.Flows.Webhook.SystemError
   alias Glific.Metrics
 
   @gemini_url "https://generativelanguage.googleapis.com/v1beta/models"
@@ -30,15 +29,12 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         %{success: true, asr_response_text: text}
 
       {:ok, %Tesla.Env{status: status_code}} ->
-        report_gemini_failure("gemini_stt", status_code, organization_id)
         %{success: false, asr_response_text: status_code}
 
-      {:error, %Tesla.Env{status: status, body: error_reason}} ->
-        report_gemini_failure("gemini_stt", status, organization_id)
+      {:error, %Tesla.Env{body: error_reason}} ->
         %{success: false, asr_response_text: error_reason}
 
       {:error, reason} ->
-        report_gemini_failure("gemini_stt", nil, organization_id)
         %{success: false, asr_response_text: reason}
     end
   end
@@ -64,36 +60,18 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
         tts_gemini_usage_stats(metadata, organization_id)
         {:ok, decoded_audio}
 
-      {:ok, %Tesla.Env{status: status}} ->
-        report_gemini_failure("gemini_tts", status, organization_id)
+      {:ok, %Tesla.Env{}} ->
         {:error, nil}
 
-      {:error, %Tesla.Env{status: status}} ->
-        report_gemini_failure("gemini_tts", status, organization_id)
+      {:error, %Tesla.Env{}} ->
         {:error, nil}
 
       {:error, _reason} ->
-        report_gemini_failure("gemini_tts", nil, organization_id)
         {:error, nil}
     end
   end
 
   # Private
-
-  # Reports a Gemini API failure to AppSignal via a structured exception.
-  # The `:message` field is kept low-cardinality so AppSignal groups identical
-  # failures into one incident; per-occurrence detail (org, status) goes in
-  # struct fields and is recorded as tags.
-  @spec report_gemini_failure(String.t(), integer() | nil, non_neg_integer()) :: :ok
-  defp report_gemini_failure(webhook_name, status, organization_id) do
-    Glific.log_exception(%SystemError{
-      message: "Webhook system_error from #{webhook_name}",
-      webhook_name: webhook_name,
-      organization_id: organization_id,
-      http_status: status
-    })
-  end
-
   @spec gemini_config() :: map()
   defp gemini_config, do: Application.fetch_env!(:glific, __MODULE__)
 

--- a/lib/glific/third_party/gemini/api_client.ex
+++ b/lib/glific/third_party/gemini/api_client.ex
@@ -42,7 +42,8 @@ defmodule Glific.ThirdParty.Gemini.ApiClient do
   @doc """
   Convert text to speech using Gemini API.
   """
-  @spec text_to_speech(String.t(), non_neg_integer()) :: {:ok, binary()} | {:error, nil}
+  @spec text_to_speech(String.t(), non_neg_integer()) ::
+          {:ok, binary()} | {:error, integer() | nil}
   def text_to_speech(text, organization_id) do
     body = tts_request_body(text)
     path = "/#{gemini_config(:tts_model)}:generateContent"

--- a/test/glific/appsignal_test.exs
+++ b/test/glific/appsignal_test.exs
@@ -66,9 +66,9 @@ defmodule Glific.AppsignalTest do
       }
 
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         assert query_event({:error, error}) == :ok
 
         assert called(
@@ -84,9 +84,9 @@ defmodule Glific.AppsignalTest do
       error = %DBConnection.ConnectionError{reason: "custom_error", message: "custom error"}
 
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         assert query_event({:error, error}) == :ok
 
         assert called(
@@ -102,9 +102,9 @@ defmodule Glific.AppsignalTest do
       error = %DBConnection.ConnectionError{reason: nil, message: "queue timeout after 2999ms"}
 
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         assert query_event({:error, error}) == :ok
 
         assert called(
@@ -118,29 +118,35 @@ defmodule Glific.AppsignalTest do
 
     test "does not track non-connection errors" do
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         assert query_event({:error, %Postgrex.Error{message: "syntax error"}}) == :ok
-        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+
+        refute called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_)
+               )
       end
     end
 
     test "does not track successful results" do
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         assert query_event({:ok, %{rows: []}}) == :ok
-        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+
+        refute called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_)
+               )
       end
     end
 
     test "handles missing result key gracefully" do
       with_mock Elixir.Appsignal,
-        [:passthrough],
-        add_distribution_value: fn _, _, _ -> :ok end,
-        increment_counter: fn _, _, _ -> :ok end do
+                [:passthrough],
+                add_distribution_value: fn _, _, _ -> :ok end,
+                increment_counter: fn _, _, _ -> :ok end do
         result =
           Appsignal.handle_event(
             [:glific, :repo, :query],
@@ -150,9 +156,11 @@ defmodule Glific.AppsignalTest do
           )
 
         assert result == :ok
-        refute called(Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_))
+
+        refute called(
+                 Elixir.Appsignal.increment_counter("glific.repo.db_connection_error", 1, :_)
+               )
       end
     end
   end
-
 end

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1192,22 +1192,6 @@ defmodule Glific.Flows.CommonWebhookTest do
       assert is_nil(tags.reason)
     end
 
-    test "emits SystemError with http_status tag on Gemini 5xx response", %{fields: fields} do
-      Tesla.Mock.mock(fn
-        %{method: :get} -> %Tesla.Env{status: 200, body: "fake_audio_bytes"}
-        %{method: :post} -> %Tesla.Env{status: 503, body: %{}}
-      end)
-
-      {exception, tags} =
-        capture_appsignal(fn ->
-          CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
-        end)
-
-      assert %SystemError{} = exception
-      assert tags.http_status == 503
-      assert tags.webhook_name == "speech_to_text_with_bhasini"
-    end
-
     test "emits SystemError with reason tag when audio download fails", %{fields: fields} do
       Tesla.Mock.mock(fn
         %{method: :get} -> %Tesla.Env{status: 404, body: ""}
@@ -1316,18 +1300,21 @@ defmodule Glific.Flows.CommonWebhookTest do
       assert tags.http_status == 401
     end
 
-    test "emits SystemError with http_status tag on Gemini 5xx response", %{fields: fields} do
-      Tesla.Mock.mock(fn
-        %{method: :post} -> %Tesla.Env{status: 503, body: %{}}
+    test "emits SystemError on OpenAI TTS failure (speech_engine = open_ai)", %{fields: fields} do
+      fields = Map.put(fields, "speech_engine", "open_ai")
+
+      Tesla.Mock.mock(fn %{method: :post} ->
+        %Tesla.Env{status: 401, body: %{}}
       end)
 
-      {_exception, tags} =
+      {exception, tags} =
         capture_appsignal(fn ->
           CommonWebhook.webhook("text_to_speech_with_bhasini", fields)
         end)
 
-      assert tags.http_status == 503
+      assert %SystemError{} = exception
       assert tags.webhook_name == "text_to_speech_with_bhasini"
+      assert tags.organization_id == 1
     end
   end
 

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -8,6 +8,7 @@ defmodule Glific.Flows.CommonWebhookTest do
     Certificates.CertificateTemplate,
     Clients.CommonWebhook,
     Fixtures,
+    Flows.Webhook.SystemError,
     Messages,
     Partners,
     Partners.Provider,
@@ -1160,6 +1161,234 @@ defmodule Glific.Flows.CommonWebhookTest do
       result = CommonWebhook.webhook("text_to_speech", fields, [])
       assert result.success == true
     end
+  end
+
+  describe "speech_to_text_with_bhasini failure reporting" do
+    setup do
+      contact = Fixtures.contact_fixture()
+      %{contact: contact, fields: bhasini_stt_fields(contact.id)}
+    end
+
+    test "emits SystemError with http_status tag on Gemini 4xx response", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :get} -> %Tesla.Env{status: 200, body: "fake_audio_bytes"}
+        %{method: :post} -> %Tesla.Env{status: 401, body: %{}}
+      end)
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result = CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
+          assert result.success == false
+        end)
+
+      assert %SystemError{} = exception
+
+      assert Exception.message(exception) ==
+               "Webhook system_error from speech_to_text_with_bhasini"
+
+      assert tags.webhook_name == "speech_to_text_with_bhasini"
+      assert tags.organization_id == 1
+      assert tags.http_status == 401
+      assert is_nil(tags.reason)
+    end
+
+    test "emits SystemError with http_status tag on Gemini 5xx response", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :get} -> %Tesla.Env{status: 200, body: "fake_audio_bytes"}
+        %{method: :post} -> %Tesla.Env{status: 503, body: %{}}
+      end)
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.http_status == 503
+      assert tags.webhook_name == "speech_to_text_with_bhasini"
+    end
+
+    test "emits SystemError with reason tag when audio download fails", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :get} -> %Tesla.Env{status: 404, body: ""}
+      end)
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result = CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
+          assert result.success == false
+          assert result.asr_response_text == "File download failed"
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.reason == "File download failed"
+      assert is_nil(tags.http_status)
+    end
+
+    test "does not call AppSignal on successful Gemini response", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{status: 200, body: "fake_audio_bytes"}
+
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              candidates: [%{content: %{parts: [%{text: ~s("transcribed text")}]}}],
+              usageMetadata: %{totalTokenCount: 10}
+            }
+          }
+      end)
+
+      test_pid = self()
+
+      with_mocks([
+        {Appsignal, [:passthrough],
+         [
+           send_error: fn _ex, _stack, _fn ->
+             send(test_pid, :appsignal_called)
+             :ok
+           end
+         ]}
+      ]) do
+        result = CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
+        assert result.success == true
+      end
+
+      refute_received :appsignal_called
+    end
+
+    test "rescue path reports SystemError and reraises on unexpected exception", %{
+      fields: fields
+    } do
+      # Gemini returns 200 with a `text` field that isn't valid JSON.
+      # ApiClient's success branch does Jason.decode!(text), which raises.
+      # The try/rescue in CommonWebhook must catch, report, and reraise.
+      Tesla.Mock.mock(fn
+        %{method: :get} ->
+          %Tesla.Env{status: 200, body: "fake_audio_bytes"}
+
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              candidates: [%{content: %{parts: [%{text: "not valid json {{{"}]}}],
+              usageMetadata: %{totalTokenCount: 1}
+            }
+          }
+      end)
+
+      {exception, _tags} =
+        capture_appsignal(fn ->
+          assert_raise Jason.DecodeError, fn ->
+            CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
+          end
+        end)
+
+      assert %SystemError{} = exception
+    end
+  end
+
+  describe "text_to_speech_with_bhasini failure reporting" do
+    setup do
+      contact = Fixtures.contact_fixture()
+      %{contact: contact, fields: bhasini_tts_fields(contact.id)}
+    end
+
+    test "emits SystemError with http_status tag on Gemini 4xx response", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :post} -> %Tesla.Env{status: 401, body: %{}}
+      end)
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result = CommonWebhook.webhook("text_to_speech_with_bhasini", fields)
+          assert result.success == false
+        end)
+
+      assert %SystemError{} = exception
+
+      assert Exception.message(exception) ==
+               "Webhook system_error from text_to_speech_with_bhasini"
+
+      assert tags.webhook_name == "text_to_speech_with_bhasini"
+      assert tags.organization_id == 1
+      assert tags.http_status == 401
+    end
+
+    test "emits SystemError with http_status tag on Gemini 5xx response", %{fields: fields} do
+      Tesla.Mock.mock(fn
+        %{method: :post} -> %Tesla.Env{status: 503, body: %{}}
+      end)
+
+      {_exception, tags} =
+        capture_appsignal(fn ->
+          CommonWebhook.webhook("text_to_speech_with_bhasini", fields)
+        end)
+
+      assert tags.http_status == 503
+      assert tags.webhook_name == "text_to_speech_with_bhasini"
+    end
+  end
+
+  # Runs `fun` with Appsignal.send_error and Appsignal.Span.set_sample_data
+  # mocked. Returns {exception, tags} captured from the production code's
+  # reporting call.
+  defp capture_appsignal(fun) do
+    test_pid = self()
+
+    with_mocks([
+      {Appsignal, [:passthrough],
+       [
+         send_error: fn ex, _stack, configurator ->
+           send(test_pid, {:appsignal_exception, ex})
+           configurator.(:fake_span)
+           :ok
+         end
+       ]},
+      {Appsignal.Span, [:passthrough],
+       [
+         set_sample_data: fn _span, key, value ->
+           send(test_pid, {:appsignal_tag, key, value})
+           :fake_span
+         end
+       ]}
+    ]) do
+      fun.()
+    end
+
+    exception =
+      receive do
+        {:appsignal_exception, ex} -> ex
+      after
+        100 -> flunk("Appsignal.send_error was not called")
+      end
+
+    tags =
+      receive do
+        {:appsignal_tag, "tags", t} -> t
+      after
+        100 -> %{}
+      end
+
+    {exception, tags}
+  end
+
+  defp bhasini_stt_fields(contact_id) do
+    %{
+      "speech" => "https://filemanager.gupshup.io/wa/audio.ogg",
+      "organization_id" => 1,
+      "contact" => %{"id" => to_string(contact_id)}
+    }
+  end
+
+  defp bhasini_tts_fields(contact_id) do
+    %{
+      "text" => "Hello world",
+      "organization_id" => "1",
+      "contact" => %{"id" => to_string(contact_id)},
+      "speech_engine" => "bhashini"
+    }
   end
 
   defp stt_fields(contact_id) do

--- a/test/glific/third_party/gemini/api_client_test.exs
+++ b/test/glific/third_party/gemini/api_client_test.exs
@@ -169,7 +169,7 @@ defmodule Glific.ThirdParty.Gemini.ApiClientTest do
         {:error, :timeout}
       end)
 
-      assert {:error, nil} == ApiClient.text_to_speech("Hello World", organization_id)
+      assert {:error, :timeout} == ApiClient.text_to_speech("Hello World", organization_id)
     end
   end
 end

--- a/test/glific/third_party/gemini/api_client_test.exs
+++ b/test/glific/third_party/gemini/api_client_test.exs
@@ -153,7 +153,7 @@ defmodule Glific.ThirdParty.Gemini.ApiClientTest do
         }
       end)
 
-      assert {:error, nil} == ApiClient.text_to_speech("Hello World", organization_id)
+      assert {:error, 400} == ApiClient.text_to_speech("Hello World", organization_id)
     end
 
     test "handles Tesla error with body", %{organization_id: organization_id} do


### PR DESCRIPTION

## Summary
 Target issue is #5064

**Description**
- Adds structured AppSignal alerting for both predictable failures `(%{success: false} returns)` and unexpected exceptions (Jason errors, missing ffmpeg, etc.) via a shared `Glific.Flows.Webhook.SystemError`, a flow_webhooks namespace, and per-occurrence tags (org, webhook name, http status, reason).
- Reporting lives at the CommonWebhook layer behind a shared `with_failure_reporting/3` helper; `Gemini.ApiClient` stays observability-agnostic. 
- Caller behaviour is unchanged,exceptions still propagate, this just adds visibility along the way.

  **Test plan**

  - mix test for new bhasini failure-reporting tests + updated api_client tests
  - mix credo and mix dialyzer clean
  - Manual smoke test: bad Gemini key → flow_webhooks alert with tags
  - Manual rescue test: Tesla.Mock returning malformed JSON → exception reraised, AppSignal alert fires
  
  
  
<img width="1145" height="492" alt="Screenshot 2026-05-15 at 6 24 35 PM" src="https://github.com/user-attachments/assets/7de044e9-6560-448c-827b-c5cd3dd2db49" />

  
