### PR TITLE
Track the webhook failures for parse_via_chatGPT and parse_via_gpt_vision

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -118,6 +118,8 @@ config :glific,
 config :glific,
   open_ai: env!("OPEN_AI_KEY", :string!, "This is not a secret")
 
+config :glific, Glific.OpenAI.ChatGPT, gpt_model: env!("OPEN_AI_MODEL", :string, "gpt-5.1")
+
 config :glific,
   gemini_api_key: env!("GEMINI_API_KEY", :string!, "This is not a secret")
 

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -257,20 +257,25 @@ defmodule Glific.Clients.CommonWebhook do
   """
   @spec webhook(String.t(), map()) :: map()
   def webhook("parse_via_chat_gpt", fields) do
-    with {:ok, fields} <- parse_chatgpt_fields(fields),
-         {:ok, fields} <- parse_response_format(fields),
-         {:ok, text} <- Glific.get_open_ai_key() |> ChatGPT.parse(fields) do
-      %{
-        success: true,
-        parsed_msg: parse_gpt_response(text)
-      }
-    else
-      {:error, error} ->
+    org_id = parse_org_id(fields)
+
+    with_failure_reporting("parse_via_chat_gpt", org_id, fn ->
+      with {:ok, fields} <- parse_chatgpt_fields(fields),
+           {:ok, fields} <- parse_response_format(fields),
+           {:ok, text} <- Glific.get_open_ai_key() |> ChatGPT.parse(fields) do
         %{
-          success: false,
-          parsed_msg: error
+          success: true,
+          parsed_msg: parse_gpt_response(text)
         }
-    end
+      else
+        {:error, error} ->
+          %{
+            success: false,
+            parsed_msg: error,
+            reason: if(is_binary(error), do: error, else: inspect(error))
+          }
+      end
+    end)
   end
 
   def webhook("voice-filesearch-gpt", fields) do
@@ -291,20 +296,30 @@ defmodule Glific.Clients.CommonWebhook do
   @spec webhook(String.t(), map()) :: any()
   def webhook("parse_via_gpt_vision", fields) do
     url = fields["url"]
-    # validating if the url passed is a valid image url
-    with %{is_valid: true} <- Glific.Messages.validate_media(url, "image"),
-         {:ok, fields} <- parse_response_format(fields),
-         {:ok, response} <- ChatGPT.gpt_vision(fields) do
-      %{success: true, response: parse_gpt_response(response)}
-    else
-      %{is_valid: false, message: message} ->
-        Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{message}")
-        message
+    org_id = parse_org_id(fields)
 
-      {:error, error} ->
-        Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{error}")
-        error
-    end
+    # Failures return a bare string (not %{success: false}) so the flow routes
+    # to the "Failure" category (handle/3 keys off is_map). We keep that shape
+    # and report explicitly — the wrapper here only covers unexpected exceptions.
+    with_failure_reporting("parse_via_gpt_vision", org_id, fn ->
+      # validating if the url passed is a valid image url
+      with %{is_valid: true} <- Glific.Messages.validate_media(url, "image"),
+           {:ok, fields} <- parse_response_format(fields),
+           {:ok, response} <- ChatGPT.gpt_vision(fields) do
+        %{success: true, response: parse_gpt_response(response)}
+      else
+        %{is_valid: false, message: message} ->
+          Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{message}")
+          report_webhook_failure("parse_via_gpt_vision", org_id, nil, message)
+          message
+
+        {:error, error} ->
+          reason = if is_binary(error), do: error, else: inspect(error)
+          Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{reason}")
+          report_webhook_failure("parse_via_gpt_vision", org_id, nil, reason)
+          error
+      end
+    end)
   end
 
   def webhook("filesearch-gpt", fields) do
@@ -712,6 +727,16 @@ defmodule Glific.Clients.CommonWebhook do
     end
   end
 
+  # Best-effort org_id for failure reporting tags. Returns nil if absent/unparseable
+  # rather than raising, since it's only used for the AppSignal tag.
+  @spec parse_org_id(map()) :: non_neg_integer() | nil
+  defp parse_org_id(fields) do
+    case Glific.parse_maybe_integer(fields["organization_id"]) do
+      {:ok, id} -> id
+      _ -> nil
+    end
+  end
+
   # Webhook param validation hook. Single check today; convert to a
   # short-circuiting `with` once there's more than one field to validate.
   @spec validate_params(map()) :: :ok | {:error, String.t()}
@@ -766,7 +791,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
+    callback_url = "https://b0e0-103-91-135-178.ngrok-free.app" <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -299,8 +299,7 @@ defmodule Glific.Clients.CommonWebhook do
     org_id = parse_org_id(fields)
 
     # Failures return a bare string (not %{success: false}) so the flow routes
-    # to the "Failure" category (lib/glific/flows/webhook.ex:527 keys off is_map).
-    # We keep that shape and report explicitly
+    # to the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
     with_failure_reporting("parse_via_gpt_vision", org_id, fn ->
       # validating if the url passed is a valid image url
       with %{is_valid: true} <- Glific.Messages.validate_media(url, "image"),
@@ -309,14 +308,9 @@ defmodule Glific.Clients.CommonWebhook do
         %{success: true, response: parse_gpt_response(response)}
       else
         %{is_valid: false, message: message} ->
-          Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{message}")
-          report_webhook_failure("parse_via_gpt_vision", org_id, nil, message)
           message
 
         {:error, error} ->
-          reason = if is_binary(error), do: error, else: inspect(error)
-          Logger.error("OpenAI GPTVision failed for URL: #{url} with error: #{reason}")
-          report_webhook_failure("parse_via_gpt_vision", org_id, nil, reason)
           error
       end
     end)
@@ -946,10 +940,19 @@ defmodule Glific.Clients.CommonWebhook do
       reraise exception, __STACKTRACE__
   end
 
-  @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer()) :: :ok
+  @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer() | nil) :: :ok
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)
     report_webhook_failure(webhook_name, org_id, status, reason)
+  end
+
+  # nil / non-map results route to the flow's Failure category (see
+  # Glific.Flows.Webhook.handle/3, which keys off is_map). Treat them as
+  # failures here too
+  defp maybe_report_webhook_failure(result, webhook_name, org_id)
+       when is_nil(result) or not is_map(result) do
+    reason = if is_binary(result), do: result, else: inspect(result)
+    report_webhook_failure(webhook_name, org_id, nil, reason)
   end
 
   defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -791,7 +791,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = "https://b0e0-103-91-135-178.ngrok-free.app" <> callback_path
+    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -269,11 +269,7 @@ defmodule Glific.Clients.CommonWebhook do
         }
       else
         {:error, error} ->
-          %{
-            success: false,
-            parsed_msg: error,
-            reason: if(is_binary(error), do: error, else: inspect(error))
-          }
+          error
       end
     end)
   end

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -299,8 +299,8 @@ defmodule Glific.Clients.CommonWebhook do
     org_id = parse_org_id(fields)
 
     # Failures return a bare string (not %{success: false}) so the flow routes
-    # to the "Failure" category (handle/3 keys off is_map). We keep that shape
-    # and report explicitly — the wrapper here only covers unexpected exceptions.
+    # to the "Failure" category (lib/glific/flows/webhook.ex:527 keys off is_map).
+    # We keep that shape and report explicitly
     with_failure_reporting("parse_via_gpt_vision", org_id, fn ->
       # validating if the url passed is a valid image url
       with %{is_valid: true} <- Glific.Messages.validate_media(url, "image"),

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -805,18 +805,17 @@ defmodule Glific.Flows.Webhook do
   end
 
   defp with_failure_reporting(webhook_name, organization_id, fun) do
-    try do
-      fun.()
-    rescue
-      exception ->
-        %SystemError{message: "Webhook system_error from #{webhook_name}"}
-        |> report_to_appsignal(%{
-          organization_id: organization_id,
-          webhook_name: webhook_name,
-          reason: Exception.message(exception)
-        })
-        reraise exception, __STACKTRACE__
-    end
+    fun.()
+  rescue
+    exception ->
+      %SystemError{message: "Webhook system_error from #{webhook_name}"}
+      |> report_to_appsignal(%{
+        organization_id: organization_id,
+        webhook_name: webhook_name,
+        reason: Exception.message(exception)
+      })
+
+      reraise exception, __STACKTRACE__
   end
 
   @spec update_context_for_wait(FlowContext.t(), integer()) ::

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -799,7 +799,24 @@ defmodule Glific.Flows.Webhook do
   @spec execute_unified_voice_filesearch(Action.t(), FlowContext.t()) ::
           {:ok | :wait, FlowContext.t(), [Message.t()]}
   def execute_unified_voice_filesearch(action, context) do
-    unified_llm_and_wait(action, context, "unified-voice-llm-call")
+    with_failure_reporting("unified-voice-llm-call", context.organization_id, fn ->
+      unified_llm_and_wait(action, context, "unified-voice-llm-call")
+    end)
+  end
+
+  defp with_failure_reporting(webhook_name, organization_id, fun) do
+    try do
+      fun.()
+    rescue
+      exception ->
+        %SystemError{message: "Webhook system_error from #{webhook_name}"}
+        |> report_to_appsignal(%{
+          organization_id: organization_id,
+          webhook_name: webhook_name,
+          reason: Exception.message(exception)
+        })
+        reraise exception, __STACKTRACE__
+    end
   end
 
   @spec update_context_for_wait(FlowContext.t(), integer()) ::

--- a/lib/glific/third_party/openAI/chatGPT.ex
+++ b/lib/glific/third_party/openAI/chatGPT.ex
@@ -11,12 +11,14 @@ defmodule Glific.OpenAI.ChatGPT do
   @endpoint "https://api.openai.com/v1"
 
   @default_params %{
-    "model" => "gpt-4o",
     "temperature" => 0.7,
     "top_p" => 1,
     "frequency_penalty" => 0,
     "presence_penalty" => 0
   }
+
+  @spec gpt_model() :: String.t()
+  defp gpt_model, do: Application.fetch_env!(:glific, __MODULE__)[:gpt_model]
 
   @doc """
   API call to GPT for translation with text only
