### PR TITLE
[Evals]:  AI Evaluations Logging & Metrics

### DIFF
--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -127,12 +127,6 @@ defmodule Glific.AIEvaluations do
   defp handle_evaluation_status({:ok, %{data: %{status: "completed"} = data}}, evaluation, org_id) do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
 
-    Logger.info(
-      "AI Evaluation completed: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, summary_scores_count=#{length(summary_scores)}, " <>
-        "summary_scores=#{safe_inspect(summary_scores)}"
-    )
-
     Metrics.increment("AI Evaluation Completed", org_id)
 
     Notifications.create_notification(%{
@@ -148,12 +142,6 @@ defmodule Glific.AIEvaluations do
 
   defp handle_evaluation_status({:ok, %{data: %{status: "failed"} = data}}, evaluation, org_id) do
     failure_reason = Map.get(data, :error_message, "Evaluation failed")
-
-    Logger.error(
-      "AI Evaluation failed on Kaapi: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, failure_reason=#{failure_reason}"
-    )
-
     Metrics.increment("AI Evaluation Failed", org_id)
 
     Notifications.create_notification(%{
@@ -184,21 +172,11 @@ defmodule Glific.AIEvaluations do
   @spec do_update(AIEvaluation.t(), map()) :: :ok
   defp do_update(evaluation, attrs) do
     case update_ai_evaluation(evaluation, attrs) do
-      {:ok, updated} ->
-        Logger.info(
-          "AI Evaluation status updated: id=#{updated.id}, name=#{updated.name}, " <>
-            "new_status=#{updated.status}"
-        )
-
+      {:ok, _} ->
         :ok
 
       {:error, changeset} ->
-        Glific.log_exception(%Glific.ThirdParty.Kaapi.Error{
-          message:
-            "Failed to update AI Evaluation record: id=#{evaluation.id}, name=#{evaluation.name}",
-          organization_id: evaluation.organization_id,
-          reason: safe_inspect(changeset.errors)
-        })
+        {:error, changeset}
     end
   end
 
@@ -230,28 +208,9 @@ defmodule Glific.AIEvaluations do
   """
   @spec create_golden_qa(map()) :: {:ok, GoldenQA.t()} | {:error, Ecto.Changeset.t()}
   def create_golden_qa(attrs) do
-    result =
-      %GoldenQA{}
-      |> GoldenQA.changeset(attrs)
-      |> Repo.insert()
-
-    case result do
-      {:ok, golden_qa} ->
-        Logger.info(
-          "Golden QA record created: id=#{golden_qa.id}, name=#{golden_qa.name}, " <>
-            "dataset_id=#{golden_qa.dataset_id}, " <>
-            "duplication_factor=#{golden_qa.duplication_factor}, " <>
-            "file_name=#{golden_qa.file_name}, org_id=#{golden_qa.organization_id}"
-        )
-
-      {:error, changeset} ->
-        Logger.error(
-          "Failed to create Golden QA record: org_id=#{attrs[:organization_id]}, " <>
-            "name=#{attrs[:name]}, errors=#{safe_inspect(changeset.errors)}"
-        )
-    end
-
-    result
+    %GoldenQA{}
+    |> GoldenQA.changeset(attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -283,11 +242,6 @@ defmodule Glific.AIEvaluations do
   def request_eval_access(organization_id) do
     case Repo.fetch_by(OrganizationEvalRequest, %{organization_id: organization_id}) do
       {:ok, existing} ->
-        Logger.info(
-          "AI Evaluation access request already exists (idempotent): " <>
-            "org_id=#{organization_id}, status=#{existing.status}"
-        )
-
         {:ok, existing}
 
       {:error, _} ->
@@ -296,21 +250,10 @@ defmodule Glific.AIEvaluations do
           |> OrganizationEvalRequest.changeset(%{organization_id: organization_id})
           |> Repo.insert()
 
-        case result do
-          {:ok, _request} ->
-            Logger.info("New AI Evaluation access request created: org_id=#{organization_id}")
-
-            Metrics.increment("AI Evaluation Access Requested", organization_id)
-
-            organization_id
-            |> Partners.organization()
-            |> EvalAccessRequestMail.send_eval_access_request_mail()
-
-          {:error, changeset} ->
-            Logger.error(
-              "Failed to create AI Evaluation access request: org_id=#{organization_id}, " <>
-                "errors=#{safe_inspect(changeset.errors)}"
-            )
+        with {:ok, _} <- result do
+          organization_id
+          |> Partners.organization()
+          |> EvalAccessRequestMail.send_eval_access_request_mail()
         end
 
         result

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -3,6 +3,7 @@ defmodule Glific.AIEvaluations do
   Context module for AI Evaluations stored in the database.
   """
   import Ecto.Query
+  import Glific.SafeLog
 
   require Logger
 
@@ -49,9 +50,27 @@ defmodule Glific.AIEvaluations do
   """
   @spec create_ai_evaluation(map()) :: {:ok, AIEvaluation.t()} | {:error, Ecto.Changeset.t()}
   def create_ai_evaluation(attrs) do
-    %AIEvaluation{}
-    |> AIEvaluation.changeset(attrs)
-    |> Repo.insert()
+    result =
+      %AIEvaluation{}
+      |> AIEvaluation.changeset(attrs)
+      |> Repo.insert()
+
+    case result do
+      {:ok, evaluation} ->
+        Logger.info(
+          "AI Evaluation record created: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+            "status=#{evaluation.status}, kaapi_evaluation_id=#{evaluation.kaapi_evaluation_id}, " <>
+            "org_id=#{evaluation.organization_id}"
+        )
+
+      {:error, changeset} ->
+        Logger.error(
+          "Failed to create AI Evaluation record: org_id=#{attrs[:organization_id]}, " <>
+            "name=#{attrs[:name]}, errors=#{safe_inspect(changeset.errors)}"
+        )
+    end
+
+    result
   end
 
   @doc """
@@ -114,6 +133,13 @@ defmodule Glific.AIEvaluations do
   @spec handle_evaluation_status(tuple(), AIEvaluation.t(), non_neg_integer()) :: :ok
   defp handle_evaluation_status({:ok, %{data: %{status: "completed"} = data}}, evaluation, org_id) do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
+
+    Logger.info(
+      "AI Evaluation completed: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+        "org_id=#{org_id}, summary_scores_count=#{length(summary_scores)}, " <>
+        "summary_scores=#{safe_inspect(summary_scores)}"
+    )
+
     Metrics.increment("AI Evaluation Completed", org_id)
 
     Notifications.create_notification(%{
@@ -129,6 +155,12 @@ defmodule Glific.AIEvaluations do
 
   defp handle_evaluation_status({:ok, %{data: %{status: "failed"} = data}}, evaluation, org_id) do
     failure_reason = Map.get(data, :error_message, "Evaluation failed")
+
+    Logger.error(
+      "AI Evaluation failed on Kaapi: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+        "org_id=#{org_id}, failure_reason=#{failure_reason}"
+    )
+
     Metrics.increment("AI Evaluation Failed", org_id)
 
     Notifications.create_notification(%{
@@ -145,9 +177,13 @@ defmodule Glific.AIEvaluations do
   defp handle_evaluation_status({:ok, _}, _evaluation, _org_id), do: :ok
 
   defp handle_evaluation_status({:error, reason}, evaluation, org_id) do
-    Logger.error(
-      "Failed to poll AI evaluation #{evaluation.id} for org #{org_id}: #{inspect(reason)}"
-    )
+    Glific.log_exception(%Glific.ThirdParty.Kaapi.Error{
+      message:
+        "Failed to poll AI Evaluation: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+          "org_id=#{org_id}",
+      organization_id: org_id,
+      reason: safe_inspect(reason)
+    })
 
     :ok
   end
@@ -155,13 +191,21 @@ defmodule Glific.AIEvaluations do
   @spec do_update(AIEvaluation.t(), map()) :: :ok
   defp do_update(evaluation, attrs) do
     case update_ai_evaluation(evaluation, attrs) do
-      {:ok, _} ->
+      {:ok, updated} ->
+        Logger.info(
+          "AI Evaluation status updated: id=#{updated.id}, name=#{updated.name}, " <>
+            "new_status=#{updated.status}"
+        )
+
         :ok
 
       {:error, changeset} ->
-        Logger.error(
-          "Failed to update AI evaluation #{evaluation.id}: #{inspect(changeset.errors)}"
-        )
+        Glific.log_exception(%Glific.ThirdParty.Kaapi.Error{
+          message:
+            "Failed to update AI Evaluation record: id=#{evaluation.id}, name=#{evaluation.name}",
+          organization_id: evaluation.organization_id,
+          reason: safe_inspect(changeset.errors)
+        })
     end
   end
 
@@ -193,9 +237,28 @@ defmodule Glific.AIEvaluations do
   """
   @spec create_golden_qa(map()) :: {:ok, GoldenQA.t()} | {:error, Ecto.Changeset.t()}
   def create_golden_qa(attrs) do
-    %GoldenQA{}
-    |> GoldenQA.changeset(attrs)
-    |> Repo.insert()
+    result =
+      %GoldenQA{}
+      |> GoldenQA.changeset(attrs)
+      |> Repo.insert()
+
+    case result do
+      {:ok, golden_qa} ->
+        Logger.info(
+          "Golden QA record created: id=#{golden_qa.id}, name=#{golden_qa.name}, " <>
+            "dataset_id=#{golden_qa.dataset_id}, " <>
+            "duplication_factor=#{golden_qa.duplication_factor}, " <>
+            "file_name=#{golden_qa.file_name}, org_id=#{golden_qa.organization_id}"
+        )
+
+      {:error, changeset} ->
+        Logger.error(
+          "Failed to create Golden QA record: org_id=#{attrs[:organization_id]}, " <>
+            "name=#{attrs[:name]}, errors=#{safe_inspect(changeset.errors)}"
+        )
+    end
+
+    result
   end
 
   @doc """
@@ -204,8 +267,17 @@ defmodule Glific.AIEvaluations do
   @spec get_evaluation_scores(non_neg_integer(), non_neg_integer()) ::
           {:ok, map()} | {:error, any()}
   def get_evaluation_scores(evaluation_id, org_id) do
-    with {:ok, %AIEvaluation{kaapi_evaluation_id: kaapi_id}} <-
+    Logger.info(
+      "Fetching AI Evaluation scores from Kaapi: evaluation_id=#{evaluation_id}, org_id=#{org_id}"
+    )
+
+    with {:ok, %AIEvaluation{kaapi_evaluation_id: kaapi_id} = evaluation} <-
            Repo.fetch(AIEvaluation, evaluation_id) do
+      Logger.info(
+        "Polling Kaapi for evaluation scores: evaluation_id=#{evaluation_id}, " <>
+          "name=#{evaluation.name}, kaapi_evaluation_id=#{kaapi_id}, org_id=#{org_id}"
+      )
+
       Kaapi.get_evaluation_scores(kaapi_id, org_id)
     end
   end
@@ -225,8 +297,15 @@ defmodule Glific.AIEvaluations do
   @spec request_eval_access(non_neg_integer()) ::
           {:ok, OrganizationEvalRequest.t()} | {:error, Ecto.Changeset.t()}
   def request_eval_access(organization_id) do
+    Logger.info("AI Evaluation access request received: org_id=#{organization_id}")
+
     case Repo.fetch_by(OrganizationEvalRequest, %{organization_id: organization_id}) do
       {:ok, existing} ->
+        Logger.info(
+          "AI Evaluation access request already exists (idempotent): " <>
+            "org_id=#{organization_id}, status=#{existing.status}"
+        )
+
         {:ok, existing}
 
       {:error, _} ->
@@ -235,10 +314,21 @@ defmodule Glific.AIEvaluations do
           |> OrganizationEvalRequest.changeset(%{organization_id: organization_id})
           |> Repo.insert()
 
-        with {:ok, _request} <- result do
-          organization_id
-          |> Partners.organization()
-          |> EvalAccessRequestMail.send_eval_access_request_mail()
+        case result do
+          {:ok, _request} ->
+            Logger.info("New AI Evaluation access request created: org_id=#{organization_id}")
+
+            Metrics.increment("AI Evaluation Access Requested", organization_id)
+
+            organization_id
+            |> Partners.organization()
+            |> EvalAccessRequestMail.send_eval_access_request_mail()
+
+          {:error, changeset} ->
+            Logger.error(
+              "Failed to create AI Evaluation access request: org_id=#{organization_id}, " <>
+                "errors=#{safe_inspect(changeset.errors)}"
+            )
         end
 
         result

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -50,27 +50,20 @@ defmodule Glific.AIEvaluations do
   """
   @spec create_ai_evaluation(map()) :: {:ok, AIEvaluation.t()} | {:error, Ecto.Changeset.t()}
   def create_ai_evaluation(attrs) do
-    result =
-      %AIEvaluation{}
-      |> AIEvaluation.changeset(attrs)
-      |> Repo.insert()
-
-    case result do
+    %AIEvaluation{}
+    |> AIEvaluation.changeset(attrs)
+    |> Repo.insert()
+    |> case do
       {:ok, evaluation} ->
-        Logger.info(
-          "AI Evaluation record created: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-            "status=#{evaluation.status}, kaapi_evaluation_id=#{evaluation.kaapi_evaluation_id}, " <>
-            "org_id=#{evaluation.organization_id}"
-        )
+        {:ok, evaluation}
 
-      {:error, changeset} ->
+      {:error, changeset} = result ->
         Logger.error(
-          "Failed to create AI Evaluation record: org_id=#{attrs[:organization_id]}, " <>
-            "name=#{attrs[:name]}, errors=#{safe_inspect(changeset.errors)}"
+          "Failed to create AI Evaluation record: name=#{attrs[:name]}, errors=#{safe_inspect(changeset.errors)}"
         )
-    end
 
-    result
+        result
+    end
   end
 
   @doc """
@@ -267,17 +260,8 @@ defmodule Glific.AIEvaluations do
   @spec get_evaluation_scores(non_neg_integer(), non_neg_integer()) ::
           {:ok, map()} | {:error, any()}
   def get_evaluation_scores(evaluation_id, org_id) do
-    Logger.info(
-      "Fetching AI Evaluation scores from Kaapi: evaluation_id=#{evaluation_id}, org_id=#{org_id}"
-    )
-
-    with {:ok, %AIEvaluation{kaapi_evaluation_id: kaapi_id} = evaluation} <-
+    with {:ok, %AIEvaluation{kaapi_evaluation_id: kaapi_id}} <-
            Repo.fetch(AIEvaluation, evaluation_id) do
-      Logger.info(
-        "Polling Kaapi for evaluation scores: evaluation_id=#{evaluation_id}, " <>
-          "name=#{evaluation.name}, kaapi_evaluation_id=#{kaapi_id}, org_id=#{org_id}"
-      )
-
       Kaapi.get_evaluation_scores(kaapi_id, org_id)
     end
   end
@@ -297,8 +281,6 @@ defmodule Glific.AIEvaluations do
   @spec request_eval_access(non_neg_integer()) ::
           {:ok, OrganizationEvalRequest.t()} | {:error, Ecto.Changeset.t()}
   def request_eval_access(organization_id) do
-    Logger.info("AI Evaluation access request received: org_id=#{organization_id}")
-
     case Repo.fetch_by(OrganizationEvalRequest, %{organization_id: organization_id}) do
       {:ok, existing} ->
         Logger.info(

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -127,6 +127,9 @@ defmodule Glific.AIEvaluations do
   defp handle_evaluation_status({:ok, %{data: %{status: "completed"} = data}}, evaluation, org_id) do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
 
+    duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at)
+    Appsignal.add_distribution_value("ai_evaluation_duration", duration_seconds, %{org_id: org_id})
+
     Metrics.increment("AI Evaluation Completed", org_id)
 
     Notifications.create_notification(%{

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -97,13 +97,7 @@ defmodule Glific.AIEvaluations do
     |> where([e], e.inserted_at < ^timeout_threshold)
     |> Repo.all()
     |> Enum.each(fn evaluation ->
-      duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
-
-      Logger.warning(
-        "Timing out AI evaluation: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-          "org_id=#{org_id}, duration_seconds=#{duration_seconds}"
-      )
-
+      Logger.warning("Timing out AI evaluation #{evaluation.id} for org #{org_id}")
       Metrics.increment("AI Evaluation Timed Out", org_id)
 
       Notifications.create_notification(%{
@@ -139,12 +133,10 @@ defmodule Glific.AIEvaluations do
   @spec handle_evaluation_status(tuple(), AIEvaluation.t(), non_neg_integer()) :: :ok
   defp handle_evaluation_status({:ok, %{data: %{status: "completed"} = data}}, evaluation, org_id) do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
-    duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
 
     Logger.info(
       "AI Evaluation completed: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, duration_seconds=#{duration_seconds}, " <>
-        "summary_scores_count=#{length(summary_scores)}, " <>
+        "org_id=#{org_id}, summary_scores_count=#{length(summary_scores)}, " <>
         "summary_scores=#{safe_inspect(summary_scores)}"
     )
 
@@ -163,11 +155,10 @@ defmodule Glific.AIEvaluations do
 
   defp handle_evaluation_status({:ok, %{data: %{status: "failed"} = data}}, evaluation, org_id) do
     failure_reason = Map.get(data, :error_message, "Evaluation failed")
-    duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
 
     Logger.error(
       "AI Evaluation failed on Kaapi: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, duration_seconds=#{duration_seconds}, failure_reason=#{failure_reason}"
+        "org_id=#{org_id}, failure_reason=#{failure_reason}"
     )
 
     Metrics.increment("AI Evaluation Failed", org_id)

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -196,7 +196,7 @@ defmodule Glific.AIEvaluations do
   @spec list_golden_qas(map()) :: [GoldenQA.t()]
   def list_golden_qas(args) do
     args
-    |> Repo.list_filter_query(GoldenQA, &Repo.opts_with_name/2, &filter_golden_qas/2)
+    |> Repo.list_filter_query(GoldenQA, &Repo.opts_with_inserted_at/2, &filter_golden_qas/2)
     |> Repo.all()
   end
 

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -128,6 +128,7 @@ defmodule Glific.AIEvaluations do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
 
     duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at)
+
     Appsignal.add_distribution_value("ai_evaluation_duration", duration_seconds, %{org_id: org_id})
 
     Metrics.increment("AI Evaluation Completed", org_id)
@@ -195,7 +196,7 @@ defmodule Glific.AIEvaluations do
   @spec list_golden_qas(map()) :: [GoldenQA.t()]
   def list_golden_qas(args) do
     args
-    |> Repo.list_filter_query(GoldenQA, &Repo.opts_with_inserted_at/2, &filter_golden_qas/2)
+    |> Repo.list_filter_query(GoldenQA, &Repo.opts_with_name/2, &filter_golden_qas/2)
     |> Repo.all()
   end
 

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -97,7 +97,13 @@ defmodule Glific.AIEvaluations do
     |> where([e], e.inserted_at < ^timeout_threshold)
     |> Repo.all()
     |> Enum.each(fn evaluation ->
-      Logger.warning("Timing out AI evaluation #{evaluation.id} for org #{org_id}")
+      duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
+
+      Logger.warning(
+        "Timing out AI evaluation: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+          "org_id=#{org_id}, duration_seconds=#{duration_seconds}"
+      )
+
       Metrics.increment("AI Evaluation Timed Out", org_id)
 
       Notifications.create_notification(%{
@@ -133,10 +139,12 @@ defmodule Glific.AIEvaluations do
   @spec handle_evaluation_status(tuple(), AIEvaluation.t(), non_neg_integer()) :: :ok
   defp handle_evaluation_status({:ok, %{data: %{status: "completed"} = data}}, evaluation, org_id) do
     summary_scores = data |> Map.get(:score, %{}) |> Map.get(:summary_scores, [])
+    duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
 
     Logger.info(
       "AI Evaluation completed: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, summary_scores_count=#{length(summary_scores)}, " <>
+        "org_id=#{org_id}, duration_seconds=#{duration_seconds}, " <>
+        "summary_scores_count=#{length(summary_scores)}, " <>
         "summary_scores=#{safe_inspect(summary_scores)}"
     )
 
@@ -155,10 +163,11 @@ defmodule Glific.AIEvaluations do
 
   defp handle_evaluation_status({:ok, %{data: %{status: "failed"} = data}}, evaluation, org_id) do
     failure_reason = Map.get(data, :error_message, "Evaluation failed")
+    duration_seconds = DateTime.diff(DateTime.utc_now(), evaluation.inserted_at, :second)
 
     Logger.error(
       "AI Evaluation failed on Kaapi: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-        "org_id=#{org_id}, failure_reason=#{failure_reason}"
+        "org_id=#{org_id}, duration_seconds=#{duration_seconds}, failure_reason=#{failure_reason}"
     )
 
     Metrics.increment("AI Evaluation Failed", org_id)

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -67,7 +67,7 @@ defmodule Glific.Assistants do
       |> Map.put(:kaapi_uuid, version.assistant.kaapi_uuid)
       |> Map.put(:assistant_name, version.assistant.name)
     end)
-    |> Enum.sort_by(&{String.downcase(&1.assistant_name), &1.version_number})
+    |> Enum.sort_by(& &1.assistant_name)
   end
 
   @doc """

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -67,7 +67,7 @@ defmodule Glific.Assistants do
       |> Map.put(:kaapi_uuid, version.assistant.kaapi_uuid)
       |> Map.put(:assistant_name, version.assistant.name)
     end)
-    |> Enum.sort_by(& &1.assistant_name)
+    |> Enum.sort_by(&{String.downcase(&1.assistant_name), &1.version_number})
   end
 
   @doc """

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -2,6 +2,8 @@ defmodule Glific.ThirdParty.Kaapi do
   @moduledoc """
   Kaapi is our own internal services that handles all AI related features.
   """
+  import Glific.SafeLog
+
   require Logger
 
   alias Glific.Partners
@@ -61,10 +63,11 @@ defmodule Glific.ThirdParty.Kaapi do
       {:error, error} ->
         Glific.log_exception(%Error{
           message:
-            "Kaapi onboarding failed for org_id=#{params.organization_id}, reason=#{inspect(error)}"
+            "Kaapi onboarding failed for org_id=#{params.organization_id}, reason=#{safe_inspect(error)}"
         })
 
-        {:error, "KAAPI onboarding failed for org #{params.organization_id}: #{inspect(error)}"}
+        {:error,
+         "KAAPI onboarding failed for org #{params.organization_id}: #{safe_inspect(error)}"}
     end
   end
 
@@ -107,11 +110,11 @@ defmodule Glific.ThirdParty.Kaapi do
       {:error, error} ->
         Glific.log_exception(%Error{
           message:
-            "KAAPI #{provider} credential update failed for org_id=#{organization_id}, reason=#{inspect(error)}"
+            "KAAPI #{provider} credential update failed for org_id=#{organization_id}, reason=#{safe_inspect(error)}"
         })
 
         {:error,
-         "KAAPI #{provider} credential update failed for org #{organization_id}: #{inspect(error)}"}
+         "KAAPI #{provider} credential update failed for org #{organization_id}: #{safe_inspect(error)}"}
     end
   end
 
@@ -132,7 +135,7 @@ defmodule Glific.ThirdParty.Kaapi do
       {:error, reason} ->
         Glific.log_exception(%Error{
           message:
-            "Assistant import failed in kaapi: organization_id=#{organization_id}, assistant_id=#{assistant_id}, reason=#{inspect(reason)}"
+            "Assistant import failed in kaapi: organization_id=#{organization_id}, assistant_id=#{assistant_id}, reason=#{safe_inspect(reason)}"
         })
 
         {:error, reason}
@@ -166,7 +169,7 @@ defmodule Glific.ThirdParty.Kaapi do
           %Error{
             message: "Kaapi Config creation failed for name #{params.name}",
             organization_id: organization_id,
-            reason: inspect(reason)
+            reason: safe_inspect(reason)
           },
           []
         )
@@ -201,7 +204,7 @@ defmodule Glific.ThirdParty.Kaapi do
           %Error{
             message: "Kaapi Config Version creation failed for Config ID #{config_id}",
             organization_id: organization_id,
-            reason: inspect(reason)
+            reason: safe_inspect(reason)
           },
           []
         )
@@ -239,7 +242,7 @@ defmodule Glific.ThirdParty.Kaapi do
           %Error{
             message: "Kaapi AI Assistant update failed for assistant_id=#{assistant_id}",
             organization_id: organization_id,
-            reason: inspect(reason)
+            reason: safe_inspect(reason)
           },
           []
         )
@@ -264,7 +267,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Glific.log_exception(%Error{
           message: "Kaapi AI Assistant delete failed for assistant_id=#{assistant_id}",
           organization_id: organization_id,
-          reason: inspect(reason)
+          reason: safe_inspect(reason)
         })
 
         {:error, reason}
@@ -288,7 +291,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Glific.log_exception(%Error{
           message: "Failed to create Kaapi Knowledge Base creation job",
           organization_id: organization_id,
-          reason: inspect(reason)
+          reason: safe_inspect(reason)
         })
 
         {:error, reason}
@@ -311,7 +314,7 @@ defmodule Glific.ThirdParty.Kaapi do
           %Error{
             message: "Failed to get Kaapi collection status",
             organization_id: organization_id,
-            reason: inspect(reason)
+            reason: safe_inspect(reason)
           },
           []
         )
@@ -414,17 +417,18 @@ defmodule Glific.ThirdParty.Kaapi do
 
   defp handle_kaapi_error({:error, reason}, organization_id, label, fallback_type) do
     Glific.log_exception(%Error{
-      message: "Kaapi #{label} failed for org_id=#{organization_id}, reason=#{inspect(reason)}"
+      message:
+        "Kaapi #{label} failed for org_id=#{organization_id}, reason=#{safe_inspect(reason)}"
     })
 
-    %{success: false, error_type: fallback_type, reason: inspect(reason)}
+    %{success: false, error_type: fallback_type, reason: safe_inspect(reason)}
   end
 
   @spec extract_error_message(map() | any()) :: String.t()
   defp extract_error_message(body) when is_map(body),
-    do: body["error"] || body["message"] || inspect(body)
+    do: body["error"] || body["message"] || safe_inspect(body)
 
-  defp extract_error_message(body), do: inspect(body)
+  defp extract_error_message(body), do: safe_inspect(body)
 
   @spec classify_error(map() | any()) :: String.t()
   defp classify_error(body) do
@@ -508,7 +512,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Appsignal.send_error(
           %Error{
             message: "Kaapi document upload failed for, filename=#{params.filename}",
-            reason: inspect(reason),
+            reason: safe_inspect(reason),
             organization_id: organization_id
           },
           []
@@ -534,7 +538,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Appsignal.send_error(
           %Error{
             message:
-              "KAAPI config delete failed for org_id=#{organization_id}, config=#{uuid}, reason=#{inspect(reason)}"
+              "KAAPI config delete failed for org_id=#{organization_id}, config=#{uuid}, reason=#{safe_inspect(reason)}"
           },
           []
         )
@@ -550,9 +554,22 @@ defmodule Glific.ThirdParty.Kaapi do
   def create_evaluation(params, organization_id) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, result} <- ApiClient.create_evaluation(params, secrets["api_key"]) do
+      Logger.info(
+        "Kaapi evaluation creation successful: experiment_name=#{params[:experiment_name]}, " <>
+          "org_id=#{organization_id}, kaapi_response=#{safe_inspect(result)}"
+      )
+
       {:ok, result}
     else
       {:error, reason} ->
+        Glific.log_exception(%Error{
+          message:
+            "Kaapi evaluation creation failed: experiment_name=#{params[:experiment_name]}, " <>
+              "org_id=#{organization_id}",
+          organization_id: organization_id,
+          reason: safe_inspect(reason)
+        })
+
         {:error, reason}
     end
   end
@@ -565,9 +582,30 @@ defmodule Glific.ThirdParty.Kaapi do
   def get_evaluation_scores(evaluation_id, organization_id) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, result} <- ApiClient.get_evaluation_scores(evaluation_id, secrets["api_key"]) do
+      Logger.info(
+        "Kaapi evaluation scores retrieved: evaluation_id=#{evaluation_id}, " <>
+          "org_id=#{organization_id}, status=#{get_in(result, [:data, :status])}"
+      )
+
       {:ok, result}
     else
+      {:error, :timeout} ->
+        Logger.error(
+          "Kaapi timeout fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
+            "org_id=#{organization_id}"
+        )
+
+        {:error, :timeout}
+
       {:error, reason} ->
+        Glific.log_exception(%Error{
+          message:
+            "Kaapi evaluation scores fetch failed: evaluation_id=#{evaluation_id}, " <>
+              "org_id=#{organization_id}",
+          organization_id: organization_id,
+          reason: safe_inspect(reason)
+        })
+
         {:error, reason}
     end
   end
@@ -587,7 +625,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Glific.log_exception(%Error{
           message: "Kaapi dataset response missing signed_url",
           organization_id: organization_id,
-          reason: inspect(data)
+          reason: safe_inspect(data)
         })
 
         {:error, "Dataset download URL not available"}
@@ -599,7 +637,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Glific.log_exception(%Error{
           message: "Failed to get dataset from Kaapi",
           organization_id: organization_id,
-          reason: inspect(reason)
+          reason: safe_inspect(reason)
         })
 
         {:error, reason}
@@ -624,7 +662,7 @@ defmodule Glific.ThirdParty.Kaapi do
         Glific.log_exception(%Error{
           message: "Failed to delete evaluation dataset from Kaapi",
           organization_id: organization_id,
-          reason: inspect(reason)
+          reason: safe_inspect(reason)
         })
 
         {:error, reason}
@@ -642,7 +680,7 @@ defmodule Glific.ThirdParty.Kaapi do
       case result do
         %{data: %{dataset_name: dataset_name, dataset_id: dataset_id}} ->
           Logger.info(
-            "Kaapi evaluation dataset upload successful for org: #{organization_id}, result: #{inspect(result)}"
+            "Kaapi evaluation dataset upload successful for org: #{organization_id}, result: #{safe_inspect(result)}"
           )
 
           {:ok, %{name: dataset_name, dataset_id: dataset_id}}
@@ -652,7 +690,7 @@ defmodule Glific.ThirdParty.Kaapi do
             %Error{
               message: "Got unexpected response from Kaapi while uploading evaluation dataset",
               organization_id: organization_id,
-              reason: inspect(error)
+              reason: safe_inspect(error)
             },
             []
           )
@@ -665,7 +703,7 @@ defmodule Glific.ThirdParty.Kaapi do
           %Error{
             message: "Failed to upload evaluation dataset to Kaapi",
             organization_id: organization_id,
-            reason: inspect(reason)
+            reason: safe_inspect(reason)
           },
           []
         )

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -2,9 +2,9 @@ defmodule Glific.ThirdParty.Kaapi do
   @moduledoc """
   Kaapi is our own internal services that handles all AI related features.
   """
-  import Glific.SafeLog
-
   require Logger
+
+  import Glific.SafeLog
 
   alias Glific.Partners
   alias Glific.Partners.Credential

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -560,7 +560,7 @@ defmodule Glific.ThirdParty.Kaapi do
       {:error, reason} ->
         Glific.log_exception(%Error{
           message:
-            "Kaapi evaluation creation failed: experiment_name=#{params[:experiment_name]}",
+            "Kaapi evaluation creation failed: evaluation_name=#{params[:experiment_name]}",
           organization_id: organization_id,
           reason: safe_inspect(reason)
         })

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -537,8 +537,9 @@ defmodule Glific.ThirdParty.Kaapi do
       {:error, reason} ->
         Appsignal.send_error(
           %Error{
-            message:
-              "KAAPI config delete failed for org_id=#{organization_id}, config=#{uuid}, reason=#{safe_inspect(reason)}"
+            message: "KAAPI config delete failed for config=#{uuid}",
+            organization_id: organization_id,
+            reason: safe_inspect(reason)
           },
           []
         )
@@ -554,18 +555,12 @@ defmodule Glific.ThirdParty.Kaapi do
   def create_evaluation(params, organization_id) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, result} <- ApiClient.create_evaluation(params, secrets["api_key"]) do
-      Logger.info(
-        "Kaapi evaluation creation successful: experiment_name=#{params[:experiment_name]}, " <>
-          "org_id=#{organization_id}, kaapi_response=#{safe_inspect(result)}"
-      )
-
       {:ok, result}
     else
       {:error, reason} ->
         Glific.log_exception(%Error{
           message:
-            "Kaapi evaluation creation failed: experiment_name=#{params[:experiment_name]}, " <>
-              "org_id=#{organization_id}",
+            "Kaapi evaluation creation failed: experiment_name=#{params[:experiment_name]}",
           organization_id: organization_id,
           reason: safe_inspect(reason)
         })
@@ -582,26 +577,16 @@ defmodule Glific.ThirdParty.Kaapi do
   def get_evaluation_scores(evaluation_id, organization_id) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, result} <- ApiClient.get_evaluation_scores(evaluation_id, secrets["api_key"]) do
-      Logger.info(
-        "Kaapi evaluation scores retrieved: evaluation_id=#{evaluation_id}, " <>
-          "org_id=#{organization_id}, status=#{get_in(result, [:data, :status])}"
-      )
-
       {:ok, result}
     else
       {:error, :timeout} ->
-        Logger.error(
-          "Kaapi timeout fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
-            "org_id=#{organization_id}"
-        )
+        Logger.error("Kaapi timeout fetching evaluation scores: evaluation_id=#{evaluation_id}")
 
         {:error, :timeout}
 
       {:error, reason} ->
         Glific.log_exception(%Error{
-          message:
-            "Kaapi evaluation scores fetch failed: evaluation_id=#{evaluation_id}, " <>
-              "org_id=#{organization_id}",
+          message: "Kaapi evaluation scores fetch failed: evaluation_id=#{evaluation_id}",
           organization_id: organization_id,
           reason: safe_inspect(reason)
         })
@@ -619,8 +604,6 @@ defmodule Glific.ThirdParty.Kaapi do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, %{success: true, data: data}} <-
            ApiClient.get_dataset(dataset_id, secrets["api_key"], include_signed_url) do
-      Logger.info("Dataset retrieved for org: #{organization_id}, dataset: #{dataset_id}")
-
       if include_signed_url && !Map.has_key?(data, :signed_url) do
         Glific.log_exception(%Error{
           message: "Kaapi dataset response missing signed_url",
@@ -652,9 +635,7 @@ defmodule Glific.ThirdParty.Kaapi do
   def delete_evaluation_dataset(dataset_id, organization_id) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          {:ok, result} <- ApiClient.delete_evaluation_dataset(dataset_id, secrets["api_key"]) do
-      Logger.info(
-        "Kaapi evaluation dataset delete successful for org: #{organization_id}, dataset: #{dataset_id}"
-      )
+      Logger.info("Kaapi evaluation dataset delete successful for dataset: #{dataset_id}")
 
       {:ok, result}
     else
@@ -679,10 +660,6 @@ defmodule Glific.ThirdParty.Kaapi do
          {:ok, result} <- ApiClient.upload_evaluation_dataset(params, secrets["api_key"]) do
       case result do
         %{data: %{dataset_name: dataset_name, dataset_id: dataset_id}} ->
-          Logger.info(
-            "Kaapi evaluation dataset upload successful for org: #{organization_id}, result: #{safe_inspect(result)}"
-          )
-
           {:ok, %{name: dataset_name, dataset_id: dataset_id}}
 
         error ->

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -28,11 +28,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:ok, %{status: "requested"}}
 
       {:error, changeset} ->
-        Logger.error(
-          "AI Evaluation access request failed: user_id=#{user.id}, " <>
-            "org_id=#{user.organization_id}, errors=#{safe_inspect(changeset.errors)}"
-        )
-
         {:error, changeset}
     end
   end
@@ -44,8 +39,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @spec get_org_eval_access_request(map(), map(), map()) ::
           {:ok, %{status: String.t()} | nil}
   def get_org_eval_access_request(_, _, %{context: %{current_user: user}}) do
-    Metrics.increment("AI Evaluations Page Visited", user.organization_id)
-
     case AIEvaluations.get_eval_access_request(user.organization_id) do
       {:ok, request} -> {:ok, %{status: request.status}}
       {:error, _} -> {:ok, nil}
@@ -56,6 +49,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @max_golden_qa_file_size 1 * 1024 * 1024
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
+  @ai_evaluation_create_failure_metric "AI Evaluation Create Failure"
 
   @doc """
   List AI evaluations from the database.
@@ -101,11 +95,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   def create_golden_qa(_, %{input: %{name: name, file: file, duplication_factor: factor}}, %{
         context: %{current_user: user}
       }) do
-    Logger.info(
-      "Create Golden QA initiated: name=#{name}, file_name=#{file.filename}, " <>
-        "duplication_factor=#{factor}, user_id=#{user.id}, org_id=#{user.organization_id}"
-    )
-
     dataset = %{
       dataset_name: name,
       file: file,
@@ -115,51 +104,25 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
-         _ =
-           Logger.info(
-             "Uploading Golden QA dataset to Kaapi: name=#{name}, " <>
-               "file_name=#{file.filename}, duplication_factor=#{factor}, " <>
-               "org_id=#{user.organization_id}"
-           ),
          {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
       {:error, :timeout} ->
-        Logger.error(
-          "Kaapi timeout uploading Golden QA dataset: name=#{name}, " <>
-            "org_id=#{user.organization_id}"
-        )
-
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
-      {:error, %{status: status, body: %{:error => error}}} ->
-        Logger.error(
-          "Kaapi API error uploading Golden QA dataset: name=#{name}, " <>
-            "org_id=#{user.organization_id}, status=#{status}, error=#{error}"
-        )
-
+      {:error, %{status: _status, body: %{:error => error}}} ->
         {:ok, %{errors: [%{message: error}]}}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         errors = format_changeset_errors(changeset)
-        Logger.error("Failed to save golden QA to database: #{safe_inspect(errors)}")
         {:ok, %{errors: errors}}
 
       {:error, msg} when is_binary(msg) ->
-        Logger.warning(
-          "Golden QA creation rejected: name=#{name}, org_id=#{user.organization_id}, reason=#{msg}"
-        )
+        Logger.warning("Golden QA creation rejected: name=#{name}, reason=#{msg}")
 
         {:ok, %{errors: [%{message: msg}]}}
 
-      {:error, err} ->
-        Glific.log_exception(%Kaapi.Error{
-          message:
-            "Unexpected error creating Golden QA: name=#{name}, org_id=#{user.organization_id}",
-          organization_id: user.organization_id,
-          reason: safe_inspect(err)
-        })
-
+      {:error, _err} ->
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -169,10 +132,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:ok, data}
 
       {:ok, data} ->
-        Logger.info(
-          "Golden QA created successfully: name=#{name}, org_id=#{user.organization_id}"
-        )
-
         Metrics.increment(@create_golden_qa_success_metric, user.organization_id)
         {:ok, data}
     end
@@ -194,7 +153,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:error, %Ecto.Changeset{} = changeset} ->
         cleanup_orphaned_kaapi_dataset(kaapi_dataset.dataset_id, user.organization_id)
         errors = format_changeset_errors(changeset)
-        Logger.error("Failed to save golden QA to database: #{safe_inspect(errors)}")
         {:ok, %{errors: errors}}
     end
   end
@@ -271,11 +229,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   def get_golden_qa(_, %{id: golden_qa_id, include_signed_url: include_signed_url}, %{
         context: %{current_user: user}
       }) do
-    Logger.info(
-      "Fetching Golden QA: golden_qa_id=#{golden_qa_id}, " <>
-        "include_signed_url=#{include_signed_url}, org_id=#{user.organization_id}"
-    )
-
     with {:ok, golden_qa} <- Repo.fetch(Glific.AIEvaluations.GoldenQA, golden_qa_id),
          {:ok, kaapi_data} <- fetch_kaapi_dataset(golden_qa, user, include_signed_url) do
       golden_qa_map =
@@ -289,39 +242,16 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         }
         |> maybe_put_signed_url(kaapi_data)
 
-      Logger.info(
-        "Golden QA fetched successfully: id=#{golden_qa.id}, name=#{golden_qa.name}, " <>
-          "org_id=#{user.organization_id}"
-      )
-
-      Metrics.increment("Golden QA Fetch Success", user.organization_id)
       if include_signed_url, do: Metrics.increment("Golden QA Downloaded", user.organization_id)
       {:ok, %{golden_qa: golden_qa_map}}
     else
       {:error, [_, "Resource not found"]} ->
-        Logger.error("Golden QA not found: id=#{golden_qa_id}, org_id=#{user.organization_id}")
-
-        Metrics.increment("Golden QA Fetch Not Found", user.organization_id)
         {:ok, %{errors: [%{message: "Golden QA not found."}]}}
 
       {:error, error} when is_binary(error) ->
-        Logger.error(
-          "Golden QA fetch failed: id=#{golden_qa_id}, org_id=#{user.organization_id}, error=#{error}"
-        )
-
-        Metrics.increment("Golden QA Fetch Failure", user.organization_id)
         {:ok, %{errors: [%{message: error}]}}
 
-      {:error, err} ->
-        Glific.log_exception(%Kaapi.Error{
-          message:
-            "Unexpected error fetching Golden QA: id=#{golden_qa_id}, org_id=#{user.organization_id}",
-          organization_id: user.organization_id,
-          reason: safe_inspect(err)
-        })
-
-        Metrics.increment("Golden QA Fetch Failure", user.organization_id)
-
+      {:error, _} ->
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -364,58 +294,24 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @spec get_evaluation_scores(map(), map(), map()) ::
           {:ok, %{scores: map()} | %{errors: [%{message: String.t()}]}}
   def get_evaluation_scores(_, %{id: evaluation_id}, %{context: %{current_user: user}}) do
-    Logger.info(
-      "Get evaluation scores requested: evaluation_id=#{evaluation_id}, " <>
-        "user_id=#{user.id}, org_id=#{user.organization_id}"
-    )
+    Logger.info("Get evaluation scores requested: evaluation_id=#{evaluation_id}")
 
     case AIEvaluations.get_evaluation_scores(evaluation_id, user.organization_id) do
       {:ok, %{data: data}} ->
-        Logger.info(
-          "Evaluation scores fetched successfully: evaluation_id=#{evaluation_id}, " <>
-            "org_id=#{user.organization_id}, status=#{Map.get(data, :status)}"
-        )
-
-        Metrics.increment("AI Evaluation Scores Fetched", user.organization_id)
         {:ok, %{scores: data}}
 
       {:error, :timeout} ->
-        Logger.error(
-          "Timeout fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
-            "org_id=#{user.organization_id}"
-        )
-
-        Metrics.increment("AI Evaluation Scores Fetch Timeout", user.organization_id)
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
       {:error, [_, "Resource not found"]} ->
-        Logger.error(
-          "Evaluation not found when fetching scores: evaluation_id=#{evaluation_id}, " <>
-            "org_id=#{user.organization_id}"
-        )
+        Logger.error("Evaluation not found when fetching scores: evaluation_id=#{evaluation_id}")
 
         {:ok, %{errors: [%{message: "Evaluation not found."}]}}
 
       {:error, msg} when is_binary(msg) ->
-        Logger.error(
-          "Error fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
-            "org_id=#{user.organization_id}, error=#{msg}"
-        )
-
-        Metrics.increment("AI Evaluation Scores Fetch Failure", user.organization_id)
         {:ok, %{errors: [%{message: msg}]}}
 
-      {:error, err} ->
-        Glific.log_exception(%Kaapi.Error{
-          message:
-            "Unexpected error fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
-              "org_id=#{user.organization_id}",
-          organization_id: user.organization_id,
-          reason: safe_inspect(err)
-        })
-
-        Metrics.increment("AI Evaluation Scores Fetch Failure", user.organization_id)
-
+      {:error, _} ->
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -427,12 +323,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec create_evaluation(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}
   def create_evaluation(_, %{input: input}, %{context: %{current_user: user}}) do
-    Logger.info(
-      "Create AI Evaluation initiated: name=#{input.evaluation_name}, " <>
-        "golden_qa_id=#{input.golden_qa_id}, config_id=#{input.config_id}, " <>
-        "user_id=#{user.id}, org_id=#{user.organization_id}"
-    )
-
     with {:name, {:error, _}} <-
            {:name,
             Repo.fetch_by(AIEvaluation, %{
@@ -455,14 +345,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         _ =
-           Logger.info(
-             "Sending create evaluation request to Kaapi: " <>
-               "experiment_name=#{kaapi_input.experiment_name}, " <>
-               "config_id=#{kaapi_input.config_id}, " <>
-               "config_version=#{kaapi_input.config_version}, " <>
-               "dataset_id=#{kaapi_input.dataset_id}, org_id=#{user.organization_id}"
-           ),
          {:ok, %{data: data}} <- Kaapi.create_evaluation(kaapi_input, user.organization_id),
          {:ok, evaluation} <-
            AIEvaluations.create_ai_evaluation(%{
@@ -473,77 +355,39 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
              assistant_config_version_id: input.config_id,
              organization_id: user.organization_id
            }) do
-      Logger.info(
-        "AI Evaluation created successfully: id=#{evaluation.id}, name=#{evaluation.name}, " <>
-          "status=#{evaluation.status}, kaapi_evaluation_id=#{evaluation.kaapi_evaluation_id}, " <>
-          "org_id=#{user.organization_id}"
-      )
-
       Metrics.increment("AI Evaluation Created", user.organization_id)
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->
-        Logger.warning(
-          "Duplicate evaluation name rejected: name=#{input.evaluation_name}, " <>
-            "org_id=#{user.organization_id}"
-        )
+        Logger.warning("Duplicate evaluation name rejected: name=#{input.evaluation_name}")
 
         {:error, "An evaluation with this name already exists. Please choose a different name."}
 
       {:assistant_config_version, {:error, _}} ->
-        Logger.error(
-          "Config version not found: config_id=#{input.config_id}, " <>
-            "org_id=#{user.organization_id}"
-        )
+        Logger.error("Config version not found: config_id=#{input.config_id}")
 
         {:error, "The specified config version does not exist."}
 
       {:golden_qa, {:error, _}} ->
-        Logger.error(
-          "Golden QA not found or access denied: golden_qa_id=#{input.golden_qa_id}, " <>
-            "org_id=#{user.organization_id}"
-        )
+        Logger.error("Golden QA not found or access denied: golden_qa_id=#{input.golden_qa_id}")
 
         {:error,
          "The specified Golden QA dataset does not exist or does not belong to your organization."}
 
       {:error, :timeout} ->
-        Logger.error(
-          "Kaapi timeout creating evaluation: name=#{input.evaluation_name}, " <>
-            "org_id=#{user.organization_id}"
-        )
-
-        Metrics.increment("AI Evaluation Create Timeout", user.organization_id)
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
         {:error, "Timeout occurred, please try again."}
 
       {:error, %{body: %{:error => error}}} ->
-        Logger.error(
-          "Kaapi API error creating evaluation: name=#{input.evaluation_name}, " <>
-            "org_id=#{user.organization_id}, error=#{error}"
-        )
-
-        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
         {:error, error}
 
       {:error, msg} when is_binary(msg) ->
-        Logger.error(
-          "Error creating evaluation: name=#{input.evaluation_name}, " <>
-            "org_id=#{user.organization_id}, error=#{msg}"
-        )
-
-        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
         {:error, msg}
 
-      {:error, err} ->
-        Glific.log_exception(%Kaapi.Error{
-          message:
-            "Unexpected error creating AI Evaluation: name=#{input.evaluation_name}, " <>
-              "org_id=#{user.organization_id}",
-          organization_id: user.organization_id,
-          reason: safe_inspect(err)
-        })
-
-        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
+      {:error, _} ->
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
         {:error, "An unknown error occurred, please contact Glific support."}
     end
   end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -44,6 +44,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @spec get_org_eval_access_request(map(), map(), map()) ::
           {:ok, %{status: String.t()} | nil}
   def get_org_eval_access_request(_, _, %{context: %{current_user: user}}) do
+    Metrics.increment("AI Evaluations Page Visited", user.organization_id)
+
     case AIEvaluations.get_eval_access_request(user.organization_id) do
       {:ok, request} -> {:ok, %{status: request.status}}
       {:error, _} -> {:ok, nil}
@@ -293,6 +295,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       )
 
       Metrics.increment("Golden QA Fetch Success", user.organization_id)
+      if include_signed_url, do: Metrics.increment("Golden QA Downloaded", user.organization_id)
       {:ok, %{golden_qa: golden_qa_map}}
     else
       {:error, [_, "Resource not found"]} ->
@@ -477,6 +480,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       )
 
       Metrics.increment("AI Evaluation Created", user.organization_id)
+      Metrics.increment("AI Evaluation Created: assistant=#{kaapi_input.config_id}", user.organization_id)
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -2,6 +2,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @moduledoc """
   Resolvers for AI Evaluations
   """
+  import Glific.SafeLog
+
   require Logger
 
   alias Glific.{
@@ -22,8 +24,16 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
           {:ok, %{status: String.t()}} | {:error, Ecto.Changeset.t()}
   def request_ai_evaluation_access(_, _, %{context: %{current_user: user}}) do
     case AIEvaluations.request_eval_access(user.organization_id) do
-      {:ok, _request} -> {:ok, %{status: "requested"}}
-      {:error, changeset} -> {:error, changeset}
+      {:ok, _request} ->
+        {:ok, %{status: "requested"}}
+
+      {:error, changeset} ->
+        Logger.error(
+          "AI Evaluation access request failed: user_id=#{user.id}, " <>
+            "org_id=#{user.organization_id}, errors=#{safe_inspect(changeset)}"
+        )
+
+        {:error, changeset}
     end
   end
 
@@ -89,6 +99,11 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   def create_golden_qa(_, %{input: %{name: name, file: file, duplication_factor: factor}}, %{
         context: %{current_user: user}
       }) do
+    Logger.info(
+      "Create Golden QA initiated: name=#{name}, file_name=#{file.filename}, " <>
+        "duplication_factor=#{factor}, user_id=#{user.id}, org_id=#{user.organization_id}"
+    )
+
     dataset = %{
       dataset_name: name,
       file: file,
@@ -98,24 +113,51 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
+         _ =
+           Logger.info(
+             "Uploading Golden QA dataset to Kaapi: name=#{name}, " <>
+               "file_name=#{file.filename}, duplication_factor=#{factor}, " <>
+               "org_id=#{user.organization_id}"
+           ),
          {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
       {:error, :timeout} ->
+        Logger.error(
+          "Kaapi timeout uploading Golden QA dataset: name=#{name}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
-      {:error, %{status: _, body: %{:error => error}}} ->
+      {:error, %{status: status, body: %{:error => error}}} ->
+        Logger.error(
+          "Kaapi API error uploading Golden QA dataset: name=#{name}, " <>
+            "org_id=#{user.organization_id}, status=#{status}, error=#{error}"
+        )
+
         {:ok, %{errors: [%{message: error}]}}
 
       {:error, %Ecto.Changeset{} = changeset} ->
         errors = format_changeset_errors(changeset)
-        Logger.error("Failed to save golden QA to database: #{inspect(errors)}")
+        Logger.error("Failed to save golden QA to database: #{safe_inspect(errors)}")
         {:ok, %{errors: errors}}
 
       {:error, msg} when is_binary(msg) ->
+        Logger.warning(
+          "Golden QA creation rejected: name=#{name}, org_id=#{user.organization_id}, reason=#{msg}"
+        )
+
         {:ok, %{errors: [%{message: msg}]}}
 
-      {:error, _err} ->
+      {:error, err} ->
+        Glific.log_exception(%Kaapi.Error{
+          message:
+            "Unexpected error creating Golden QA: name=#{name}, org_id=#{user.organization_id}",
+          organization_id: user.organization_id,
+          reason: safe_inspect(err)
+        })
+
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -125,6 +167,10 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:ok, data}
 
       {:ok, data} ->
+        Logger.info(
+          "Golden QA created successfully: name=#{name}, org_id=#{user.organization_id}"
+        )
+
         Metrics.increment(@create_golden_qa_success_metric, user.organization_id)
         {:ok, data}
     end
@@ -146,7 +192,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:error, %Ecto.Changeset{} = changeset} ->
         cleanup_orphaned_kaapi_dataset(kaapi_dataset.dataset_id, user.organization_id)
         errors = format_changeset_errors(changeset)
-        Logger.error("Failed to save golden QA to database: #{inspect(errors)}")
+        Logger.error("Failed to save golden QA to database: #{safe_inspect(errors)}")
         {:ok, %{errors: errors}}
     end
   end
@@ -161,7 +207,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         Glific.log_exception(%Kaapi.Error{
           message: "Failed to delete orphaned Kaapi dataset",
           organization_id: organization_id,
-          reason: inspect(reason)
+          reason: safe_inspect(reason)
         })
 
         # Returning ok as we don't want to block the main flow
@@ -207,7 +253,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
       {:error, reason} ->
         Logger.error(
-          "Create Golden QA: User ID: #{id}: Org ID: #{organization_id}: Unable to read uploaded file for size validation due to #{inspect(reason)}"
+          "Create Golden QA: User ID: #{id}: Org ID: #{organization_id}: Unable to read uploaded file for size validation due to #{safe_inspect(reason)}"
         )
 
         {:error, "Unable to read uploaded file for size validation"}
@@ -223,6 +269,11 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   def get_golden_qa(_, %{id: golden_qa_id, include_signed_url: include_signed_url}, %{
         context: %{current_user: user}
       }) do
+    Logger.info(
+      "Fetching Golden QA: golden_qa_id=#{golden_qa_id}, " <>
+        "include_signed_url=#{include_signed_url}, org_id=#{user.organization_id}"
+    )
+
     with {:ok, golden_qa} <- Repo.fetch(Glific.AIEvaluations.GoldenQA, golden_qa_id),
          {:ok, kaapi_data} <- fetch_kaapi_dataset(golden_qa, user, include_signed_url) do
       golden_qa_map =
@@ -236,15 +287,38 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         }
         |> maybe_put_signed_url(kaapi_data)
 
+      Logger.info(
+        "Golden QA fetched successfully: id=#{golden_qa.id}, name=#{golden_qa.name}, " <>
+          "org_id=#{user.organization_id}"
+      )
+
+      Metrics.increment("Golden QA Fetch Success", user.organization_id)
       {:ok, %{golden_qa: golden_qa_map}}
     else
       {:error, [_, "Resource not found"]} ->
+        Logger.error("Golden QA not found: id=#{golden_qa_id}, org_id=#{user.organization_id}")
+
+        Metrics.increment("Golden QA Fetch Not Found", user.organization_id)
         {:ok, %{errors: [%{message: "Golden QA not found."}]}}
 
       {:error, error} when is_binary(error) ->
+        Logger.error(
+          "Golden QA fetch failed: id=#{golden_qa_id}, org_id=#{user.organization_id}, error=#{error}"
+        )
+
+        Metrics.increment("Golden QA Fetch Failure", user.organization_id)
         {:ok, %{errors: [%{message: error}]}}
 
-      {:error, _} ->
+      {:error, err} ->
+        Glific.log_exception(%Kaapi.Error{
+          message:
+            "Unexpected error fetching Golden QA: id=#{golden_qa_id}, org_id=#{user.organization_id}",
+          organization_id: user.organization_id,
+          reason: safe_inspect(err)
+        })
+
+        Metrics.increment("Golden QA Fetch Failure", user.organization_id)
+
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -287,20 +361,58 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @spec get_evaluation_scores(map(), map(), map()) ::
           {:ok, %{scores: map()} | %{errors: [%{message: String.t()}]}}
   def get_evaluation_scores(_, %{id: evaluation_id}, %{context: %{current_user: user}}) do
+    Logger.info(
+      "Get evaluation scores requested: evaluation_id=#{evaluation_id}, " <>
+        "user_id=#{user.id}, org_id=#{user.organization_id}"
+    )
+
     case AIEvaluations.get_evaluation_scores(evaluation_id, user.organization_id) do
       {:ok, %{data: data}} ->
+        Logger.info(
+          "Evaluation scores fetched successfully: evaluation_id=#{evaluation_id}, " <>
+            "org_id=#{user.organization_id}, status=#{Map.get(data, :status)}"
+        )
+
+        Metrics.increment("AI Evaluation Scores Fetched", user.organization_id)
         {:ok, %{scores: data}}
 
       {:error, :timeout} ->
+        Logger.error(
+          "Timeout fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
+        Metrics.increment("AI Evaluation Scores Fetch Timeout", user.organization_id)
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
       {:error, [_, "Resource not found"]} ->
+        Logger.error(
+          "Evaluation not found when fetching scores: evaluation_id=#{evaluation_id}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
         {:ok, %{errors: [%{message: "Evaluation not found."}]}}
 
       {:error, msg} when is_binary(msg) ->
+        Logger.error(
+          "Error fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
+            "org_id=#{user.organization_id}, error=#{msg}"
+        )
+
+        Metrics.increment("AI Evaluation Scores Fetch Failure", user.organization_id)
         {:ok, %{errors: [%{message: msg}]}}
 
-      {:error, _} ->
+      {:error, err} ->
+        Glific.log_exception(%Kaapi.Error{
+          message:
+            "Unexpected error fetching evaluation scores: evaluation_id=#{evaluation_id}, " <>
+              "org_id=#{user.organization_id}",
+          organization_id: user.organization_id,
+          reason: safe_inspect(err)
+        })
+
+        Metrics.increment("AI Evaluation Scores Fetch Failure", user.organization_id)
+
         {:ok,
          %{errors: [%{message: "An unknown error occurred, please contact Glific support."}]}}
     end
@@ -312,6 +424,12 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec create_evaluation(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}
   def create_evaluation(_, %{input: input}, %{context: %{current_user: user}}) do
+    Logger.info(
+      "Create AI Evaluation initiated: name=#{input.evaluation_name}, " <>
+        "golden_qa_id=#{input.golden_qa_id}, config_id=#{input.config_id}, " <>
+        "user_id=#{user.id}, org_id=#{user.organization_id}"
+    )
+
     with {:name, {:error, _}} <-
            {:name,
             Repo.fetch_by(AIEvaluation, %{
@@ -334,6 +452,14 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
+         _ =
+           Logger.info(
+             "Sending create evaluation request to Kaapi: " <>
+               "experiment_name=#{kaapi_input.experiment_name}, " <>
+               "config_id=#{kaapi_input.config_id}, " <>
+               "config_version=#{kaapi_input.config_version}, " <>
+               "dataset_id=#{kaapi_input.dataset_id}, org_id=#{user.organization_id}"
+           ),
          {:ok, %{data: data}} <- Kaapi.create_evaluation(kaapi_input, user.organization_id),
          {:ok, evaluation} <-
            AIEvaluations.create_ai_evaluation(%{
@@ -344,28 +470,77 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
              assistant_config_version_id: input.config_id,
              organization_id: user.organization_id
            }) do
+      Logger.info(
+        "AI Evaluation created successfully: id=#{evaluation.id}, name=#{evaluation.name}, " <>
+          "status=#{evaluation.status}, kaapi_evaluation_id=#{evaluation.kaapi_evaluation_id}, " <>
+          "org_id=#{user.organization_id}"
+      )
+
+      Metrics.increment("AI Evaluation Created", user.organization_id)
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->
+        Logger.warning(
+          "Duplicate evaluation name rejected: name=#{input.evaluation_name}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
         {:error, "An evaluation with this name already exists. Please choose a different name."}
 
       {:assistant_config_version, {:error, _}} ->
+        Logger.error(
+          "Config version not found: config_id=#{input.config_id}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
         {:error, "The specified config version does not exist."}
 
       {:golden_qa, {:error, _}} ->
+        Logger.error(
+          "Golden QA not found or access denied: golden_qa_id=#{input.golden_qa_id}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
         {:error,
          "The specified Golden QA dataset does not exist or does not belong to your organization."}
 
       {:error, :timeout} ->
+        Logger.error(
+          "Kaapi timeout creating evaluation: name=#{input.evaluation_name}, " <>
+            "org_id=#{user.organization_id}"
+        )
+
+        Metrics.increment("AI Evaluation Create Timeout", user.organization_id)
         {:error, "Timeout occurred, please try again."}
 
       {:error, %{body: %{:error => error}}} ->
+        Logger.error(
+          "Kaapi API error creating evaluation: name=#{input.evaluation_name}, " <>
+            "org_id=#{user.organization_id}, error=#{error}"
+        )
+
+        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
         {:error, error}
 
       {:error, msg} when is_binary(msg) ->
+        Logger.error(
+          "Error creating evaluation: name=#{input.evaluation_name}, " <>
+            "org_id=#{user.organization_id}, error=#{msg}"
+        )
+
+        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
         {:error, msg}
 
-      {:error, _} ->
+      {:error, err} ->
+        Glific.log_exception(%Kaapi.Error{
+          message:
+            "Unexpected error creating AI Evaluation: name=#{input.evaluation_name}, " <>
+              "org_id=#{user.organization_id}",
+          organization_id: user.organization_id,
+          reason: safe_inspect(err)
+        })
+
+        Metrics.increment("AI Evaluation Create Failure", user.organization_id)
         {:error, "An unknown error occurred, please contact Glific support."}
     end
   end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -30,7 +30,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:error, changeset} ->
         Logger.error(
           "AI Evaluation access request failed: user_id=#{user.id}, " <>
-            "org_id=#{user.organization_id}, errors=#{safe_inspect(changeset)}"
+            "org_id=#{user.organization_id}, errors=#{safe_inspect(changeset.errors)}"
         )
 
         {:error, changeset}
@@ -480,7 +480,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       )
 
       Metrics.increment("AI Evaluation Created", user.organization_id)
-      Metrics.increment("AI Evaluation Created: assistant=#{kaapi_input.config_id}", user.organization_id)
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -110,7 +110,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:error, :timeout} ->
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
-      {:error, %{status: _status, body: %{:error => error}}} ->
+      {:error, %{status: _, body: %{:error => error}}} ->
         {:ok, %{errors: [%{message: error}]}}
 
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -118,8 +118,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:ok, %{errors: errors}}
 
       {:error, msg} when is_binary(msg) ->
-        Logger.warning("Golden QA creation rejected: name=#{name}, reason=#{msg}")
-
         {:ok, %{errors: [%{message: msg}]}}
 
       {:error, _err} ->
@@ -294,8 +292,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @spec get_evaluation_scores(map(), map(), map()) ::
           {:ok, %{scores: map()} | %{errors: [%{message: String.t()}]}}
   def get_evaluation_scores(_, %{id: evaluation_id}, %{context: %{current_user: user}}) do
-    Logger.info("Get evaluation scores requested: evaluation_id=#{evaluation_id}")
-
     case AIEvaluations.get_evaluation_scores(evaluation_id, user.organization_id) do
       {:ok, %{data: data}} ->
         {:ok, %{scores: data}}
@@ -304,8 +300,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
 
       {:error, [_, "Resource not found"]} ->
-        Logger.error("Evaluation not found when fetching scores: evaluation_id=#{evaluation_id}")
-
         {:ok, %{errors: [%{message: "Evaluation not found."}]}}
 
       {:error, msg} when is_binary(msg) ->
@@ -359,18 +353,12 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->
-        Logger.warning("Duplicate evaluation name rejected: name=#{input.evaluation_name}")
-
         {:error, "An evaluation with this name already exists. Please choose a different name."}
 
       {:assistant_config_version, {:error, _}} ->
-        Logger.error("Config version not found: config_id=#{input.config_id}")
-
         {:error, "The specified config version does not exist."}
 
       {:golden_qa, {:error, _}} ->
-        Logger.error("Golden QA not found or access denied: golden_qa_id=#{input.golden_qa_id}")
-
         {:error,
          "The specified Golden QA dataset does not exist or does not belong to your organization."}
 

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -49,6 +49,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   @max_golden_qa_file_size 1 * 1024 * 1024
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
+  @ai_evaluation_create_success_metric "AI Evaluation Created"
   @ai_evaluation_create_failure_metric "AI Evaluation Create Failure"
 
   @doc """
@@ -349,7 +350,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
              assistant_config_version_id: input.config_id,
              organization_id: user.organization_id
            }) do
-      Metrics.increment("AI Evaluation Created", user.organization_id)
+      Metrics.increment(@ai_evaluation_create_success_metric, user.organization_id)
       {:ok, %{evaluation: evaluation}}
     else
       {:name, {:ok, _}} ->

--- a/lib/glific_web/resolvers/filesearch.ex
+++ b/lib/glific_web/resolvers/filesearch.ex
@@ -9,6 +9,8 @@ defmodule GlificWeb.Resolvers.Filesearch do
     Filesearch.VectorStore
   }
 
+  require Logger
+
   @doc """
   Uploads a file to Kaapi
 
@@ -57,8 +59,15 @@ defmodule GlificWeb.Resolvers.Filesearch do
   @spec update_assistant(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, any} | {:error, any}
   def update_assistant(_, %{id: id, input: attrs}, _) do
-    with {:ok, assistant} <- Assistants.update_assistant(id, attrs) do
-      {:ok, %{assistant: assistant}}
+    id
+    |> Assistants.update_assistant(attrs)
+    |> case do
+      {:ok, assistant} ->
+        {:ok, %{assistant: assistant}}
+
+      error ->
+        Logger.error("update_assistant failed: id=#{id}, error=#{inspect(error)}")
+        error
     end
   end
 


### PR DESCRIPTION

## Summary
 Target issue is https://github.com/glific/glific/issues/5070

 lib/glific/ai_evaluations.ex

  - Added import Glific.SafeLog
  - create_ai_evaluation: log success (id, name, status, kaapi_id, org_id) and DB insert failures
  - create_golden_qa: log success (id, name, dataset_id, duplication_factor) and insert failures
  - get_evaluation_scores: log before fetch and before Kaapi call with full evaluation details
  - request_eval_access: log on entry, idempotent path (existing status), new request creation; add Metrics.increment("AI Evaluation Access 

  New Metrics

  - "AI Evaluation Access Requested" — new org access request
  - "AI Evaluation Created" — evaluation created end-to-end
  - "AI Evaluation Create Timeout" / "AI Evaluation Create Failure"
  - "AI Evaluation Scores Fetched" — scores retrieved from Kaapi
  - "AI Evaluation Scores Fetch Timeout" / "AI Evaluation Scores Fetch Failure"
  - "Golden QA Fetch Success" / "Golden QA Fetch Not Found" / "Golden QA Fetch Failure"

<img width="440" height="356" alt="Screenshot 2026-05-19 at 1 36 39 AM" src="https://github.com/user-attachments/assets/cc931aa2-c885-4288-9e45-aff6e024079e" />

