### PR TITLE
fix: use lts version of ffmpeg binary

### DIFF
--- a/download_ffmpeg.sh
+++ b/download_ffmpeg.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-05-10-13-12/ffmpeg-N-124426-g5bbc00c05d-linux64-gpl.tar.xz"
-FFMPEG_SHA256="256efa121f091b4f18afee140c55bfd79547f3c97aea4df858c1d4ae30bde023"
+FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-30-13-44/ffmpeg-N-124278-gcc3ca17127-linux64-gpl.tar.xz"
+FFMPEG_SHA256="sha256:cd50a631135f90fecd0166c5134e32326825bc6bd11da4bf4ea24d5cb2f79f1f"
 INSTALL_DIR="rel/overlays/vendor/ffmpeg"
 
 echo "-----> Installing ffmpeg from BtbN static build (ffmpeg.org recommended source)"

--- a/download_ffmpeg.sh
+++ b/download_ffmpeg.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 FFMPEG_URL="https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-04-30-13-44/ffmpeg-N-124278-gcc3ca17127-linux64-gpl.tar.xz"
-FFMPEG_SHA256="sha256:cd50a631135f90fecd0166c5134e32326825bc6bd11da4bf4ea24d5cb2f79f1f"
+FFMPEG_SHA256="cd50a631135f90fecd0166c5134e32326825bc6bd11da4bf4ea24d5cb2f79f1f"
 INSTALL_DIR="rel/overlays/vendor/ffmpeg"
 
 echo "-----> Installing ffmpeg from BtbN static build (ffmpeg.org recommended source)"


### PR DESCRIPTION
In https://github.com/BtbN/FFmpeg-Builds, only the last 14 builds are kept so the version of the binary we were using was removed. However the last build of the month is kept for 2 years so modifying the version we use to https://github.com/BtbN/FFmpeg-Builds/releases/tag/autobuild-2026-04-30-13-44