### PR TITLE
 Cover unified-voice-llm-call failure surfaces in AppSignal

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -730,7 +730,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = "https://9dc7-103-91-135-178.ngrok-free.app" <> callback_path
+    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -133,7 +133,9 @@ defmodule Glific.Clients.CommonWebhook do
             }
           })
 
-        do_unified_llm_call(updated_fields, headers, callback_url, request_metadata)
+        with_failure_reporting("unified-voice-llm-call", organization_id, fn ->
+          do_unified_llm_call(updated_fields, headers, callback_url, request_metadata)
+        end)
 
       %{success: false} = stt_failure ->
         %{success: false, reason: stt_failure[:asr_response_text] || "Speech to text failed"}
@@ -203,17 +205,18 @@ defmodule Glific.Clients.CommonWebhook do
 
   # Uses Gemini for STT via Bhasini flow nodes
   def webhook("speech_to_text_with_bhasini", fields) do
-    case Bhasini.validate_params(fields) do
-      {:ok, contact} ->
-        Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
+    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
 
-        with_failure_reporting("speech_to_text_with_bhasini", contact.organization_id, fn ->
+    with_failure_reporting("speech_to_text_with_bhasini", org_id, fn ->
+      case Bhasini.validate_params(fields) do
+        {:ok, contact} ->
+          Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
           Gemini.speech_to_text(fields["speech"], contact.organization_id)
-        end)
 
-      {:error, error} ->
-        error
-    end
+        {:error, error} ->
+          %{success: false, asr_response_text: error}
+      end
+    end)
   end
 
   # Uses Gemini/Bhasini/OpenAI for TTS via Bhasini flow nodes
@@ -727,7 +730,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
+    callback_url = "https://9dc7-103-91-135-178.ngrok-free.app" <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -92,7 +92,8 @@ defmodule Glific.Clients.CommonWebhook do
     {callback_url, request_metadata} =
       build_flow_resume_metadata(organization_id, flow_id, contact_id, fields)
 
