### PR TITLE
fix: increase recv_timeout for evaluations API call to 15 seconds

### DIFF
--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -278,7 +278,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
     |> client()
     |> Tesla.get("/api/v1/evaluations/:evaluation_id",
       query: [get_trace_info: "true"],
-      opts: [path_params: [evaluation_id: evaluation_id]]
+      opts: [path_params: [evaluation_id: evaluation_id], adapter: [recv_timeout: 15_000]]
     )
     |> parse_kaapi_response()
   end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -345,7 +345,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            AIEvaluations.create_ai_evaluation(%{
              name: input.evaluation_name,
              status: String.to_existing_atom(data.status),
-             failure_reason: Map.get(data, :error_message, ""),
+             failure_reason: (data.status == "failed" && Map.get(data, :error_message)) || nil,
              kaapi_evaluation_id: data.id,
              golden_qa_id: input.golden_qa_id,
              assistant_config_version_id: input.config_id,

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -345,6 +345,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            AIEvaluations.create_ai_evaluation(%{
              name: input.evaluation_name,
              status: String.to_existing_atom(data.status),
+             failure_reason: Map.get(data, :error_message, ""),
              kaapi_evaluation_id: data.id,
              golden_qa_id: input.golden_qa_id,
              assistant_config_version_id: input.config_id,


### PR DESCRIPTION

## Summary
increase recv_timeout for evaluations API call to 15 seconds


