### PR TITLE
chore: deny Claude from reading secret config files

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,11 @@
 {
   "enabledPlugins": {
     "claude-md-management@claude-plugins-official": true
+  },
+  "permissions": {
+    "deny": [
+      "Read(config/.env.dev)",
+      "Read(config/dev.secret.exs)"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `permissions.deny` block to `.claude/settings.json`
- Blocks Claude Code from reading `config/.env.dev` and `config/dev.secret.exs` at the harness level
- Prevents accidental exposure of local secrets and credentials during AI-assisted development

## What changed and why

Claude Code supports project-level permission rules. By listing file paths under `permissions.deny`, any attempt by Claude to read those files is blocked regardless of the instruction source — providing a hard guardrail around sensitive config files that contain API keys, database passwords, and other secrets.

## Reviewer notes

This only affects the Claude Code CLI tooling configuration (`.claude/settings.json`). It has no impact on the application runtime, tests, or CI.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)