@@ -42,7 +44,7 @@ defmodule Glific.OpenAI.ChatGPT do
       @default_params
       |> Map.merge(%{
         "messages" => add_prompt(params),
-        "model" => params["model"],
+        "model" => params["model"] || gpt_model(),
         "temperature" => params["temperature"],
         "response_format" => params["response_format"]
       })
@@ -86,7 +88,7 @@ defmodule Glific.OpenAI.ChatGPT do
   def gpt_vision(params \\ %{}) do
     url = @endpoint <> "/chat/completions"
     api_key = Glific.get_open_ai_key()
-    model = Map.get(params, "model", "gpt-4-turbo")
+    model = Map.get(params, "model", gpt_model())
 
     data =
       %{

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -2060,4 +2060,63 @@ defmodule Glific.Flows.CommonWebhookTest do
     assert tags.http_status == 200
     assert tags.reason =~ "empty"
   end
+
+  describe "parse_via_chat_gpt / parse_via_gpt_vision failure reporting" do
+    test "reports SystemError when parse_via_chat_gpt fails" do
+      # empty question_text fails in parse_chatgpt_fields, before any OpenAI call
+      {exception, tags} =
+        capture_appsignal(fn ->
+          result = CommonWebhook.webhook("parse_via_chat_gpt", %{"organization_id" => 1})
+          # return shape unchanged — still a %{success: false} map
+          assert result.success == false
+          assert result.parsed_msg == "question_text is empty"
+        end)
+
+      assert %SystemError{} = exception
+      assert tags.webhook_name == "parse_via_chat_gpt"
+      assert tags.organization_id == 1
+      assert tags.reason == "question_text is empty"
+    end
+
+    test "reports SystemError when parse_via_gpt_vision fails on invalid response_format" do
+      fields = %{
+        "organization_id" => 1,
+        "url" => "https://example.com/image.jpg",
+        "response_format" => %{"type" => "json_objectz"}
+      }
+
+      with_mock(Messages, validate_media: fn _, _ -> %{is_valid: true, message: "success"} end) do
+        {exception, tags} =
+          capture_appsignal(fn ->
+            result = CommonWebhook.webhook("parse_via_gpt_vision", fields)
+            # bare-string return preserved (routes to the flow's Failure category)
+            assert result == "response_format type should be json_schema or json_object"
+          end)
+
+        assert %SystemError{} = exception
+        assert tags.webhook_name == "parse_via_gpt_vision"
+        assert tags.organization_id == 1
+        assert tags.reason == "response_format type should be json_schema or json_object"
+      end
+    end
+
+    test "reports SystemError when parse_via_gpt_vision fails on invalid media URL" do
+      fields = %{"organization_id" => 1, "url" => "not-an-image"}
+
+      with_mock(Messages,
+        validate_media: fn _, _ -> %{is_valid: false, message: "Media URL is invalid"} end
+      ) do
+        {exception, tags} =
+          capture_appsignal(fn ->
+            result = CommonWebhook.webhook("parse_via_gpt_vision", fields)
+            assert result == "Media URL is invalid"
+          end)
+
+        assert %SystemError{} = exception
+        assert tags.webhook_name == "parse_via_gpt_vision"
+        assert tags.organization_id == 1
+        assert tags.reason == "Media URL is invalid"
+      end
+    end
+  end
 end

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -441,7 +441,7 @@ defmodule Glific.Flows.CommonWebhookTest do
   end
 
   test "parse_via_chat_gpt, failed due to empty question_text" do
-    assert %{success: false, parsed_msg: "question_text is empty"} =
+    assert "question_text is empty" =
              CommonWebhook.webhook("parse_via_chat_gpt", %{})
   end
 
@@ -450,7 +450,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "question_text" => ""
     }
 
