### PR TITLE
Migrate Gupshup partner authentication from password to client secret

### DIFF
--- a/config/.env.dev.txt
+++ b/config/.env.dev.txt
@@ -39,3 +39,4 @@ USE_REPLICA_DB=true
 GLIFIC_BASE_DOMAIN=glific.com
 # GLIFIC_API_HOST_OVERRIDE=https://your-ngrok-url.ngrok.io
 DIFY_API_KEY=app-this_is_not_the_key
+GUPSHUP_PARTNER_CLIENT_SECRET=this_is_not_secret

--- a/config/.env.test
+++ b/config/.env.test
@@ -23,3 +23,4 @@ BHASINI_USER_ID=this_is_not_the_secret
 BHASINI_ULCA_API_KEY=this_is_not_the_secret
 GOOGLE_MAPS_API_KEY=this_is_not_the_secret
 READ_REPLICA_DATABASE_URL=ecto://postgres:postgres@127.0.0.1:5432/glific_test
+GUPSHUP_PARTNER_CLIENT_SECRET=this_is_not_the_secret

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -165,6 +165,9 @@ config :glific,
 config :glific,
   avni_password: env!("AVNI_PASSWORD", :string!, "This is not a secret")
 
+config :glific,
+  gupshup_partner_client_secret: env!("GUPSHUP_PARTNER_CLIENT_SECRET", :string!, "")
+
 config :glific, Glific.Erase,
   msg_delete_batch_size: env!("MSG_DELETE_BATCH_SIZE", :integer, 100_000),
   max_msg_rows_to_delete: env!("MAX_MSG_ROWS_TO_DELETE", :integer, 2_000_000)

--- a/config/test.exs
+++ b/config/test.exs
@@ -71,3 +71,5 @@ config :glific,
 config :glific, Glific.Communications.Mailer, adapter: Swoosh.Adapters.Test
 
 config :glific, open_ai: "sk-test_api_key"
+
+config :glific, gupshup_partner_client_secret: "test_client_secret"

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -12,6 +12,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   }
 
   use Tesla
+  use Publicist
   require Logger
 
   alias Plug.Conn.Query
@@ -21,7 +22,12 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     @moduledoc """
     Custom Error module for Gupshup partner api failures
     """
