### PR TITLE
Track webhook node success/failure counts in AppSignal

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -751,7 +751,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
+    callback_url = "https://5150-103-91-135-178.ngrok-free.app" <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,
@@ -849,7 +849,7 @@ defmodule Glific.Clients.CommonWebhook do
   rescue
     exception ->
       report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
-      Webhook.track_webhook_count(webhook_name, org_id, "failure")
+      Webhook.track_webhook_count(webhook_name, "failure")
       reraise exception, __STACKTRACE__
   end
 
@@ -857,7 +857,7 @@ defmodule Glific.Clients.CommonWebhook do
   defp record_webhook_outcome(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)
     report_webhook_failure(webhook_name, org_id, status, reason)
-    Webhook.track_webhook_count(webhook_name, org_id, "failure")
+    Webhook.track_webhook_count(webhook_name, "failure")
   end
 
   # nil / non-map results route to the flow's Failure category (see
@@ -867,14 +867,14 @@ defmodule Glific.Clients.CommonWebhook do
        when is_nil(result) or not is_map(result) do
     reason = if is_binary(result), do: result, else: inspect(result)
     report_webhook_failure(webhook_name, org_id, nil, reason)
-    Webhook.track_webhook_count(webhook_name, org_id, "failure")
+    Webhook.track_webhook_count(webhook_name, "failure")
   end
 
   # Success. For async webhooks this is only the dispatch ack, so we skip it and
   # let the callback record the real outcome; sync webhooks are terminal here.
-  defp record_webhook_outcome(_result, webhook_name, org_id) do
+  defp record_webhook_outcome(_result, webhook_name, _org_id) do
     unless webhook_name in @async_webhooks,
-      do: Webhook.track_webhook_count(webhook_name, org_id, "success")
+      do: Webhook.track_webhook_count(webhook_name, "success")
 
     :ok
   end

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -853,7 +853,6 @@ defmodule Glific.Clients.CommonWebhook do
       reraise exception, __STACKTRACE__
   end
 