-    assert %{success: false, parsed_msg: "question_text is empty"} =
+    assert "question_text is empty" =
              CommonWebhook.webhook("parse_via_chat_gpt", fields)
   end
 
@@ -2063,13 +2063,12 @@ defmodule Glific.Flows.CommonWebhookTest do
 
   describe "parse_via_chat_gpt / parse_via_gpt_vision failure reporting" do
     test "reports SystemError when parse_via_chat_gpt fails" do
-      # empty question_text fails in parse_chatgpt_fields, before any OpenAI call
       {exception, tags} =
         capture_appsignal(fn ->
-          result = CommonWebhook.webhook("parse_via_chat_gpt", %{"organization_id" => 1})
-          # return shape unchanged — still a %{success: false} map
-          assert result.success == false
-          assert result.parsed_msg == "question_text is empty"
+          result =
+            CommonWebhook.webhook("parse_via_chat_gpt", %{"organization_id" => 1})
+
+          assert result == "question_text is empty"
         end)
 
       assert %SystemError{} = exception

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -2,6 +2,8 @@ defmodule Glific.Flows.WebhookTest do
   use Glific.DataCase, async: true
   use Oban.Pro.Testing, repo: Glific.Repo
 
+  import Mock
+
   alias Glific.Flows.{
     Action,
     FlowContext,
@@ -12,6 +14,7 @@ defmodule Glific.Flows.WebhookTest do
 
   alias Glific.{
     Fixtures,
+    Partners,
     Seeds.SeedsDev
   }
 
@@ -626,5 +629,66 @@ defmodule Glific.Flows.WebhookTest do
     [job] = all_enqueued(worker: Webhook, prefix: "global")
     assert job.queue == "gpt_webhook_queue"
     assert job.priority == 2
+  end
+
+  describe "execute_unified_voice_filesearch/2 failure reporting" do
+    setup do
+      {:ok, _credential} =
+        Partners.create_credential(%{
+          organization_id: 1,
+          shortcode: "kaapi",
+          keys: %{},
+          secrets: %{"api_key" => "sk_test_key"},
+          is_active: true
+        })
+
+      Partners.get_organization!(1) |> Partners.fill_cache()
+      :ok
+    end
+
+    test "catches a raised exception, reports it to AppSignal, and reraises it" do
+      test_pid = self()
+
+      # With Kaapi creds present, unified_llm_and_wait injects the API key via
+      # Map.put(action.headers, ...). A nil headers map raises BadMapError -- exactly
+      # the kind of unexpected failure with_failure_reporting must catch and report.
+      action = %Action{headers: nil, method: "FUNCTION", url: "voice-filesearch-gpt", body: "{}"}
+      context = %FlowContext{organization_id: 1}
+
+      with_mocks([
+        {Appsignal, [:passthrough],
+         [
+           send_error: fn exception, _stack, configurator ->
+             send(test_pid, {:appsignal_exception, exception})
+             configurator.(:fake_span)
+             :ok
+           end
+         ]},
+        {Appsignal.Span, [:passthrough],
+         [
+           set_sample_data: fn _span, key, value ->
+             send(test_pid, {:appsignal_tag, key, value})
+             :fake_span
+           end
+         ]}
+      ]) do
+        # The original exception is reraised after the failure is reported.
+        assert_raise BadMapError, fn ->
+          Webhook.execute_unified_voice_filesearch(action, context)
+        end
+      end
+
+      # A low-cardinality SystemError is reported so AppSignal groups these failures.
+      assert_receive {:appsignal_exception,
+                      %Webhook.SystemError{
+                        message: "Webhook system_error from unified-voice-llm-call"
+                      }}
+
+      # Per-occurrence detail is attached as AppSignal tags, not on the struct.
+      assert_receive {:appsignal_tag, "tags", tags}
+      assert tags.organization_id == 1
+      assert tags.webhook_name == "unified-voice-llm-call"
+      assert tags.reason =~ "map"
+    end
   end
 end


### PR DESCRIPTION

## Summary
 Target issue is #5129
Extend webhook failure reporting (same as the async webhooks) to the two synchronous OpenAI webhooks so their failures surface as SystemError in the flow_webhooks namespace, tagged per webhook_name.

  - parse_via_chat_gpt: wrap in with_failure_reporting. It already returns `%{success: false}`, so failures are auto-reported via `maybe_report_webhook_failure`; added a `reason` tag for clean AppSignal samples. Return shape unchanged.

  - parse_via_gpt_vision: keep the bare-string error returns (they route to the flow's Failure category via handle/3's is_map check — turning them into maps would flip routing to Success), so report explicitly with `report_webhook_failure` in each error branch. Wrap in `with_failure_reporting` only to catch unexpected exceptions.

  - Add parse_org_id/1 helper for the org tag.

Both changes are reporting-only: return values and flow routing are unchanged, so no user-facing behavior change. Exceptions are caught and reported (and reraised) for both.