### PR TITLE
chore: reduce PR stale period from 90 to 30 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,6 +17,6 @@ jobs:
           stale-pr-message: "Without activity, this PR will be closed in 1 day."
           close-pr-message: "This PR was closed for inactivity."
           stale-pr-label: "inactive"
-          days-before-pr-stale: 90
+          days-before-pr-stale: 30
           days-before-pr-close: 1
           exempt-all-assignees: true


### PR DESCRIPTION
## Summary

- Reduces the GitHub stale PR timeout from 90 days to 30 days in the `stale.yml` workflow
- PRs with no activity for 30 days will be marked stale and closed after 1 additional day of inactivity
- PRs with assignees are still exempt from stale marking

## Context

This was decided during a dev retrospective to keep the PR backlog cleaner and encourage faster review cycles.