### PR TITLE
Fix template_parameters_count undercounting dynamic URL buttons

### DIFF
--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -755,13 +755,27 @@ defmodule Glific.Templates do
   end
 
   @doc """
-  Returns the count of variables in template
+  Returns the count of variables in template.
+
+  Body variables are counted as unique `{{N}}` occurrences. URL button variables
+  are counted per-button (each dynamic URL button contributes one parameter),
+  since WhatsApp treats every URL button's `{{1}}` as its own local variable.
   """
   @spec template_parameters_count(map()) :: non_neg_integer()
   def template_parameters_count(template) do
-    template = parse_buttons(template, false, Map.get(template, :has_buttons, false))
+    body_count = count_body_parameters(Map.get(template, :body, "") || "")
 
-    template.body
+    button_count =
+      if Map.get(template, :has_buttons, false),
+        do: count_url_button_parameters(Map.get(template, :buttons, [])),
+        else: 0
+
+    body_count + button_count
+  end
+
+  @spec count_body_parameters(String.t()) :: non_neg_integer()
+  defp count_body_parameters(body) do
+    body
     |> String.split()
     |> Enum.reduce([], fn word, acc ->
       with true <- String.match?(word, ~r/{{([1-9]|[1-9][0-9])}}/),
@@ -774,6 +788,19 @@ defmodule Glific.Templates do
     |> Enum.uniq()
     |> Enum.count()
   end
+
+  @spec count_url_button_parameters(list() | any()) :: non_neg_integer()
+  defp count_url_button_parameters(buttons) when is_list(buttons) do
+    Enum.count(buttons, fn
+      %{"type" => "URL", "url" => url} when is_binary(url) ->
+        String.match?(url, ~r/{{([1-9]|[1-9][0-9])}}/)
+
+      _ ->
+        false
+    end)
+  end
+
+  defp count_url_button_parameters(_), do: 0
 
   @spec hsm_template_uuid_map() :: map()
   defp hsm_template_uuid_map do

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -1779,6 +1779,59 @@ defmodule Glific.TemplatesTest do
       assert Templates.template_parameters_count(%{body: template_body, has_buttons: false}) == 10
     end
 
+    test "template_parameters_count/1 counts body and URL button params separately" do
+      # two URL buttons each with a {{1}} → one parameter per dynamic URL button,
+      # so total = 1 (body) + 2 (buttons) = 3, even though both URLs are identical
+      template_body = "Hi {{1}}, Here is the report for activity."
+
+      buttons = [
+        %{
+          "type" => "URL",
+          "text" => "Open",
+          "url" => "https://prod.glific.com/{{1}}"
+        },
+        %{
+          "type" => "URL",
+          "text" => "Open2",
+          "url" => "https://prod.glific.com/{{1}}"
+        }
+      ]
+
+      assert Templates.template_parameters_count(%{
+               body: template_body,
+               has_buttons: true,
+               buttons: buttons
+             }) == 3
+
+      # static URL buttons (no {{N}}) do not contribute parameters
+      static_buttons = [
+        %{"type" => "URL", "text" => "Visit", "url" => "https://github.com/glific"},
+        %{"type" => "PHONE_NUMBER", "text" => "Call", "phone_number" => "+917302307943"},
+        %{"type" => "QUICK_REPLY", "text" => "Yes"}
+      ]
+
+      assert Templates.template_parameters_count(%{
+               body: template_body,
+               has_buttons: true,
+               buttons: static_buttons
+             }) == 1
+
+      # mix of dynamic and static URL buttons
+      mixed_buttons = [
+        %{"type" => "URL", "text" => "Dynamic", "url" => "https://prod.glific.com/{{1}}"},
+        %{"type" => "URL", "text" => "Static", "url" => "https://github.com/glific"}
+      ]
+
+      assert Templates.template_parameters_count(%{
+               body: template_body,
+               has_buttons: true,
+               buttons: mixed_buttons
+             }) == 2
+
+      # has_buttons: true but buttons key missing → body count only
+      assert Templates.template_parameters_count(%{body: template_body, has_buttons: true}) == 1
+    end
+
     test "parse_buttons/2 should return updated body with buttons" do
       template_body = "Hi {{1}}, What is your status"
 


### PR DESCRIPTION
## Summary

- `Templates.template_parameters_count/1` was returning the wrong count for HSM templates with multiple dynamic URL buttons. Two URL buttons each containing `{{1}}` were collapsed into a single parameter because the previous implementation merged buttons into the body string and then deduplicated cleaned tokens — identical URLs produced identical cleaned strings.
- Body params and URL button params are now counted separately. Each dynamic URL button (URL containing `{{N}}`) contributes one parameter, matching WhatsApp's convention where every URL button has its own local `{{1}}` variable.
- `parse_buttons/3` is unchanged since it is still used by `Messages` for actual message rendering.

### Example

For the payload below, `number_parameters` is now `3` (was `2`):

```json
{
  "body": "Hello {{1}} how are you doing whats up",
  "hasButtons": true,
  "buttons": [
    { "type": "URL", "text": "Open",  "url": "https://prod.glific.com/{{1}}" },
    { "type": "URL", "text": "Open2", "url": "https://prod.glific.com/{{1}}" }
  ]
}