-    defexception [:message]
+    defexception [:message, :reason]
+
+    @spec message(%__MODULE__{}) :: String.t()
+    def message(%Error{} = error) do
+      "#{error.message} reason: #{error.reason}"
+    end
   end
 
   plug(Tesla.Middleware.FormUrlencoded,
@@ -288,7 +294,8 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     rescue
       error ->
         Glific.log_exception(%Error{
-          message: "Error occurred while applying gupshup settings due to #{inspect(error)}"
+          message: "Error occurred while applying gupshup settings",
+          reason: error
         })
 
         :ok
@@ -324,23 +331,36 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   defp fetch_partner_token do
     url = @partner_url <> "/login"
     credentials = Saas.isv_credentials()
+    client_secret = Application.get_env(:glific, :gupshup_partner_client_secret)
 
-    request_params = %{"email" => credentials["email"], "password" => credentials["password"]}
+    case client_secret do
+      secret when secret in [nil, ""] ->
+        Glific.log_exception(%Error{
+          message: "Partner token fetch failed",
+          reason: "Gupshup partner client secret is missing"
+        })
 
-    post(url, request_params, headers: [])
-    |> case do
-      {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
-        res = Jason.decode!(body)
+        {:error, "Could not fetch the partner token"}
 
-        {:ok, token} =
-          Caches.set(@global_organization_id, "partner_token", res["token"],
-            ttl: :timer.hours(22)
-          )
+      _ ->
+        request_params = %{"email" => credentials["email"], "password" => client_secret}
 
-        {:ok, %{partner_token: token}}
+        post(url, request_params, headers: [])
+        |> case do
+          {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
+            res = Jason.decode!(body)
 
-      {_status, response} ->
-        {:error, "Could not fetch the partner token #{inspect(response)}"}
+            {:ok, token} =
+              Caches.set(@global_organization_id, "partner_token", res["token"],
+                ttl: :timer.hours(22)
+              )
+
+            {:ok, %{partner_token: token}}
+
+          {_status, response} ->
+            Glific.log_exception(%Error{message: "Partner token fetch failed", reason: response})
+            {:error, "Could not fetch the partner token"}
+        end
     end
   end
 
@@ -578,7 +598,8 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     else
       {:error, error} ->
         Glific.log_exception(%Error{
-          message: "Fetching app details for app #{app_name} failed due to #{error}"
+          message: "Fetching app details for app #{app_name} failed",
+          reason: error
         })
 
         "Fetching app details failed, please double check App name and API key are correct"
@@ -600,7 +621,8 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
 
       {:error, error} ->
         Glific.log_exception(%Error{
-          message: "Fetching app details for app #{app_id} failed due to #{error}"
+          message: "Fetching app details for app #{app_id} failed",
+          reason: error
         })
 
         "Fetching app details failed, please double check App name, App ID and API key are correct"

--- a/test/glific/partners/partners_test.exs
+++ b/test/glific/partners/partners_test.exs
@@ -1770,6 +1770,65 @@ defmodule Glific.PartnersTest do
     end
   end
 
+  describe "fetch_partner_token" do
+    setup do
+      Glific.Caches.remove(0, ["partner_token"])
+      :ok
+    end
+
+    test "successfully fetches and caches the partner token" do
+      Tesla.Mock.mock(fn
+        %{method: :post, url: "https://partner.gupshup.io/partner/account/login"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => "test_partner_token_123"})
+          }
+      end)
+
+      assert {:ok, %{partner_token: "test_partner_token_123"}} = PartnerAPI.fetch_partner_token()
+
+      assert {:ok, "test_partner_token_123"} =
+               Glific.Caches.get(0, "partner_token", refresh_cache: false)
+    end
+
+    test "returns error when client_secret is nil" do
+      original = Application.get_env(:glific, :gupshup_partner_client_secret)
+      on_exit(fn -> Application.put_env(:glific, :gupshup_partner_client_secret, original) end)
+      Application.put_env(:glific, :gupshup_partner_client_secret, nil)
+
+      assert {:error, "Could not fetch the partner token"} = PartnerAPI.fetch_partner_token()
+    end
+
+    test "returns error when client_secret is empty string" do
+      original = Application.get_env(:glific, :gupshup_partner_client_secret)
+      on_exit(fn -> Application.put_env(:glific, :gupshup_partner_client_secret, original) end)
+      Application.put_env(:glific, :gupshup_partner_client_secret, "")
+
+      assert {:error, "Could not fetch the partner token"} = PartnerAPI.fetch_partner_token()
+    end
+
+    test "returns error on non-200 HTTP response" do
+      Tesla.Mock.mock(fn
+        %{method: :post, url: "https://partner.gupshup.io/partner/account/login"} ->
+          %Tesla.Env{
+            status: 401,
+            body: Jason.encode!(%{"message" => "Unauthorized"})
+          }
+      end)
+
+      assert {:error, "Could not fetch the partner token"} = PartnerAPI.fetch_partner_token()
+    end
+
+    test "returns error on HTTP network failure" do
+      Tesla.Mock.mock(fn
+        %{method: :post, url: "https://partner.gupshup.io/partner/account/login"} ->
+          {:error, :econnrefused}
+      end)
+
+      assert {:error, "Could not fetch the partner token"} = PartnerAPI.fetch_partner_token()
+    end
+  end
+
   describe "Partner.set_subscription/4" do
     setup do
       error = %{


### PR DESCRIPTION
## Summary

Gupshup partner API now requires a client secret for authentication instead of a password. This PR migrates the `fetch_partner_token` flow to use `GUPSHUP_PARTNER_CLIENT_SECRET` and improves error handling throughout the partner API module.

**Changes:**
- Replace password-based auth with `GUPSHUP_PARTNER_CLIENT_SECRET` in `fetch_partner_token/0`
- Add `GUPSHUP_PARTNER_CLIENT_SECRET` to dev and test env files with placeholder values
- Add runtime config for `gupshup_partner_client_secret` in `runtime.exs` and `test.exs`
- Add `reason` field to the `Error` exception struct and a custom `message/1` for structured logging
- Sanitize error log messages — separate static message from dynamic reason to avoid interpolated noise
- Add 5 targeted tests covering success, missing/empty secret, HTTP 4xx, and network failure scenarios

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Notes

Operators deploying this change must set `GUPSHUP_PARTNER_CLIENT_SECRET` in their environment. Without it, `fetch_partner_token` will return `{:error, "Could not fetch the partner token"}` and log the misconfiguration via `Glific.log_exception/1`.