### PR TITLE
ci: Configure Dependabot for 'mix' package ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "mix"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Removed comments and added support for 'mix' package ecosystem. We want to retire Snyk and enable dependabot for vulnerability updates. Using [dependabot suggested configuration](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-) for the setup. 
