### PR TITLE
fix: add retry middleware, recv_timeout and telemetry to Google Sheets Tesla client

### DIFF
--- a/lib/glific/third_party/sheets/google_sheets.ex
+++ b/lib/glific/third_party/sheets/google_sheets.ex
@@ -88,7 +88,7 @@ defmodule Glific.Sheets.GoogleSheets do
 
         if is_nil(token),
           do: {:error, "Error fetching token with Service Account JSON"},
-          else: {:ok, %{conn: Connection.new(token.token)}}
+          else: {:ok, %{conn: build_conn(token.token)}}
 
       {:error, _error} ->
         {:error, "Invalid Service Account JSON"}
@@ -149,6 +149,17 @@ defmodule Glific.Sheets.GoogleSheets do
       _ ->
         {:error, "Failed to fetch spreadsheet metadata"}
     end
+  end
+
+  @spec build_conn(String.t()) :: Tesla.Client.t()
+  defp build_conn(token) do
+    extra = [
+      {Tesla.Middleware.Opts, [recv_timeout: 10_000]},
+      {Tesla.Middleware.Telemetry, metadata: %{provider: "google_sheets_api"}}
+      | Glific.get_tesla_retry_middleware()
+    ]
+
+    Tesla.client(extra ++ Tesla.Client.middleware(Connection.new(token)))
   end
 
   @doc """

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -1028,6 +1028,161 @@ defmodule Glific.SheetsTest do
     end
   end
 
+  describe "build_conn middleware injection" do
+    test "fetch_credentials returns a conn with recv_timeout and retry middleware", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        assert {:ok, %{conn: conn}} = GoogleSheets.fetch_credentials(organization_id)
+
+        middleware = Tesla.Client.middleware(conn)
+
+        middleware_modules =
+          Enum.map(middleware, fn
+            {mod, _opts} -> mod
+            mod -> mod
+          end)
+
+        assert Tesla.Middleware.Opts in middleware_modules
+        assert Tesla.Middleware.Retry in middleware_modules
+        assert Tesla.Middleware.Telemetry in middleware_modules
+
+        {Tesla.Middleware.Opts, opts} =
+          Enum.find(middleware, fn
+            {Tesla.Middleware.Opts, _} -> true
+            _ -> false
+          end)
+
+        assert opts[:recv_timeout] == 10_000
+
+        {Tesla.Middleware.Telemetry, telemetry_opts} =
+          Enum.find(middleware, fn
+            {Tesla.Middleware.Telemetry, _} -> true
+            _ -> false
+          end)
+
+        assert telemetry_opts[:metadata][:provider] == "google_sheets_api"
+      end
+    end
+  end
+
+  describe "GoogleSheets retry behavior" do
+    test "get_headers/2 retries on 429 and eventually succeeds", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+        Tesla.Mock.mock(fn %{method: :get} ->
+          count = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+
+          if count == 0 do
+            %Tesla.Env{status: 429, body: "Rate limit exceeded"}
+          else
+            %Tesla.Env{
+              status: 200,
+              body:
+                Jason.encode!(%{
+                  range: "Sheet1!A1:ZZ1",
+                  majorDimension: "ROWS",
+                  values: [["name", "age", "city"]]
+                })
+            }
+          end
+        end)
+
+        assert {:ok, ["name", "age", "city"]} =
+                 GoogleSheets.get_headers(organization_id, @spreadsheet_id)
+
+        assert Agent.get(call_count, & &1) == 2
+      end
+    end
+
+    test "insert_row/3 retries on :timeout and eventually succeeds", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+        Tesla.Mock.mock(fn %{method: :post} ->
+          count = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+
+          if count == 0 do
+            {:error, :timeout}
+          else
+            %Tesla.Env{
+              status: 200,
+              body:
+                Jason.encode!(%{
+                  spreadsheetId: @spreadsheet_id,
+                  updates: %{updatedRows: 1}
+                })
+            }
+          end
+        end)
+
+        params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
+        assert {:ok, _} = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+
+        assert Agent.get(call_count, & &1) == 2
+      end
+    end
+
+    test "read_sheet_data/2 retries on 500 and eventually succeeds", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        {:ok, call_count} = Agent.start_link(fn -> 0 end)
+
+        Tesla.Mock.mock(fn %{method: :get, url: url} ->
+          count = Agent.get_and_update(call_count, fn n -> {n, n + 1} end)
+
+          cond do
+            count == 0 ->
+              %Tesla.Env{status: 500, body: "Internal Server Error"}
+
+            url == @sheets_base_url ->
+              %Tesla.Env{status: 200, body: spreadsheet_metadata_response()}
+
+            String.starts_with?(url, @sheets_base_url <> "/values/") ->
+              %Tesla.Env{
+                status: 200,
+                body: values_response([["name", "age"], ["Alice", "30"]])
+              }
+          end
+        end)
+
+        assert {:ok, rows} = GoogleSheets.read_sheet_data(organization_id, @sheet_url)
+        assert length(rows) == 1
+        assert {:ok, %{"name" => "Alice", "age" => "30"}} = Enum.at(rows, 0)
+      end
+    end
+  end
+
   describe "GoogleSheets.get_headers/2" do
     test "returns headers from first row via Google Sheets API", %{
       organization_id: organization_id


### PR DESCRIPTION
## Summary

Closes #5036

Production logs showed recurring failures across multiple orgs:
- `Google Sheets API read failed: :timeout` — default 5 s recv_timeout too short for large/slow sheets
- `429 - Quota exceeded for quota metric 'Read requests per minute per user'` — no retry on quota exceeded
- `Failed to write WhatsApp form response to Google Sheet: :timeout`

The root cause: `Connection.new(token)` from `google_api_sheets` creates a plain Tesla client with only the auth header — no timeout config and no retry logic.

## Changes

**`lib/glific/third_party/sheets/google_sheets.ex`**

Replaced `Connection.new(token.token)` in `decode_credential/2` with a new private `build_conn/1` function that composes a Tesla client by prepending three middleware layers before the auth header (using the public `Tesla.Client.middleware/1` API, since `google_api_sheets` 0.34.0 only exposes `Connection.new/1`):

| Middleware | Purpose |
|---|---|
| `Tesla.Middleware.Opts` | Raises `recv_timeout` from 5 s → 10 s |
| `Tesla.Middleware.Telemetry` | Emits `[:tesla, :request, :stop]` events tagged `provider: "google_sheets_api"` so AppSignal tracks error rates for authenticated API calls separately from the CSV fallback client |
| `Glific.get_tesla_retry_middleware()` | 2 retries with 500 ms delay on 429, 5xx, `:timeout`, and `:connrefused` |

All three call sites (`get_headers`, `insert_row`, `read_sheet_data`) benefit automatically — they all go through `fetch_credentials/1` → `decode_credential/2`.

## How it was tested

Four new tests added in `test/glific/sheets_test.exs`:

**Middleware injection** (`describe "build_conn middleware injection"`):
- Calls `fetch_credentials` with a mocked Goth token and inspects `Tesla.Client.middleware(conn)` to assert `Tesla.Middleware.Opts` (recv_timeout 10 000), `Tesla.Middleware.Retry`, and `Tesla.Middleware.Telemetry` (provider `"google_sheets_api"`) are all present.

**Retry behaviour** (`describe "GoogleSheets retry behavior"`):
- `get_headers/2` retries on 429: an Agent counter returns 429 on the first call and 200 on the second; asserts success and exactly 2 API calls.
- `insert_row/3` retries on `:timeout`: same pattern with `{:error, :timeout}` on first call.
- `read_sheet_data/2` retries on 500: first GET returns 500; subsequent calls route to correct metadata/values responses by URL; asserts correct data is returned.