-    request_metadata = Map.put(request_metadata, :call_type, "llm")
+    request_metadata =
+      Map.merge(request_metadata, %{call_type: "llm", webhook_name: "unified-llm-call"})
 
     with_failure_reporting("unified-llm-call", organization_id, fn ->
       do_unified_llm_call(fields, headers, callback_url, request_metadata)
@@ -126,6 +127,7 @@ defmodule Glific.Clients.CommonWebhook do
         request_metadata =
           Map.merge(request_metadata, %{
             call_type: "voice_llm",
+            webhook_name: "unified-voice-llm-call",
             voice_post_process: %{
               source_language: fields["source_language"],
               target_language: fields["target_language"],
@@ -155,7 +157,8 @@ defmodule Glific.Clients.CommonWebhook do
     {callback_url, request_metadata} =
       build_flow_resume_metadata(organization_id, flow_id, contact_id, fields)
 
-    request_metadata = Map.put(request_metadata, :call_type, "stt")
+    request_metadata =
+      Map.merge(request_metadata, %{call_type: "stt", webhook_name: "speech_to_text"})
 
     stt_opts = %{
       provider: fields["provider"],
@@ -185,7 +188,8 @@ defmodule Glific.Clients.CommonWebhook do
     {callback_url, request_metadata} =
       build_flow_resume_metadata(organization_id, flow_id, contact_id, fields)
 
-    request_metadata = Map.put(request_metadata, :call_type, "tts")
+    request_metadata =
+      Map.merge(request_metadata, %{call_type: "tts", webhook_name: "text_to_speech"})
 
     tts_opts = %{
       provider: fields["provider"],

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -168,7 +168,7 @@ defmodule Glific.Clients.CommonWebhook do
     }
 
     with_failure_reporting("speech_to_text", organization_id, fn ->
-      case validate_media(speech) do
+      case validate_params(fields) do
         :ok ->
           Glific.Metrics.increment("Kaapi STT Call", organization_id)
           Kaapi.speech_to_text(speech, callback_url, request_metadata, organization_id, stt_opts)
@@ -712,11 +712,20 @@ defmodule Glific.Clients.CommonWebhook do
     end
   end
 
+  # Webhook param validation hook. Single check today; convert to a
+  # short-circuiting `with` once there's more than one field to validate.
+  @spec validate_params(map()) :: :ok | {:error, String.t()}
+  defp validate_params(fields), do: validate_media(fields["speech"])
+
   @spec validate_media(any()) :: :ok | {:error, String.t()}
   defp validate_media(url) when is_binary(url) do
-    if String.starts_with?(url, "https"),
-      do: :ok,
-      else: {:error, "Media URL is invalid"}
+    case URI.parse(url) do
+      %URI{scheme: "https", host: host} when is_binary(host) and host != "" ->
+        :ok
+
+      _ ->
+        {:error, "Media URL is invalid"}
+    end
   end
 
   defp validate_media(_), do: {:error, "Media URL is needed"}

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -149,6 +149,7 @@ defmodule Glific.Clients.CommonWebhook do
   # Optional fields from flow node: provider, model, language (input language for transcription),
   # output_language (if omitted, Kaapi transcribes in the input language without translation)
   def webhook("speech_to_text", fields, _headers) do
+    speech = fields["speech"]
     {organization_id, flow_id, contact_id} = parse_flow_fields(fields)
 
     {callback_url, request_metadata} =
@@ -163,16 +164,15 @@ defmodule Glific.Clients.CommonWebhook do
       output_language: fields["output_language"]
     }
 
-    Glific.Metrics.increment("Kaapi STT Call", organization_id)
-
     with_failure_reporting("speech_to_text", organization_id, fn ->
-      Kaapi.speech_to_text(
-        fields["speech"],
-        callback_url,
-        request_metadata,
-        organization_id,
-        stt_opts
-      )
+      case validate_media(speech) do
+        :ok ->
+          Glific.Metrics.increment("Kaapi STT Call", organization_id)
+          Kaapi.speech_to_text(speech, callback_url, request_metadata, organization_id, stt_opts)
+
+        {:error, reason} ->
+          %{success: false, reason: reason}
+      end
     end)
   end
 
@@ -693,6 +693,15 @@ defmodule Glific.Clients.CommonWebhook do
       _ -> raise ArgumentError, "Invalid flow metadata for Kaapi webhook: #{inspect(fields)}"
     end
   end
+
+  @spec validate_media(any()) :: :ok | {:error, String.t()}
+  defp validate_media(url) when is_binary(url) do
+    if String.starts_with?(url, "https"),
+      do: :ok,
+      else: {:error, "Media URL is invalid"}
+  end
+
+  defp validate_media(_), do: {:error, "Media URL is needed"}
 
   # Builds the callback URL and request_metadata map needed for all Kaapi async calls
   # (unified-llm-call, STT, TTS). Centralises signature generation and callback URL construction.

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -472,16 +472,30 @@ defmodule Glific.Clients.CommonWebhook do
     voice_fields = response["voice_post_process"] || %{}
 
     tts_result =
-      if success && llm_response_text != "" do
-        webhook("nmt_tts_with_bhasini", %{
-          "text" => llm_response_text,
-          "organization_id" => organization_id,
-          "source_language" => voice_fields["source_language"],
-          "target_language" => voice_fields["target_language"],
-          "speech_engine" => voice_fields["speech_engine"] || ""
-        })
-      else
-        %{success: false, translated_text: llm_response_text, media_url: nil}
+      cond do
+        success && llm_response_text != "" ->
+          webhook("nmt_tts_with_bhasini", %{
+            "text" => llm_response_text,
+            "organization_id" => organization_id,
+            "source_language" => voice_fields["source_language"],
+            "target_language" => voice_fields["target_language"],
+            "speech_engine" => voice_fields["speech_engine"] || ""
+          })
+
+        # Kaapi reported success but gave us no text to speak
+        # sending error code 200 since the call from kaapi is success
+        success ->
+          report_webhook_failure(
+            "unified-voice-llm-call",
+            organization_id,
+            200,
+            "Kaapi callback returned success=true but message was empty/nil"
+          )
+
+          %{success: false, translated_text: "", media_url: nil}
+
+        true ->
+          %{success: false, translated_text: llm_response_text, media_url: nil}
       end
 
     translated_text =

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -1174,7 +1174,7 @@ defmodule Glific.Flows.FlowContext do
            FunWithFlags.enabled?(:is_kaapi_enabled,
              for: %{organization_id: context.organization_id}
            ),
-         true <- current_node_filesearch?(flow, context) do
+         true <- current_node_async_webhook?(flow, context) do
       webhook_log =
         WebhookLog
         |> where([w], w.flow_context_id == ^context.id)
@@ -1190,21 +1190,15 @@ defmodule Glific.Flows.FlowContext do
     end
   end
 
-  @spec current_node_filesearch?(Flow.t(), FlowContext.t()) :: boolean()
-  defp current_node_filesearch?(flow, context) do
-    case Map.fetch(flow.uuid_map, context.node_uuid) do
-      {:ok, {:node, node}} ->
-        Enum.any?(node.actions, fn action -> action.url == "filesearch-gpt" end)
-
-      _ ->
-        false
-    end
-  end
-
   # Async webhook URLs whose flow node parks the flow waiting for a Kaapi
   # callback. A nil-message wakeup of such a node means the callback never
-  # arrived within the wait window
-  @async_webhook_urls ["speech_to_text", "text_to_speech", "filesearch-gpt"]
+  # arrived within the wait window.
+  @async_webhook_urls [
+    "speech_to_text",
+    "text_to_speech",
+    "filesearch-gpt",
+    "voice-filesearch-gpt"
+  ]
 
   @spec async_webhook_url(Flow.t(), FlowContext.t()) :: String.t() | nil
   defp async_webhook_url(flow, context) do
@@ -1216,6 +1210,10 @@ defmodule Glific.Flows.FlowContext do
       _ -> nil
     end
   end
+
+  @spec current_node_async_webhook?(Flow.t(), FlowContext.t()) :: boolean()
+  defp current_node_async_webhook?(flow, context),
+    do: not is_nil(async_webhook_url(flow, context))
 
   # When a flow times out (woken with no callback message), report async
   # webhook nodes to AppSignal. Gated to async webhook nodes so plain

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -1182,7 +1182,10 @@ defmodule Glific.Flows.FlowContext do
         |> limit(1)
         |> Repo.one()
 
-      Webhook.update_log(webhook_log.id, "Timeout: taking long to process response")
+      if webhook_log do
+        Webhook.update_log(webhook_log.id, "Timeout: taking long to process response")
+      end
+
       Messages.create_temp_message(context.organization_id, "Failure")
     else
       _ ->

--- a/lib/glific/third_party/gemini.ex
+++ b/lib/glific/third_party/gemini.ex
@@ -46,7 +46,7 @@ defmodule Glific.ThirdParty.Gemini do
       %{success: false, error: "Failed to fetch audio"}
 
   """
-  @spec speech_to_text(String.t(), non_neg_integer()) :: map()
+  @spec speech_to_text(String.t(), non_neg_integer()) :: map() | String.t()
   def speech_to_text(audio_url, organization_id) do
     with {:ok, encoded_audio} <- GupshupClient.download_media_content(audio_url, organization_id),
          %{success: true} = response <- ApiClient.speech_to_text(encoded_audio, organization_id) do

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -95,6 +95,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
     %Webhook.SystemError{message: "Webhook callback failure"}
     |> Webhook.report_to_appsignal(%{
       organization_id: response["organization_id"],
+      webhook_name: response["webhook_name"],
       flow_id: response["flow_id"],
       contact_id: response["contact_id"],
       webhook_log_id: response["webhook_log_id"],

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -148,6 +148,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
         do: Webhook.update_log(response["webhook_log_id"], voice_response)
 
       track_kaapi_latency(response)
+      maybe_report_callback_failure(result, response)
 
       FlowContext.resume_contact_flow(
         contact,

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -2049,7 +2049,6 @@ defmodule Glific.Flows.CommonWebhookTest do
       capture_appsignal(fn ->
         result = CommonWebhook.voice_post_process(organization_id, true, response)
 
-        # Falls through to the empty-message branch — no TTS call, no media_url
         assert result["translated_text"] == ""
         assert is_nil(result["media_url"])
       end)

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -2030,4 +2030,35 @@ defmodule Glific.Flows.CommonWebhookTest do
       assert tags.http_status == 503
     end
   end
+
+  test "reports SystemError when Kaapi callback says success=true but message is empty" do
+    organization_id = 1
+
+    response = %{
+      "message" => "",
+      "voice_post_process" => %{
+        "source_language" => "english",
+        "target_language" => "hindi"
+      },
+      "flow_id" => 1,
+      "contact_id" => 2,
+      "webhook_log_id" => 1
+    }
+
+    {exception, tags} =
+      capture_appsignal(fn ->
+        result = CommonWebhook.voice_post_process(organization_id, true, response)
+
+        # Falls through to the empty-message branch — no TTS call, no media_url
+        assert result["translated_text"] == ""
+        assert is_nil(result["media_url"])
+      end)
+
+    assert %SystemError{} = exception
+    assert tags.webhook_name == "unified-voice-llm-call"
+    # 200 distinguishes this from a 5xx/timeout — the call succeeded at the
+    # HTTP layer, the body was just unusable.
+    assert tags.http_status == 200
+    assert tags.reason =~ "empty"
+  end
 end

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1144,6 +1144,23 @@ defmodule Glific.Flows.CommonWebhookTest do
       assert tags.webhook_name == "speech_to_text"
       assert tags.http_status == 503
     end
+
+    test "rejects empty speech URL without calling Kaapi and reports SystemError", %{
+      fields: fields
+    } do
+      fields = Map.put(fields, "speech", "")
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result = CommonWebhook.webhook("speech_to_text", fields, [])
+          assert result == %{success: false, reason: "Media URL is invalid"}
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.webhook_name == "speech_to_text"
+      assert tags.reason == "Media URL is invalid"
+      assert is_nil(tags.http_status)
+    end
   end
 
   describe "text_to_speech webhook" do

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1923,5 +1923,94 @@ defmodule Glific.Flows.CommonWebhookTest do
 
       assert payload.query.input == "Transcribed audio"
     end
+
+    test "returns structured failure (no CaseClauseError) when Bhasini rejects the URL" do
+      organization_id = 1
+      contact = Fixtures.contact_fixture()
+
+      fields = %{
+        "organization_id" => organization_id,
+        "flow_id" => 1,
+        "contact_id" => contact.id,
+        "assistant_id" => "asst_voice_bad_url",
+        # http (not https) → Bhasini.validate_params returns {:error, "Media URL is invalid"}
+        "speech" => "http://example.com/audio.ogg",
+        "source_language" => "english",
+        "target_language" => "hindi",
+        "webhook_log_id" => 1,
+        "result_name" => "result"
+      }
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result =
+            CommonWebhook.webhook("unified-voice-llm-call", fields, unified_llm_headers())
+
+          assert result == %{success: false, reason: "Media URL is invalid"}
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.webhook_name == "speech_to_text_with_bhasini"
+      assert tags.reason == "Media URL is invalid"
+      assert is_nil(tags.http_status)
+    end
+
+    test "reports SystemError under unified-voice-llm-call when LLM dispatch fails" do
+      organization_id = 1
+      assistant_display_id = "asst_voice_llm_fail"
+      create_assistant_with_config(organization_id, assistant_display_id: assistant_display_id)
+
+      contact = Fixtures.contact_fixture()
+
+      fields = %{
+        "organization_id" => organization_id,
+        "flow_id" => 1,
+        "contact_id" => contact.id,
+        "assistant_id" => assistant_display_id,
+        "speech" => "https://example.com/audio.ogg",
+        "source_language" => "english",
+        "target_language" => "hindi",
+        "webhook_log_id" => 1,
+        "result_name" => "result"
+      }
+
+      Tesla.Mock.mock(fn
+        %Tesla.Env{method: :get, url: "https://example.com/audio.ogg"} ->
+          %Tesla.Env{status: 200, body: "fake-audio-bytes"}
+
+        %Tesla.Env{method: :post, url: url} ->
+          cond do
+            String.contains?(url, "generativelanguage.googleapis.com") ->
+              %Tesla.Env{
+                status: 200,
+                body: %{
+                  candidates: [
+                    %{content: %{parts: [%{text: Jason.encode!("Hello world")}]}}
+                  ],
+                  usageMetadata: %{totalTokenCount: 10}
+                }
+              }
+
+            String.contains?(url, "/api/v1/llm/call") ->
+              %Tesla.Env{status: 503, body: %{"error" => "kaapi unavailable"}}
+
+            true ->
+              %Tesla.Env{status: 200, body: %{}}
+          end
+      end)
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result =
+            CommonWebhook.webhook("unified-voice-llm-call", fields, unified_llm_headers())
+
+          assert result.success == false
+          assert result.http_status == 503
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.webhook_name == "unified-voice-llm-call"
+      assert tags.http_status == 503
+    end
   end
 end

--- a/test/glific_web/flows/flow_resume_controller_test.exs
+++ b/test/glific_web/flows/flow_resume_controller_test.exs
@@ -765,7 +765,8 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
         "timestamp" => timestamp,
         "webhook_log_id" => webhook_log.id,
         "result_name" => "result",
-        "message" => "Voice answer"
+        "message" => "Voice answer",
+        "webhook_name" => "unified-voice-llm-call"
       }
 
       result = %{
@@ -799,6 +800,7 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
       assert %SystemError{} = exception
       assert Exception.message(exception) == "Webhook callback failure"
       assert tags.organization_id == organization_id
+      assert tags.webhook_name == "unified-voice-llm-call"
       assert tags.flow_id == flow.id
       assert tags.contact_id == contact.id
       assert tags.webhook_log_id == webhook_log.id

--- a/test/glific_web/flows/flow_resume_controller_test.exs
+++ b/test/glific_web/flows/flow_resume_controller_test.exs
@@ -7,6 +7,7 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
     Fixtures,
     Flows.Flow,
     Flows.FlowContext,
+    Flows.Webhook.SystemError,
     Seeds.SeedsDev
   }
 
@@ -736,6 +737,75 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
                )
     end
 
+    test "do_voice_flow_resume reports SystemError when callback says success=false", %{
+      conn: %{assigns: %{organization_id: organization_id}} = _conn
+    } do
+      contact = Fixtures.contact_fixture()
+      webhook_log = Fixtures.webhook_log_fixture(%{organization_id: organization_id})
+      timestamp = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+      flow = Flow.get_loaded_flow(organization_id, "published", %{keyword: "call_and_wait"})
+      [node | _tail] = flow.nodes
+
+      signature_payload = %{
+        "organization_id" => organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp
+      }
+
+      signature =
+        Glific.signature(organization_id, Jason.encode!(signature_payload), timestamp)
+
+      response = %{
+        "organization_id" => organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "signature" => signature,
+        "timestamp" => timestamp,
+        "webhook_log_id" => webhook_log.id,
+        "result_name" => "result",
+        "message" => "Voice answer"
+      }
+
+      result = %{
+        "success" => false,
+        "reason" => "LLM provider timed out",
+        "error_type" => "timeout"
+      }
+
+      {:ok, _context} =
+        FlowContext.create_flow_context(%{
+          contact_id: contact.id,
+          flow_id: flow.id,
+          flow_uuid: flow.uuid,
+          uuid_map: %{},
+          organization_id: organization_id,
+          wakeup_at: DateTime.add(DateTime.utc_now(), 60),
+          is_await_result: true,
+          node_uuid: node.uuid
+        })
+
+      {exception, tags} =
+        capture_appsignal(fn ->
+          assert :ok =
+                   FlowResumeController.do_voice_flow_resume(
+                     organization_id,
+                     result,
+                     response
+                   )
+        end)
+
+      assert %SystemError{} = exception
+      assert Exception.message(exception) == "Webhook callback failure"
+      assert tags.organization_id == organization_id
+      assert tags.flow_id == flow.id
+      assert tags.contact_id == contact.id
+      assert tags.webhook_log_id == webhook_log.id
+      assert tags.error_type == "timeout"
+      assert tags.reason == "LLM provider timed out"
+    end
+
     test "returns 200 when TTS audio upload fails (bad base64)", %{
       conn: %{assigns: %{organization_id: organization_id}} = conn
     } do
@@ -797,5 +867,45 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
       conn = post(conn, "/webhook/flow_resume", params)
       assert json_response(conn, 200) == ""
     end
+  end
+
+  defp capture_appsignal(fun) do
+    test_pid = self()
+
+    with_mocks([
+      {Appsignal, [:passthrough],
+       [
+         send_error: fn ex, _stack, configurator ->
+           send(test_pid, {:appsignal_exception, ex})
+           configurator.(:fake_span)
+           :ok
+         end
+       ]},
+      {Appsignal.Span, [:passthrough],
+       [
+         set_sample_data: fn _span, key, value ->
+           send(test_pid, {:appsignal_tag, key, value})
+           :fake_span
+         end
+       ]}
+    ]) do
+      fun.()
+    end
+
+    exception =
+      receive do
+        {:appsignal_exception, ex} -> ex
+      after
+        100 -> flunk("Appsignal.send_error was not called")
+      end
+
+    tags =
+      receive do
+        {:appsignal_tag, "tags", t} -> t
+      after
+        100 -> %{}
+      end
+
+    {exception, tags}
   end
 end


### PR DESCRIPTION
## Summary
 Target issue is #5122 
  - Wrap `speech_to_text_with_bhasini` so Bhasini validation failures (e.g. invalid media URL) return a structured `%{success: false}` and surface as SystemError under webhook_name speech_to_text_with_bhasini instead of leaking a bare error string that crashed unified-voice-llm-call's case with CaseClauseError.
  - Wrap the LLM dispatch step inside unified-voice-llm-call so  Kaapi-side dispatch failures (auth, invalid assistant, recv_timeout, callback-URL rejection) report under webhook_name unified-voice-llm-call. Async callback failures continue to be reported from the resume controller.
