### PR TITLE
Fix FUNCTION Webhooks Returning False Success

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -411,16 +411,11 @@ defmodule Glific.Clients.CommonWebhook do
           %{success: false, translated_text: llm_response_text, media_url: nil}
       end
 
-    # do_nmt_tts_with_bhasini can return a bare string on failure (e.g. GCS
-    # disabled), so guard the map access.
-    translated_text =
-      (is_map(tts_result) && tts_result[:translated_text]) || llm_response_text
-
-    media_url = if is_map(tts_result), do: tts_result[:media_url], else: nil
+    translated_text = tts_result[:translated_text] || llm_response_text
 
     response
     |> Map.put("translated_text", translated_text)
-    |> Map.put("media_url", media_url)
+    |> Map.put("media_url", tts_result[:media_url])
   end
 
   defp do_unified_llm_call(fields, headers, callback_url, request_metadata) do

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -300,35 +300,10 @@ defmodule Glific.Clients.CommonWebhook do
     url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{long}&key=#{api_key}"
 
     with_failure_reporting("geolocation", org_id, fn ->
-      Tesla.get(url)
-      |> case do
+      case Tesla.get(url) do
         {:ok, %Tesla.Env{status: 200, body: body}} ->
-          %{"results" => results} = Jason.decode!(body)
-
           Glific.Metrics.increment("Geolocation API Success")
-
-          case results do
-            [%{"address_components" => components, "formatted_address" => formatted_address} | _] ->
-              city = find_component(components, "locality")
-              state = find_component(components, "administrative_area_level_1")
-              country = find_component(components, "country")
-              postal_code = find_component(components, "postal_code")
-              district = find_component(components, "administrative_area_level_3")
-
-              %{
-                success: true,
-                city: city,
-                state: state,
-                country: country,
-                postal_code: postal_code,
-                district: district,
-                address: formatted_address
-              }
-
-            _ ->
-              Glific.Metrics.increment("Geolocation API Failure")
-              "No results found"
-          end
+          body |> Jason.decode!() |> Map.fetch!("results") |> parse_geolocation_results()
 
         {:ok, %Tesla.Env{status: status_code}} ->
           Glific.Metrics.increment("Geolocation API Failure")
@@ -484,6 +459,23 @@ defmodule Glific.Clients.CommonWebhook do
     end
   end
 
+  @spec parse_geolocation_results(list(map())) :: map() | String.t()
+  defp parse_geolocation_results([
+         %{"address_components" => components, "formatted_address" => formatted_address} | _
+       ]) do
+    %{
+      success: true,
+      city: find_component(components, "locality"),
+      state: find_component(components, "administrative_area_level_1"),
+      country: find_component(components, "country"),
+      postal_code: find_component(components, "postal_code"),
+      district: find_component(components, "administrative_area_level_3"),
+      address: formatted_address
+    }
+  end
+
+  defp parse_geolocation_results(_), do: "No results found"
+
   @spec gemini_nmt_tts_call(
           String.t(),
           String.t(),
@@ -491,9 +483,6 @@ defmodule Glific.Clients.CommonWebhook do
           String.t(),
           Keyword.t()
         ) :: map()
-  # Returns the raw %{success: ...} map. No in-tree internal callers today, but
-  # kept symmetric with the other bhasini cores: the webhook/2 clause does the
-  # flow-routing normalization, all engine selection logic lives here.
   @spec do_text_to_speech_with_bhasini(map()) :: map() | String.t()
   defp do_text_to_speech_with_bhasini(fields) do
     text = fields["text"]
@@ -522,9 +511,10 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
-  # Returns the raw %{success: ...} map. Internal callers (unified-voice-llm-call)
-  # use this directly; the webhook/2 clause normalizes failures for flow routing.
-  @spec do_speech_to_text_with_bhasini(map()) :: map() | String.t()
+  # Spec includes `{:error, _}` defensively so the unified-voice-llm-call call
+  # site can keep an error-tuple match (even if Gemini.speech_to_text doesn't
+  # currently surface one) without Dialyzer flagging the clause as unreachable.
+  @spec do_speech_to_text_with_bhasini(map()) :: map() | String.t() | {:error, any()}
   defp do_speech_to_text_with_bhasini(fields) do
     {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
 
@@ -540,8 +530,6 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
-  # Returns the raw %{success: ...} map. Internal callers (voice_post_process)
-  # use this directly; the webhook/2 clause normalizes failures for flow routing.
   @spec do_nmt_tts_with_bhasini(map()) :: map() | String.t()
   defp do_nmt_tts_with_bhasini(fields) do
     text = fields["text"]

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -198,42 +198,16 @@ defmodule Glific.Clients.CommonWebhook do
 
   def webhook(function, fields, _headers), do: webhook(function, fields)
 
-  # Uses Gemini for STT via Bhasini flow nodes. The webhook/2 entry normalizes
-  # failures to a bare string for flow routing; do_speech_to_text_with_bhasini/1
-  # returns the raw %{success: ...} map for internal callers
-  # (unified-voice-llm-call) that pattern-match on it.
   def webhook("speech_to_text_with_bhasini", fields) do
     fields
     |> do_speech_to_text_with_bhasini()
     |> normalize_failure()
   end
 
-  # Uses Gemini/Bhasini/OpenAI for TTS via Bhasini flow nodes
+  # Uses Gemini/Bhasini/OpenAI for TTS via Bhasini flow nodes.
   def webhook("text_to_speech_with_bhasini", fields) do
-    text = fields["text"]
-    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
-    contact_id = Glific.parse_maybe_integer!(fields["contact"]["id"])
-    contact = Contacts.preload_contact_language(contact_id)
-    source_language = contact.language.label |> String.downcase()
-    speech_engine = Map.get(fields, "speech_engine", "")
-
-    with_failure_reporting("text_to_speech_with_bhasini", org_id, fn ->
-      cond do
-        speech_engine == "open_ai" ->
-          ChatGPT.text_to_speech_with_open_ai(org_id, text)
-
-        speech_engine == "bhashini" ->
-          Glific.Metrics.increment("Gemini TTS Call", org_id)
-          Gemini.text_to_speech(org_id, text)
-
-        source_language == "english" ->
-          ChatGPT.text_to_speech_with_open_ai(org_id, text)
-
-        true ->
-          Glific.Metrics.increment("Gemini TTS Call", org_id)
-          Gemini.text_to_speech(org_id, text)
-      end
-    end)
+    fields
+    |> do_text_to_speech_with_bhasini()
     |> normalize_failure()
   end
 
@@ -283,18 +257,20 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
-  # The webhook/2 entry normalizes failures to a bare string for flow routing;
-  # run_nmt_tts_with_bhasini/1 returns the raw %{success: ...} map for internal
-  # callers (voice_post_process) that read media_url/translated_text from it.
   def webhook("nmt_tts_with_bhasini", fields) do
     fields
-    |> run_nmt_tts_with_bhasini()
+    |> do_nmt_tts_with_bhasini()
     |> normalize_failure()
   end
 
   def webhook("detect_language", fields) do
     speech = fields["speech"]
-    Bhasini.detect_language(speech)
+    org_id = parse_org_id(fields)
+
+    with_failure_reporting("detect_language", org_id, fn ->
+      Bhasini.detect_language(speech)
+    end)
+    |> normalize_failure()
   end
 
   def webhook("get_buttons", fields) do
@@ -315,8 +291,6 @@ defmodule Glific.Clients.CommonWebhook do
   def webhook("check_response", fields),
     do: %{response: String.equivalent?(fields["correct_response"], fields["user_response"])}
 
-  # Failures return a bare string (not %{success: false}) so the flow routes to
-  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("geolocation", fields) do
     lat = fields["lat"]
     long = fields["long"]
@@ -368,8 +342,6 @@ defmodule Glific.Clients.CommonWebhook do
   end
 
   # webhook for sending whatsapp group polls in a flow
-  # Failures return a bare string (not %{success: false}) so the flow routes to
-  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("send_wa_group_poll", fields) do
     org_id = parse_org_id(fields)
 
@@ -403,8 +375,6 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
-  # Failures return a bare string (not %{success: false}) so the flow routes to
-  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("create_certificate", fields) do
     org_id = parse_org_id(fields)
 
@@ -442,7 +412,7 @@ defmodule Glific.Clients.CommonWebhook do
     tts_result =
       cond do
         success && llm_response_text != "" ->
-          run_nmt_tts_with_bhasini(%{
+          do_nmt_tts_with_bhasini(%{
             "text" => llm_response_text,
             "organization_id" => organization_id,
             "source_language" => voice_fields["source_language"],
@@ -466,7 +436,7 @@ defmodule Glific.Clients.CommonWebhook do
           %{success: false, translated_text: llm_response_text, media_url: nil}
       end
 
-    # run_nmt_tts_with_bhasini can return a bare string on failure (e.g. GCS
+    # do_nmt_tts_with_bhasini can return a bare string on failure (e.g. GCS
     # disabled), so guard the map access.
     translated_text =
       (is_map(tts_result) && tts_result[:translated_text]) || llm_response_text
@@ -514,13 +484,44 @@ defmodule Glific.Clients.CommonWebhook do
     end
   end
 
-  @spec do_nmt_tts_with_bhasini(
+  @spec gemini_nmt_tts_call(
           String.t(),
           String.t(),
           non_neg_integer(),
           String.t(),
           Keyword.t()
         ) :: map()
+  # Returns the raw %{success: ...} map. No in-tree internal callers today, but
+  # kept symmetric with the other bhasini cores: the webhook/2 clause does the
+  # flow-routing normalization, all engine selection logic lives here.
+  @spec do_text_to_speech_with_bhasini(map()) :: map() | String.t()
+  defp do_text_to_speech_with_bhasini(fields) do
+    text = fields["text"]
+    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
+    contact_id = Glific.parse_maybe_integer!(fields["contact"]["id"])
+    contact = Contacts.preload_contact_language(contact_id)
+    source_language = contact.language.label |> String.downcase()
+    speech_engine = Map.get(fields, "speech_engine", "")
+
+    with_failure_reporting("text_to_speech_with_bhasini", org_id, fn ->
+      cond do
+        speech_engine == "open_ai" ->
+          ChatGPT.text_to_speech_with_open_ai(org_id, text)
+
+        speech_engine == "bhashini" ->
+          Glific.Metrics.increment("Gemini TTS Call", org_id)
+          Gemini.text_to_speech(org_id, text)
+
+        source_language == "english" ->
+          ChatGPT.text_to_speech_with_open_ai(org_id, text)
+
+        true ->
+          Glific.Metrics.increment("Gemini TTS Call", org_id)
+          Gemini.text_to_speech(org_id, text)
+      end
+    end)
+  end
+
   # Returns the raw %{success: ...} map. Internal callers (unified-voice-llm-call)
   # use this directly; the webhook/2 clause normalizes failures for flow routing.
   @spec do_speech_to_text_with_bhasini(map()) :: map() | String.t()
@@ -541,8 +542,8 @@ defmodule Glific.Clients.CommonWebhook do
 
   # Returns the raw %{success: ...} map. Internal callers (voice_post_process)
   # use this directly; the webhook/2 clause normalizes failures for flow routing.
-  @spec run_nmt_tts_with_bhasini(map()) :: map() | String.t()
-  defp run_nmt_tts_with_bhasini(fields) do
+  @spec do_nmt_tts_with_bhasini(map()) :: map() | String.t()
+  defp do_nmt_tts_with_bhasini(fields) do
     text = fields["text"]
     org_id = fields["organization_id"]
     source_language = normalize_language(fields["source_language"])
@@ -553,14 +554,14 @@ defmodule Glific.Clients.CommonWebhook do
       if source_language == target_language do
         handle_tts_only(source_language, org_id, text, speech_engine)
       else
-        do_nmt_tts_with_bhasini(source_language, target_language, org_id, text,
+        gemini_nmt_tts_call(source_language, target_language, org_id, text,
           speech_engine: speech_engine
         )
       end
     end)
   end
 
-  defp do_nmt_tts_with_bhasini(source_language, target_language, org_id, text, opts) do
+  defp gemini_nmt_tts_call(source_language, target_language, org_id, text, opts) do
     organization = Partners.organization(org_id)
     services = organization.services["google_cloud_storage"]
 
@@ -904,6 +905,7 @@ defmodule Glific.Clients.CommonWebhook do
       is_binary(result[:reason]) -> result[:reason]
       is_binary(result[:error]) -> result[:error]
       is_binary(result[:asr_response_text]) -> result[:asr_response_text]
+      is_binary(result[:detected_language]) -> result[:detected_language]
       true -> "Webhook execution failed"
     end
   end

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -100,7 +100,7 @@ defmodule Glific.Clients.CommonWebhook do
 
     Glific.Metrics.increment("Voice Unified LLM Call", org_id)
 
-    case webhook("speech_to_text_with_bhasini", stt_fields) do
+    case do_speech_to_text_with_bhasini(stt_fields) do
       %{success: true, asr_response_text: transcribed_text} ->
         updated_fields = Map.put(fields, "question", transcribed_text)
         {organization_id, flow_id, contact_id} = parse_flow_fields(fields)
@@ -198,20 +198,14 @@ defmodule Glific.Clients.CommonWebhook do
 
   def webhook(function, fields, _headers), do: webhook(function, fields)
 
-  # Uses Gemini for STT via Bhasini flow nodes
+  # Uses Gemini for STT via Bhasini flow nodes. The webhook/2 entry normalizes
+  # failures to a bare string for flow routing; do_speech_to_text_with_bhasini/1
+  # returns the raw %{success: ...} map for internal callers
+  # (unified-voice-llm-call) that pattern-match on it.
   def webhook("speech_to_text_with_bhasini", fields) do
-    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
-
-    with_failure_reporting("speech_to_text_with_bhasini", org_id, fn ->
-      case Bhasini.validate_params(fields) do
-        {:ok, contact} ->
-          Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
-          Gemini.speech_to_text(fields["speech"], contact.organization_id)
-
-        {:error, error} ->
-          %{success: false, asr_response_text: error}
-      end
-    end)
+    fields
+    |> do_speech_to_text_with_bhasini()
+    |> normalize_failure()
   end
 
   # Uses Gemini/Bhasini/OpenAI for TTS via Bhasini flow nodes
@@ -240,6 +234,7 @@ defmodule Glific.Clients.CommonWebhook do
           Gemini.text_to_speech(org_id, text)
       end
     end)
+    |> normalize_failure()
   end
 
   @doc """
@@ -288,22 +283,13 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
+  # The webhook/2 entry normalizes failures to a bare string for flow routing;
+  # run_nmt_tts_with_bhasini/1 returns the raw %{success: ...} map for internal
+  # callers (voice_post_process) that read media_url/translated_text from it.
   def webhook("nmt_tts_with_bhasini", fields) do
-    text = fields["text"]
-    org_id = fields["organization_id"]
-    source_language = normalize_language(fields["source_language"])
-    target_language = normalize_language(fields["target_language"])
-    speech_engine = Map.get(fields, "speech_engine", "")
-
-    with_failure_reporting("nmt_tts_with_bhasini", org_id, fn ->
-      if source_language == target_language do
-        handle_tts_only(source_language, org_id, text, speech_engine)
-      else
-        do_nmt_tts_with_bhasini(source_language, target_language, org_id, text,
-          speech_engine: speech_engine
-        )
-      end
-    end)
+    fields
+    |> run_nmt_tts_with_bhasini()
+    |> normalize_failure()
   end
 
   def webhook("detect_language", fields) do
@@ -456,7 +442,7 @@ defmodule Glific.Clients.CommonWebhook do
     tts_result =
       cond do
         success && llm_response_text != "" ->
-          webhook("nmt_tts_with_bhasini", %{
+          run_nmt_tts_with_bhasini(%{
             "text" => llm_response_text,
             "organization_id" => organization_id,
             "source_language" => voice_fields["source_language"],
@@ -480,13 +466,16 @@ defmodule Glific.Clients.CommonWebhook do
           %{success: false, translated_text: llm_response_text, media_url: nil}
       end
 
+    # run_nmt_tts_with_bhasini can return a bare string on failure (e.g. GCS
+    # disabled), so guard the map access.
     translated_text =
-      tts_result[:translated_text] ||
-        llm_response_text
+      (is_map(tts_result) && tts_result[:translated_text]) || llm_response_text
+
+    media_url = if is_map(tts_result), do: tts_result[:media_url], else: nil
 
     response
     |> Map.put("translated_text", translated_text)
-    |> Map.put("media_url", tts_result[:media_url])
+    |> Map.put("media_url", media_url)
   end
 
   defp do_unified_llm_call(fields, headers, callback_url, request_metadata) do
@@ -532,6 +521,45 @@ defmodule Glific.Clients.CommonWebhook do
           String.t(),
           Keyword.t()
         ) :: map()
+  # Returns the raw %{success: ...} map. Internal callers (unified-voice-llm-call)
+  # use this directly; the webhook/2 clause normalizes failures for flow routing.
+  @spec do_speech_to_text_with_bhasini(map()) :: map() | String.t()
+  defp do_speech_to_text_with_bhasini(fields) do
+    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
+
+    with_failure_reporting("speech_to_text_with_bhasini", org_id, fn ->
+      case Bhasini.validate_params(fields) do
+        {:ok, contact} ->
+          Glific.Metrics.increment("Gemini STT Call", contact.organization_id)
+          Gemini.speech_to_text(fields["speech"], contact.organization_id)
+
+        {:error, error} ->
+          %{success: false, asr_response_text: error}
+      end
+    end)
+  end
+
+  # Returns the raw %{success: ...} map. Internal callers (voice_post_process)
+  # use this directly; the webhook/2 clause normalizes failures for flow routing.
+  @spec run_nmt_tts_with_bhasini(map()) :: map() | String.t()
+  defp run_nmt_tts_with_bhasini(fields) do
+    text = fields["text"]
+    org_id = fields["organization_id"]
+    source_language = normalize_language(fields["source_language"])
+    target_language = normalize_language(fields["target_language"])
+    speech_engine = Map.get(fields, "speech_engine", "")
+
+    with_failure_reporting("nmt_tts_with_bhasini", org_id, fn ->
+      if source_language == target_language do
+        handle_tts_only(source_language, org_id, text, speech_engine)
+      else
+        do_nmt_tts_with_bhasini(source_language, target_language, org_id, text,
+          speech_engine: speech_engine
+        )
+      end
+    end)
+  end
+
   defp do_nmt_tts_with_bhasini(source_language, target_language, org_id, text, opts) do
     organization = Partners.organization(org_id)
     services = organization.services["google_cloud_storage"]
@@ -864,6 +892,23 @@ defmodule Glific.Clients.CommonWebhook do
       report_webhook_failure(webhook_name, org_id, nil, Exception.message(exception))
       reraise exception, __STACKTRACE__
   end
+
+  # FUNCTION webhooks signal Failure to the flow by returning a non-map (see
+  # Glific.Flows.Webhook.handle/3, which keys off is_map). Convert a
+  # %{success: false} result into a bare error string so the flow routes to the
+  # Failure category; pass anything else (success maps, already-bare strings)
+  # through unchanged.
+  @spec normalize_failure(map() | String.t()) :: map() | String.t()
+  defp normalize_failure(%{success: false} = result) do
+    cond do
+      is_binary(result[:reason]) -> result[:reason]
+      is_binary(result[:error]) -> result[:error]
+      is_binary(result[:asr_response_text]) -> result[:asr_response_text]
+      true -> "Webhook execution failed"
+    end
+  end
+
+  defp normalize_failure(result), do: result
 
   @spec maybe_report_webhook_failure(any(), String.t(), non_neg_integer() | nil) :: :ok
   defp maybe_report_webhook_failure(%{success: false} = result, webhook_name, org_id) do

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -15,6 +15,7 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.Partners
   alias Glific.Providers.Maytapi
   alias Glific.Repo
+  alias Glific.SafeLog
   alias Glific.ThirdParty.Gemini
   alias Glific.ThirdParty.GoogleSlide.Slide
   alias Glific.ThirdParty.Kaapi
@@ -311,7 +312,7 @@ defmodule Glific.Clients.CommonWebhook do
 
         {:error, reason} ->
           Glific.Metrics.increment("Geolocation API Failure")
-          "HTTP request failed: #{inspect(reason)}"
+          "HTTP request failed: #{SafeLog.safe_inspect(reason)}"
       end
     end)
   end
@@ -345,7 +346,7 @@ defmodule Glific.Clients.CommonWebhook do
           reason
 
         {:error, reason} ->
-          inspect(reason)
+          SafeLog.safe_inspect(reason)
       end
     end)
   end
@@ -366,7 +367,6 @@ defmodule Glific.Clients.CommonWebhook do
         )
       else
         {:error, reason} ->
-          Logger.error("Error in certificate creation webhook: #{reason}")
           reason
       end
     end)
@@ -471,13 +471,6 @@ defmodule Glific.Clients.CommonWebhook do
 
   defp parse_geolocation_results(_), do: "No results found"
 
-  @spec gemini_nmt_tts_call(
-          String.t(),
-          String.t(),
-          non_neg_integer(),
-          String.t(),
-          Keyword.t()
-        ) :: map()
   @spec do_text_to_speech_with_bhasini(map()) :: map() | String.t()
   defp do_text_to_speech_with_bhasini(fields) do
     text = fields["text"]
@@ -528,7 +521,7 @@ defmodule Glific.Clients.CommonWebhook do
   @spec do_nmt_tts_with_bhasini(map()) :: map() | String.t()
   defp do_nmt_tts_with_bhasini(fields) do
     text = fields["text"]
-    org_id = fields["organization_id"]
+    {:ok, org_id} = fields["organization_id"] |> Glific.parse_maybe_integer()
     source_language = normalize_language(fields["source_language"])
     target_language = normalize_language(fields["target_language"])
     speech_engine = Map.get(fields, "speech_engine", "")
@@ -544,6 +537,13 @@ defmodule Glific.Clients.CommonWebhook do
     end)
   end
 
+  @spec gemini_nmt_tts_call(
+          String.t(),
+          String.t(),
+          non_neg_integer(),
+          String.t(),
+          Keyword.t()
+        ) :: map()
   defp gemini_nmt_tts_call(source_language, target_language, org_id, text, opts) do
     organization = Partners.organization(org_id)
     services = organization.services["google_cloud_storage"]

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -329,98 +329,116 @@ defmodule Glific.Clients.CommonWebhook do
   def webhook("check_response", fields),
     do: %{response: String.equivalent?(fields["correct_response"], fields["user_response"])}
 
+  # Failures return a bare string (not %{success: false}) so the flow routes to
+  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("geolocation", fields) do
     lat = fields["lat"]
     long = fields["long"]
+    org_id = parse_org_id(fields)
     api_key = Glific.get_google_maps_api_key()
 
     url = "https://maps.googleapis.com/maps/api/geocode/json?latlng=#{lat},#{long}&key=#{api_key}"
 
-    Tesla.get(url)
-    |> case do
-      {:ok, %Tesla.Env{status: 200, body: body}} ->
-        %{"results" => results} = Jason.decode!(body)
+    with_failure_reporting("geolocation", org_id, fn ->
+      Tesla.get(url)
+      |> case do
+        {:ok, %Tesla.Env{status: 200, body: body}} ->
+          %{"results" => results} = Jason.decode!(body)
 
-        Glific.Metrics.increment("Geolocation API Success")
+          Glific.Metrics.increment("Geolocation API Success")
 
-        case results do
-          [%{"address_components" => components, "formatted_address" => formatted_address} | _] ->
-            city = find_component(components, "locality")
-            state = find_component(components, "administrative_area_level_1")
-            country = find_component(components, "country")
-            postal_code = find_component(components, "postal_code")
-            district = find_component(components, "administrative_area_level_3")
+          case results do
+            [%{"address_components" => components, "formatted_address" => formatted_address} | _] ->
+              city = find_component(components, "locality")
+              state = find_component(components, "administrative_area_level_1")
+              country = find_component(components, "country")
+              postal_code = find_component(components, "postal_code")
+              district = find_component(components, "administrative_area_level_3")
 
-            %{
-              success: true,
-              city: city,
-              state: state,
-              country: country,
-              postal_code: postal_code,
-              district: district,
-              address: formatted_address
-            }
+              %{
+                success: true,
+                city: city,
+                state: state,
+                country: country,
+                postal_code: postal_code,
+                district: district,
+                address: formatted_address
+              }
 
-          _ ->
-            %{success: false, error: "No results found"}
-        end
+            _ ->
+              Glific.Metrics.increment("Geolocation API Failure")
+              "No results found"
+          end
 
-      {:ok, %Tesla.Env{status: status_code}} ->
-        Glific.Metrics.increment("Geolocation API Failure")
-        %{success: false, error: "Received status code #{status_code}"}
+        {:ok, %Tesla.Env{status: status_code}} ->
+          Glific.Metrics.increment("Geolocation API Failure")
+          "Received status code #{status_code}"
 
-      {:error, reason} ->
-        Glific.Metrics.increment("Geolocation API Failure")
-        %{success: false, error: "HTTP request failed: #{reason}"}
-    end
+        {:error, reason} ->
+          Glific.Metrics.increment("Geolocation API Failure")
+          "HTTP request failed: #{inspect(reason)}"
+      end
+    end)
   end
 
   # webhook for sending whatsapp group polls in a flow
+  # Failures return a bare string (not %{success: false}) so the flow routes to
+  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("send_wa_group_poll", fields) do
-    with {:ok, fields} <- parse_wa_poll_params(fields),
-         {:ok, wa_phone} <-
-           Repo.fetch_by(WAManagedPhone, %{
-             id: fields.wa_group["wa_managed_phone_id"],
-             organization_id: fields.organization_id
-           }),
-         {:ok, wa_group} <-
-           Repo.fetch_by(WAGroup, %{
-             id: fields.wa_group["id"],
-             organization_id: fields.organization_id
-           }),
-         {:ok, wa_poll} <-
-           Repo.fetch_by(WaPoll, %{
-             uuid: fields.poll_uuid,
-             organization_id: fields.organization_id
-           }),
-         {:ok, wa_message} <-
-           Maytapi.Message.create_and_send_wa_message(wa_phone, wa_group, %{poll_id: wa_poll.id}) do
-      %{success: true, poll: wa_message.poll_content}
-    else
-      {:error, reason} when is_binary(reason) ->
-        %{success: false, error: "#{reason}"}
+    org_id = parse_org_id(fields)
 
-      {:error, reason} ->
-        %{success: false, error: "#{inspect(reason)}"}
-    end
+    with_failure_reporting("send_wa_group_poll", org_id, fn ->
+      with {:ok, fields} <- parse_wa_poll_params(fields),
+           {:ok, wa_phone} <-
+             Repo.fetch_by(WAManagedPhone, %{
+               id: fields.wa_group["wa_managed_phone_id"],
+               organization_id: fields.organization_id
+             }),
+           {:ok, wa_group} <-
+             Repo.fetch_by(WAGroup, %{
+               id: fields.wa_group["id"],
+               organization_id: fields.organization_id
+             }),
+           {:ok, wa_poll} <-
+             Repo.fetch_by(WaPoll, %{
+               uuid: fields.poll_uuid,
+               organization_id: fields.organization_id
+             }),
+           {:ok, wa_message} <-
+             Maytapi.Message.create_and_send_wa_message(wa_phone, wa_group, %{poll_id: wa_poll.id}) do
+        %{success: true, poll: wa_message.poll_content}
+      else
+        {:error, reason} when is_binary(reason) ->
+          reason
+
+        {:error, reason} ->
+          inspect(reason)
+      end
+    end)
   end
 
+  # Failures return a bare string (not %{success: false}) so the flow routes to
+  # the "Failure" category (lib/glific/flows/webhook.ex keys off is_map).
   def webhook("create_certificate", fields) do
-    with {:ok, parsed_fields} <- parse_certificate_params(fields),
-         {:ok, certificate_template} <- fetch_certificate_template(parsed_fields),
-         {:ok, slide_details} <-
-           Slide.parse_slides_url(certificate_template.url) do
-      Certificate.generate_certificate(
-        parsed_fields,
-        parsed_fields.contact["id"],
-        slide_details.presentation_id,
-        slide_details.page_id
-      )
-    else
-      {:error, reason} ->
-        Logger.error("Error in certificate creation webhook: #{reason}")
-        %{success: false, error: reason}
-    end
+    org_id = parse_org_id(fields)
+
+    with_failure_reporting("create_certificate", org_id, fn ->
+      with {:ok, parsed_fields} <- parse_certificate_params(fields),
+           {:ok, certificate_template} <- fetch_certificate_template(parsed_fields),
+           {:ok, slide_details} <-
+             Slide.parse_slides_url(certificate_template.url) do
+        Certificate.generate_certificate(
+          parsed_fields,
+          parsed_fields.contact["id"],
+          slide_details.presentation_id,
+          slide_details.page_id
+        )
+      else
+        {:error, reason} ->
+          Logger.error("Error in certificate creation webhook: #{reason}")
+          reason
+      end
+    end)
   end
 
   def webhook(_, _fields), do: %{error: "Missing webhook function implementation"}

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -244,11 +244,25 @@ defmodule Glific.Flows.Webhook do
     webhook_log |> WebhookLog.update_webhook_log(attrs)
   end
 
-  def update_log(webhook_log, result) when is_map(result) do
+  # Distinguishes a success map from an application-level failure map
+  # (%{success: false, ...}) so the WebhookLog row records the failure with a
+  # non-200 status and an error reason
+  def update_log(webhook_log, %{success: false} = result) do
+    reason =
+      Map.get(result, :reason) || Map.get(result, :error) || Map.get(result, :message)
+
     attrs = %{
       response_json: result,
-      status_code: 200
+      status_code: 400,
+      error: to_string(reason || "Webhook failure")
     }
+
+    webhook_log
+    |> WebhookLog.update_webhook_log(attrs)
+  end
+
+  def update_log(webhook_log, result) when is_map(result) do
+    attrs = %{response_json: result, status_code: 200}
 
     webhook_log
     |> WebhookLog.update_webhook_log(attrs)

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -251,11 +251,17 @@ defmodule Glific.Flows.Webhook do
     reason =
       Map.get(result, :reason) || Map.get(result, :error) || Map.get(result, :message)
 
-    attrs = %{
-      response_json: result,
-      status_code: 400,
-      error: to_string(reason || "Webhook failure")
-    }
+    # reason can be a non-binary term (e.g. a decoded JSON map from a Tesla 500
+    # body — see lib/glific/third_party/bhasini/bhasini.ex). to_string/1 would
+    # raise on those; inspect/1 produces a safe string for any term.
+    error =
+      cond do
+        is_binary(reason) -> reason
+        is_nil(reason) -> "Webhook failure"
+        true -> inspect(reason)
+      end
+
+    attrs = %{response_json: result, status_code: 400, error: error}
 
     webhook_log
     |> WebhookLog.update_webhook_log(attrs)

--- a/lib/glific/third_party/bhasini/bhasini.ex
+++ b/lib/glific/third_party/bhasini/bhasini.ex
@@ -273,7 +273,7 @@ defmodule Glific.Bhasini do
     services = organization.services["google_cloud_storage"]
 
     if is_nil(services) do
-      "Enable GCS is use Bhashini text to speech"
+      %{success: false, reason: "GCS is disabled"}
     else
       text_to_speech(source_language, org_id, text)
     end

--- a/lib/glific/third_party/gemini.ex
+++ b/lib/glific/third_party/gemini.ex
@@ -79,13 +79,13 @@ defmodule Glific.ThirdParty.Gemini do
       %{success: false, media_url: nil, translated_text: "Error case"}
 
   """
-  @spec text_to_speech(integer(), String.t()) :: map() | String.t()
+  @spec text_to_speech(integer(), String.t()) :: map()
   def text_to_speech(organization_id, text) do
     organization = Partners.organization(organization_id)
     services = organization.services["google_cloud_storage"]
 
     if is_nil(services) do
-      "Enable GCS to use Gemini text to speech"
+      %{success: false, reason: "GCS is disabled"}
     else
       do_text_to_speech(organization_id, text)
     end

--- a/lib/glific/third_party/openAI/chatGPT.ex
+++ b/lib/glific/third_party/openAI/chatGPT.ex
@@ -232,7 +232,7 @@ defmodule Glific.OpenAI.ChatGPT do
       |> Map.put(:translated_text, text)
     else
       true ->
-        "Enable GCS is use Open AI text to speech"
+        %{success: false, reason: "GCS is disabled"}
 
       error ->
         error

--- a/test/glific/flags_test.exs
+++ b/test/glific/flags_test.exs
@@ -193,7 +193,10 @@ defmodule Glific.FlagsTest do
     FunWithFlags.enable(:high_trigger_tps_enabled, for_actor: %{organization_id: organization.id})
     assert Flags.get_flag_enabled(:high_trigger_tps_enabled, organization) == true
 
-    FunWithFlags.disable(:high_trigger_tps_enabled, for_actor: %{organization_id: organization.id})
+    FunWithFlags.disable(:high_trigger_tps_enabled,
+      for_actor: %{organization_id: organization.id}
+    )
+
     assert Flags.get_flag_enabled(:high_trigger_tps_enabled, organization) == false
   end
 end

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -119,10 +119,7 @@ defmodule Glific.Flows.CommonWebhookTest do
 
     result = CommonWebhook.webhook("geolocation", fields)
 
-    # Assert that success is false and an error message is returned
-    refute result[:success]
-    refute is_nil(result[:error])
-    assert result[:error] == "Received status code 500"
+    assert result == "Received status code 500"
   end
 
   test "detect_language/1 detects correct language from voice note using Bhashini" do
@@ -160,8 +157,7 @@ defmodule Glific.Flows.CommonWebhookTest do
     end)
 
     result = CommonWebhook.webhook("detect_language", fields)
-    assert result[:success] == false
-    assert result[:detected_language] == "Could not detect language"
+    assert result == "Could not detect language"
   end
 
   test "parse_via_gpt_vision without response_format params, trying to get valid json" do
@@ -582,8 +578,7 @@ defmodule Glific.Flows.CommonWebhookTest do
   test "send_wa_group_poll", attrs do
     fields = %{}
 
-    assert %{success: false, error: "wa_group is invalid"} =
-             CommonWebhook.webhook("send_wa_group_poll", fields)
+    assert "wa_group is invalid" = CommonWebhook.webhook("send_wa_group_poll", fields)
 
     fields = %{
       "wa_group" => %{
@@ -593,8 +588,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "organization_id" => attrs.organization_id
     }
 
-    assert %{success: false, error: "poll_uuid is invalid"} =
-             CommonWebhook.webhook("send_wa_group_poll", fields)
+    assert "poll_uuid is invalid" = CommonWebhook.webhook("send_wa_group_poll", fields)
 
     poll = Fixtures.wa_poll_fixture(%{label: "poll_a"})
 
@@ -607,10 +601,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "poll_uuid" => poll.uuid
     }
 
-    assert %{
-             success: false,
-             error: "[\"Elixir.Glific.WAGroup.WAManagedPhone\", \"Resource not found\"]"
-           } =
+    assert "[\"Elixir.Glific.WAGroup.WAManagedPhone\", \"Resource not found\"]" =
              CommonWebhook.webhook("send_wa_group_poll", fields)
 
     wa_phone = Fixtures.wa_managed_phone_fixture(attrs)
@@ -977,17 +968,13 @@ defmodule Glific.Flows.CommonWebhookTest do
 
     result = CommonWebhook.webhook("create_certificate", fields)
 
-    assert result[:success] == false
-    assert result[:error] == "Certificate template not found for ID: #{certificate_id}"
+    assert result == "Certificate template not found for ID: #{certificate_id}"
   end
 
   test "webhook/2 for certificate should fail when validation fails" do
-    # when certificate is invalid
     invalid_fields = %{}
-
-    assert %{success: false, error: error} =
-             CommonWebhook.webhook("create_certificate", invalid_fields)
-
+    error = CommonWebhook.webhook("create_certificate", invalid_fields)
+    assert is_binary(error)
     assert String.split(error, "is required") |> length() == 5
 
     # replace text
@@ -998,7 +985,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "replace_texts" => "John Doe"
     }
 
-    assert %{error: "replace_texts is invalid", success: false} =
+    assert "replace_texts is invalid" =
              CommonWebhook.webhook("create_certificate", invalid_fields)
 
     invalid_fields = %{
@@ -1007,8 +994,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "replace_texts" => %{"{1}" => "John Doe", "{2}" => "March 5, 2025"}
     }
 
-    assert %{error: "contact is required", success: false} =
-             CommonWebhook.webhook("create_certificate", invalid_fields)
+    assert "contact is required" = CommonWebhook.webhook("create_certificate", invalid_fields)
 
     invalid_fields = %{
       "certificate_id" => 0,
@@ -1017,7 +1003,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "replace_texts" => %{"{1}" => "John Doe", "{2}" => "March 5, 2025"}
     }
 
-    assert %{error: "Certificate template not found" <> _} =
+    assert "Certificate template not found" <> _ =
              CommonWebhook.webhook("create_certificate", invalid_fields)
   end
 
@@ -1236,7 +1222,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       {exception, tags} =
         capture_appsignal(fn ->
           result = CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
-          assert result.success == false
+          assert is_binary(result)
         end)
 
       assert %SystemError{} = exception
@@ -1258,8 +1244,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       {exception, tags} =
         capture_appsignal(fn ->
           result = CommonWebhook.webhook("speech_to_text_with_bhasini", fields)
-          assert result.success == false
-          assert result.asr_response_text == "File download failed"
+          assert result == "File download failed"
         end)
 
       assert %SystemError{} = exception
@@ -1345,7 +1330,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       {exception, tags} =
         capture_appsignal(fn ->
           result = CommonWebhook.webhook("text_to_speech_with_bhasini", fields)
-          assert result.success == false
+          assert is_binary(result)
         end)
 
       assert %SystemError{} = exception

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -601,7 +601,7 @@ defmodule Glific.Flows.CommonWebhookTest do
       "poll_uuid" => poll.uuid
     }
 
-    assert "[\"Elixir.Glific.WAGroup.WAManagedPhone\", \"Resource not found\"]" =
+    assert ~s|["Elixir.Glific.WAGroup.WAManagedPhone", "Resource not found"]| =
              CommonWebhook.webhook("send_wa_group_poll", fields)
 
     wa_phone = Fixtures.wa_managed_phone_fixture(attrs)

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -356,6 +356,64 @@ defmodule Glific.Flows.WebhookTest do
     end
   end
 
+  describe "Webhook.update_log/2 failure handling" do
+    test "records %{success: false, reason: _} as status 400 with the reason as error", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: false, reason: "Kaapi STT failed"}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 400
+      assert log.error == "Kaapi STT failed"
+      assert log.response_json == result
+    end
+
+    test "falls back to :error when :reason is absent", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: false, error: "Bad input"}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 400
+      assert log.error == "Bad input"
+    end
+
+    test "falls back to :message when :reason and :error are absent", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: false, message: "Something went wrong"}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 400
+      assert log.error == "Something went wrong"
+    end
+
+    test "defaults to a generic error when no reason-like field is present", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: false}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 400
+      assert log.error == "Webhook failure"
+    end
+
+    test "leaves success maps as status 200 with no error", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: true, parsed_msg: "ok"}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 200
+      assert log.error == nil
+    end
+
+    test "treats a map without a success key as a 200 response(for get_buttons and check_response webhook)",
+         attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{response: "ok", extra: 1}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 200
+      assert log.error == nil
+    end
+  end
+
   test "execute a webhook with a POST request, consecutive webhook calls should not work",
        attrs do
     Tesla.Mock.mock(fn

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -412,6 +412,19 @@ defmodule Glific.Flows.WebhookTest do
       assert log.status_code == 200
       assert log.error == nil
     end
+
+    test "handles non-binary reason (e.g. a decoded JSON map) without crashing", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      # Bhasini sets %{success: false, reason: body} on a 500 with body being a
+      # decoded JSON map. to_string/1 would raise on that; the cond path uses
+      # inspect/1 instead so the log row still gets written.
+      result = %{success: false, reason: %{"error" => "upstream blew up"}}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 400
+      assert is_binary(log.error)
+      assert String.contains?(log.error, "upstream blew up")
+    end
   end
 
   test "execute a webhook with a POST request, consecutive webhook calls should not work",

--- a/test/glific/third_party/gemini_test.exs
+++ b/test/glific/third_party/gemini_test.exs
@@ -76,9 +76,9 @@ defmodule Glific.ThirdParty.GeminiTest do
   end
 
   describe "text_to_speech/2" do
-    test "returns error message when GCS is not enabled", %{organization_id: organization_id} do
+    test "returns a failure map when GCS is not enabled", %{organization_id: organization_id} do
       result = Gemini.text_to_speech(organization_id, "Hello World")
-      assert result == "Enable GCS to use Gemini text to speech"
+      assert result == %{success: false, reason: "GCS is disabled"}
     end
 
     @tag :skip


### PR DESCRIPTION

## Summary
 Target issue is  #5136
 
A number of our FUNCTION webhooks returned a %{success: false, ...} map on error. Because Glific.Flows.Webhook.handle/3 decides Success vs Failure purely by is_map (a map ⇒ Success), these failures took the Success branch — the contact got a broken/empty response while the flow carried on, forcing flow authors to bolt on split-by-success nodes to catch errors.

This PR makes the affected webhooks return a bare error string on failure, so the flow consistently routes to the Failure category, and wraps each in with_failure_reporting so the failure is also logged to AppSignal. It's the same pattern already applied to parse_via_chat_gpt / parse_via_gpt_vision in #5132.

**Webhooks fixed:** geolocation, send_wa_group_poll, create_certificate, speech_to_text_with_bhasini, text_to_speech_with_bhasini, nmt_tts_with_bhasini.