-  # Reports failures to AppSignal and bumps the success/failure counter.
   @spec record_webhook_outcome(any(), String.t(), non_neg_integer() | nil) :: :ok
   defp record_webhook_outcome(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -870,17 +870,22 @@ defmodule Glific.Clients.CommonWebhook do
   # (GlificWeb.Flows.FlowResumeController) to avoid double counting.
   @async_webhooks ~w(speech_to_text text_to_speech unified-llm-call unified-voice-llm-call)
 
-  # Wraps a webhook entry point body so any failure — predictable
   @spec with_failure_reporting(String.t(), non_neg_integer() | nil, (-> any())) :: any()
   defp with_failure_reporting(webhook_name, org_id, fun) do
-    result = fun.()
-    record_webhook_outcome(result, webhook_name, org_id)
-    result
-  rescue
-    exception ->
-      report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
-      Webhook.track_webhook_count(webhook_name, "failure")
-      reraise exception, __STACKTRACE__
+    start = System.monotonic_time(:millisecond)
+
+    try do
+      result = fun.()
+      duration_ms = System.monotonic_time(:millisecond) - start
+      record_webhook_outcome(result, webhook_name, org_id, duration_ms)
+      result
+    rescue
+      exception ->
+        duration_ms = System.monotonic_time(:millisecond) - start
+        report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
+        record_webhook_metrics(webhook_name, "failure", duration_ms)
+        reraise exception, __STACKTRACE__
+    end
   end
 
   # FUNCTION webhooks signal Failure to the flow by returning a non-map (see
@@ -901,29 +906,35 @@ defmodule Glific.Clients.CommonWebhook do
 
   defp normalize_failure(result), do: result
 
-  @spec record_webhook_outcome(any(), String.t(), non_neg_integer() | nil) :: :ok
-  defp record_webhook_outcome(%{success: false} = result, webhook_name, org_id) do
+  @spec record_webhook_outcome(any(), String.t(), non_neg_integer() | nil, non_neg_integer()) ::
+          :ok
+  defp record_webhook_outcome(%{success: false} = result, webhook_name, org_id, duration_ms) do
     {status, reason} = extract_status_and_reason(result)
     report_webhook_failure(webhook_name, org_id, status, reason)
-    Webhook.track_webhook_count(webhook_name, "failure")
+    record_webhook_metrics(webhook_name, "failure", duration_ms)
   end
 
   # nil / non-map results route to the flow's Failure category (see
   # Glific.Flows.Webhook.handle/3, which keys off is_map). Treat them as
   # failures here too
-  defp record_webhook_outcome(result, webhook_name, org_id)
+  defp record_webhook_outcome(result, webhook_name, org_id, duration_ms)
        when is_nil(result) or not is_map(result) do
     reason = if is_binary(result), do: result, else: inspect(result)
     report_webhook_failure(webhook_name, org_id, nil, reason)
-    Webhook.track_webhook_count(webhook_name, "failure")
+    record_webhook_metrics(webhook_name, "failure", duration_ms)
   end
 
-  # Success. For async webhooks this is only the dispatch ack, so we skip it and
-  # let the callback record the real outcome; sync webhooks are terminal here.
-  defp record_webhook_outcome(_result, webhook_name, _org_id) do
+  defp record_webhook_outcome(_result, webhook_name, _org_id, duration_ms) do
     unless webhook_name in @async_webhooks,
-      do: Webhook.track_webhook_count(webhook_name, "success")
+      do: record_webhook_metrics(webhook_name, "success", duration_ms)
 
+    :ok
+  end
+
+  @spec record_webhook_metrics(String.t() | nil, String.t(), non_neg_integer()) :: :ok
+  defp record_webhook_metrics(webhook_name, status, duration_ms) do
+    Webhook.track_webhook_count(webhook_name, status)
+    Webhook.track_webhook_latency(webhook_name, status, duration_ms)
     :ok
   end
 

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -835,34 +835,50 @@ defmodule Glific.Clients.CommonWebhook do
   defp fetch_kaapi_uuid(%{kaapi_uuid: nil}), do: {:error, :missing_kaapi_uuid}
   defp fetch_kaapi_uuid(%{kaapi_uuid: uuid}), do: {:ok, uuid}
 
+  # Webhooks whose real outcome arrives later via a flow_resume callback. Here we
+  # only see the dispatch ack, so their success is counted at the callback
+  # (GlificWeb.Flows.FlowResumeController) to avoid double counting.
+  @async_webhooks ~w(speech_to_text text_to_speech unified-llm-call unified-voice-llm-call)
+
   # Wraps a webhook entry point body so any failure — predictable
   @spec with_failure_reporting(String.t(), non_neg_integer() | nil, (-> any())) :: any()
   defp with_failure_reporting(webhook_name, org_id, fun) do
     result = fun.()
-    maybe_report_webhook_failure(result, webhook_name, org_id)
+    record_webhook_outcome(result, webhook_name, org_id)
     result
   rescue
     exception ->
       report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
+      Webhook.track_webhook_count(webhook_name, org_id, "failure")
       reraise exception, __STACKTRACE__
   end
 
-  @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer() | nil) :: :ok
-  defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do
+  # Reports failures to AppSignal and bumps the success/failure counter.
+  @spec record_webhook_outcome(any(), String.t(), non_neg_integer() | nil) :: :ok
+  defp record_webhook_outcome(%{success: false} = result, webhook_name, org_id) do
     {status, reason} = extract_status_and_reason(result)
     report_webhook_failure(webhook_name, org_id, status, reason)
+    Webhook.track_webhook_count(webhook_name, org_id, "failure")
   end
 
   # nil / non-map results route to the flow's Failure category (see
   # Glific.Flows.Webhook.handle/3, which keys off is_map). Treat them as
   # failures here too
-  defp maybe_report_webhook_failure(result, webhook_name, org_id)
+  defp record_webhook_outcome(result, webhook_name, org_id)
        when is_nil(result) or not is_map(result) do
     reason = if is_binary(result), do: result, else: inspect(result)
     report_webhook_failure(webhook_name, org_id, nil, reason)
+    Webhook.track_webhook_count(webhook_name, org_id, "failure")
   end
 
-  defp maybe_report_webhook_failure(_result, _webhook_name, _org_id), do: :ok
+  # Success. For async webhooks this is only the dispatch ack, so we skip it and
+  # let the callback record the real outcome; sync webhooks are terminal here.
+  defp record_webhook_outcome(_result, webhook_name, org_id) do
+    unless webhook_name in @async_webhooks,
+      do: Webhook.track_webhook_count(webhook_name, org_id, "success")
+
+    :ok
+  end
 
   @spec extract_status_and_reason(map()) :: {integer() | nil, String.t() | nil}
   defp extract_status_and_reason(result) do

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -751,7 +751,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     organization = Partners.organization(organization_id)
 
-    callback_url = "https://5150-103-91-135-178.ngrok-free.app" <> callback_path
+    callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
 
     request_metadata = %{
       organization_id: organization_id,

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -1180,7 +1180,7 @@ defmodule Glific.Flows.FlowContext do
 
       if webhook_log do
         Webhook.update_log(webhook_log.id, "Timeout: taking long to process response")
-        track_timeout_metrics(flow, context, webhook_log)
+        track_timeout_metrics(flow, context)
       end
 
       Messages.create_temp_message(context.organization_id, "Failure")
@@ -1189,14 +1189,12 @@ defmodule Glific.Flows.FlowContext do
     end
   end
 
-  # A timed-out async webhook node never reaches the flow_resume callback, so its
-  # failure count + latency are emitted here
-  @spec track_timeout_metrics(Flow.t(), FlowContext.t(), WebhookLog.t()) :: :ok
-  defp track_timeout_metrics(flow, context, webhook_log) do
+  # A timed-out async webhook node never reaches the flow_resume callback, so
+  # its failure count is emitted here.
+  @spec track_timeout_metrics(Flow.t(), FlowContext.t()) :: :ok
+  defp track_timeout_metrics(flow, context) do
     webhook_url = async_webhook_url(flow, context)
-    duration_ms = DateTime.diff(DateTime.utc_now(), webhook_log.inserted_at, :millisecond)
     Webhook.track_webhook_count(webhook_url, "failure")
-    Webhook.track_webhook_latency(webhook_url, "failure", duration_ms)
   end
 
   # Async webhook URLs whose flow node parks the flow waiting for a Kaapi

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -1180,12 +1180,23 @@ defmodule Glific.Flows.FlowContext do
 
       if webhook_log do
         Webhook.update_log(webhook_log.id, "Timeout: taking long to process response")
+        track_timeout_metrics(flow, context, webhook_log)
       end
 
       Messages.create_temp_message(context.organization_id, "Failure")
     else
       Messages.create_temp_message(context.organization_id, "No Response")
     end
+  end
+
+  # A timed-out async webhook node never reaches the flow_resume callback, so its
+  # failure count + latency are emitted here
+  @spec track_timeout_metrics(Flow.t(), FlowContext.t(), WebhookLog.t()) :: :ok
+  defp track_timeout_metrics(flow, context, webhook_log) do
+    webhook_url = async_webhook_url(flow, context)
+    duration_ms = DateTime.diff(DateTime.utc_now(), webhook_log.inserted_at, :millisecond)
+    Webhook.track_webhook_count(webhook_url, "failure")
+    Webhook.track_webhook_latency(webhook_url, "failure", duration_ms)
   end
 
   # Async webhook URLs whose flow node parks the flow waiting for a Kaapi

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -90,6 +90,22 @@ defmodule Glific.Flows.Webhook do
     :ok
   end
 
+  @doc """
+  Increment a counter for a flow-webhook node outcome so success/failure ratios
+  can be computed per webhook node and organization. `status` is "success" or
+  "failure".
+  """
+  @spec track_webhook_count(String.t() | nil, non_neg_integer() | nil, String.t()) :: :ok
+  def track_webhook_count(webhook_name, organization_id, status) do
+    Appsignal.increment_counter("flow_webhook_count", 1, %{
+      webhook_name: webhook_name || "unknown",
+      organization_id: organization_id,
+      status: status
+    })
+
+    :ok
+  end
+
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do
     now = System.system_time(:second)

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -558,9 +558,8 @@ defmodule Glific.Flows.Webhook do
   # in the Oban queue wait as well as the HTTP round trip.
   @spec track_sync_metrics(String.t(), String.t(), non_neg_integer(), any()) :: :ok
   defp track_sync_metrics(method, url, webhook_log_id, result) do
-    status = if is_nil(result), do: "failure", else: "success"
+    status = if is_map(result), do: "success", else: "failure"
     name = webhook_name(method, url)
-
     track_webhook_count(name, status)
 
     case Repo.get(WebhookLog, webhook_log_id) do

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -109,6 +109,30 @@ defmodule Glific.Flows.Webhook do
     :ok
   end
 
+  @doc """
+  Records end-to-end latency for a webhook node execution as an AppSignal
+  distribution (so p50/p95/p99 can be charted). Generic across all node types
+  """
+  @spec track_webhook_latency(String.t() | nil, String.t(), number()) :: :ok
+  def track_webhook_latency(webhook_name, status, duration_ms) do
+    Appsignal.add_distribution_value("flow_webhook_latency", duration_ms, %{
+      webhook_name: webhook_name || "unknown",
+      status: status
+    })
+
+    :ok
+  end
+
+  @spec webhook_name(String.t(), String.t()) :: String.t()
+  defp webhook_name("function", function), do: function
+
+  defp webhook_name(_method, url) do
+    case URI.parse(url) do
+      %URI{host: host} when is_binary(host) -> host
+      _ -> "unknown"
+    end
+  end
+
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do
     now = System.system_time(:second)
@@ -522,7 +546,31 @@ defmodule Glific.Flows.Webhook do
           nil
       end
 
+    track_sync_metrics(method, url, webhook_log_id, result)
+
     handle(result, context, result_name)
+  end
+
+  # Emits the generic count + latency metrics for a sync webhook node. A nil
+  # result means the node did not get a usable response (non-2xx, undecodable
+  # body, or transport error) and counts as a failure. Latency is measured from
+  # node entry (webhook_log.inserted_at, set in create_log) to now, so it folds
+  # in the Oban queue wait as well as the HTTP round trip.
+  @spec track_sync_metrics(String.t(), String.t(), non_neg_integer(), any()) :: :ok
+  defp track_sync_metrics(method, url, webhook_log_id, result) do
+    status = if is_nil(result), do: "failure", else: "success"
+    name = webhook_name(method, url)
+
+    track_webhook_count(name, status)
+
+    case Repo.get(WebhookLog, webhook_log_id) do
+      %WebhookLog{inserted_at: inserted_at} ->
+        duration_ms = DateTime.diff(DateTime.utc_now(), inserted_at, :millisecond)
+        track_webhook_latency(name, status, duration_ms)
+
+      _ ->
+        :ok
+    end
   end
 
   @spec handle(String.t(), map(), String.t()) :: :ok

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -93,11 +93,6 @@ defmodule Glific.Flows.Webhook do
   @doc """
   Increment a counter for a flow-webhook node outcome so success/failure ratios
   can be computed per webhook node. `status` is "success" or "failure".
-
-  We deliberately do NOT tag by organization_id: AppSignal counter metrics are
-  queryable only by the exact emitted tag set (no wildcards), so a high-cardinality
-  org tag would force per-org enumeration and block aggregate charts. Per-org
-  failures remain visible via the `flow_webhooks` error reports.
   """
   @spec track_webhook_count(String.t() | nil, String.t()) :: :ok
   def track_webhook_count(webhook_name, status) do

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -123,16 +123,6 @@ defmodule Glific.Flows.Webhook do
     :ok
   end
 
-  @spec webhook_name(String.t(), String.t()) :: String.t()
-  defp webhook_name("function", function), do: function
-
-  defp webhook_name(_method, url) do
-    case URI.parse(url) do
-      %URI{host: host} when is_binary(host) -> host
-      _ -> "unknown"
-    end
-  end
-
   @spec add_signature(map() | nil, non_neg_integer, String.t()) :: map()
   defp add_signature(headers, organization_id, body) do
     now = System.system_time(:second)
@@ -566,31 +556,7 @@ defmodule Glific.Flows.Webhook do
           nil
       end
 
-    track_sync_metrics(method, url, webhook_log_id, result)
-
     handle(result, context, result_name)
-  end
-
-  # Emits the generic count + latency metrics for a sync webhook node. A nil
-  # result means the node did not get a usable response (non-2xx, undecodable
-  # body, or transport error) and counts as a failure. Latency is measured from
-  # node entry (webhook_log.inserted_at, set in create_log) to now, so it folds
-  # in the Oban queue wait as well as the HTTP round trip.
-  @spec track_sync_metrics(String.t(), String.t(), non_neg_integer(), any()) :: :ok
-  defp track_sync_metrics(method, url, webhook_log_id, result) do
-    status = if is_nil(result), do: "failure", else: "success"
-    name = webhook_name(method, url)
-
-    track_webhook_count(name, status)
-
-    case Repo.get(WebhookLog, webhook_log_id) do
-      %WebhookLog{inserted_at: inserted_at} ->
-        duration_ms = DateTime.diff(DateTime.utc_now(), inserted_at, :millisecond)
-        track_webhook_latency(name, status, duration_ms)
-
-      _ ->
-        :ok
-    end
   end
 
   @spec handle(String.t(), map(), String.t()) :: :ok

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -92,14 +92,17 @@ defmodule Glific.Flows.Webhook do
 
   @doc """
   Increment a counter for a flow-webhook node outcome so success/failure ratios
-  can be computed per webhook node and organization. `status` is "success" or
-  "failure".
+  can be computed per webhook node. `status` is "success" or "failure".
+
+  We deliberately do NOT tag by organization_id: AppSignal counter metrics are
+  queryable only by the exact emitted tag set (no wildcards), so a high-cardinality
+  org tag would force per-org enumeration and block aggregate charts. Per-org
+  failures remain visible via the `flow_webhooks` error reports.
   """
-  @spec track_webhook_count(String.t() | nil, non_neg_integer() | nil, String.t()) :: :ok
-  def track_webhook_count(webhook_name, organization_id, status) do
+  @spec track_webhook_count(String.t() | nil, String.t()) :: :ok
+  def track_webhook_count(webhook_name, status) do
     Appsignal.increment_counter("flow_webhook_count", 1, %{
       webhook_name: webhook_name || "unknown",
-      organization_id: organization_id,
       status: status
     })
 

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -63,7 +63,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
     track_kaapi_latency(response)
     maybe_report_callback_failure(result, response)
-    track_callback_outcome(result, response, organization_id)
+    track_callback_outcome(result, response)
 
     with true <- validate_request(organization_id, response),
          {:ok, contact} <-
@@ -151,7 +151,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
       track_kaapi_latency(response)
       maybe_report_callback_failure(result, response)
-      track_callback_outcome(result, response, organization_id)
+      track_callback_outcome(result, response)
 
       FlowContext.resume_contact_flow(
         contact,
@@ -249,10 +249,10 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
   defp track_kaapi_latency(_response), do: :ok
 
-  @spec track_callback_outcome(map(), map(), non_neg_integer()) :: :ok
-  defp track_callback_outcome(result, response, organization_id) do
+  @spec track_callback_outcome(map(), map()) :: :ok
+  defp track_callback_outcome(result, response) do
     status = if result["success"], do: "success", else: "failure"
-    Webhook.track_webhook_count(response["webhook_name"], organization_id, status)
+    Webhook.track_webhook_count(response["webhook_name"], status)
   end
 
   @spec validate_request(non_neg_integer(), map()) :: boolean()

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -249,7 +249,6 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
   defp track_kaapi_latency(_response), do: :ok
 
-  # Records the true success/failure of an async webhook node
   @spec track_callback_outcome(map(), map(), non_neg_integer()) :: :ok
   defp track_callback_outcome(result, response, organization_id) do
     status = if result["success"], do: "success", else: "failure"

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -303,12 +303,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
     maybe_report_callback_failure(result, response)
   end
 
-  # Records latency for an async webhook callback. Emits the kaapi-specific
-  # `kaapi_llm_latency` (by call_type) when a call_type is present, plus the
-  # generic `flow_webhook_latency` (by webhook_name + status) shared with sync
-  # nodes. `timestamp` is the (microsecond) request-initiation time threaded
-  # through the callback, so a callback that arrives after the flow already
-  # timed out still records its real, uncapped latency (tagged "failure").
+  # Records latency for an async webhook callback.
   @spec track_kaapi_latency(map(), String.t()) :: :ok
   defp track_kaapi_latency(%{"timestamp" => timestamp} = response, status)
        when is_integer(timestamp) do

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -71,8 +71,6 @@ defmodule GlificWeb.Flows.FlowResumeController do
           nil
       end
 
-    track_kaapi_latency(response)
-    maybe_report_callback_failure(result, response)
     track_callback_outcome(result, response)
 
     with true <- validate_request(organization_id, response),
@@ -202,8 +200,6 @@ defmodule GlificWeb.Flows.FlowResumeController do
       if response["webhook_log_id"],
         do: Webhook.update_log(response["webhook_log_id"], voice_response)
 
-      track_kaapi_latency(response)
-      maybe_report_callback_failure(result, response)
       track_callback_outcome(result, response)
 
       case FlowContext.resume_contact_flow(
@@ -299,24 +295,40 @@ defmodule GlificWeb.Flows.FlowResumeController do
     end
   end
 
-  @spec track_kaapi_latency(map()) :: :ok
-  defp track_kaapi_latency(%{"timestamp" => timestamp, "call_type" => call_type})
-       when is_integer(timestamp) do
-    now = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
-    duration_ms = (now - timestamp) / 1_000
-
-    Appsignal.add_distribution_value("kaapi_llm_latency", duration_ms, %{
-      call_type: call_type
-    })
-  end
-
-  defp track_kaapi_latency(_response), do: :ok
-
   @spec track_callback_outcome(map(), map()) :: :ok
   defp track_callback_outcome(result, response) do
     status = if result["success"], do: "success", else: "failure"
     Webhook.track_webhook_count(response["webhook_name"], status)
+    track_kaapi_latency(response, status)
+    maybe_report_callback_failure(result, response)
   end
+
+  # Records latency for an async webhook callback. Emits the kaapi-specific
+  # `kaapi_llm_latency` (by call_type) when a call_type is present, plus the
+  # generic `flow_webhook_latency` (by webhook_name + status) shared with sync
+  # nodes. `timestamp` is the (microsecond) request-initiation time threaded
+  # through the callback, so a callback that arrives after the flow already
+  # timed out still records its real, uncapped latency (tagged "failure").
+  @spec track_kaapi_latency(map(), String.t()) :: :ok
+  defp track_kaapi_latency(%{"timestamp" => timestamp} = response, status)
+       when is_integer(timestamp) do
+    now = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+    duration_ms = (now - timestamp) / 1_000
+
+    case response["call_type"] do
+      nil ->
+        :ok
+
+      call_type ->
+        Appsignal.add_distribution_value("kaapi_llm_latency", duration_ms, %{
+          call_type: call_type
+        })
+    end
+
+    Webhook.track_webhook_latency(response["webhook_name"], status, duration_ms)
+  end
+
+  defp track_kaapi_latency(_response, _status), do: :ok
 
   @spec validate_request(non_neg_integer(), map()) :: boolean()
   defp validate_request(_new_organization_id, fields) when map_size(fields) == 0,

--- a/lib/glific_web/flows/flow_resume_controller.ex
+++ b/lib/glific_web/flows/flow_resume_controller.ex
@@ -63,6 +63,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
     track_kaapi_latency(response)
     maybe_report_callback_failure(result, response)
+    track_callback_outcome(result, response, organization_id)
 
     with true <- validate_request(organization_id, response),
          {:ok, contact} <-
@@ -150,6 +151,7 @@ defmodule GlificWeb.Flows.FlowResumeController do
 
       track_kaapi_latency(response)
       maybe_report_callback_failure(result, response)
+      track_callback_outcome(result, response, organization_id)
 
       FlowContext.resume_contact_flow(
         contact,
@@ -246,6 +248,13 @@ defmodule GlificWeb.Flows.FlowResumeController do
   end
 
   defp track_kaapi_latency(_response), do: :ok
+
+  # Records the true success/failure of an async webhook node
+  @spec track_callback_outcome(map(), map(), non_neg_integer()) :: :ok
+  defp track_callback_outcome(result, response, organization_id) do
+    status = if result["success"], do: "success", else: "failure"
+    Webhook.track_webhook_count(response["webhook_name"], organization_id, status)
+  end
 
   @spec validate_request(non_neg_integer(), map()) :: boolean()
   defp validate_request(new_organization_id, fields) do


### PR DESCRIPTION

## Summary
 Target issue is #5121
 
Add Glific.Flows.Webhook.track_webhook_count/3 which bumps a "flow_webhook_count" counter tagged with webhook_name, organization_id and status (success/failure), and emit it from:

- the CommonWebhook `with_failure_reporting` wrapper: counts failures (and exceptions), plus successes for sync webhooks
- the flow_resume callbacks (flow_resume_with_results, do_voice_flow_resume): counts the real outcome of async webhooks

Async webhooks (speech_to_text, text_to_speech, unified-llm-call, unified-voice-llm-call) only return a dispatch ack in the wrapper, so their success is recorded at the callback instead to avoid double counting; the wrapper still records their dispatch failures.
