### PR TITLE
feat: restrict golden QA when questions × duplication_factor > 80

### DIFF
--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -278,7 +278,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
     |> client()
     |> Tesla.get("/api/v1/evaluations/:evaluation_id",
       query: [get_trace_info: "true"],
-      opts: [path_params: [evaluation_id: evaluation_id], adapter: [recv_timeout: 15_000]]
+      opts: [path_params: [evaluation_id: evaluation_id], adapter: [recv_timeout: 30_000]]
     )
     |> parse_kaapi_response()
   end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -47,6 +47,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   # 1MB
   @max_golden_qa_file_size 1 * 1024 * 1024
+  @max_golden_qa_evaluations 80
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
   @ai_evaluation_create_success_metric "AI Evaluation Created"
@@ -105,6 +106,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
+         :ok <- validate_golden_qa_question_limit(file, factor),
          {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
@@ -184,6 +186,42 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     |> Enum.map(fn {field, messages} ->
       %{message: "#{field}: #{Enum.join(messages, "; ")}"}
     end)
+  end
+
+  @spec validate_golden_qa_question_limit(struct(), integer()) :: :ok | {:error, String.t()}
+  defp validate_golden_qa_question_limit(%{path: path}, factor) do
+    case count_csv_data_rows(path) do
+      {:ok, count} ->
+        total = count * factor
+
+        if total <= @max_golden_qa_evaluations do
+          :ok
+        else
+          {:error,
+           "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
+             "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
+             "Please reduce the number of questions in the CSV or the duplication factor."}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec count_csv_data_rows(String.t()) :: {:ok, non_neg_integer()} | {:error, String.t()}
+  defp count_csv_data_rows(path) do
+    count =
+      path
+      |> File.stream!()
+      |> CSV.decode(headers: true)
+      |> Enum.count(fn
+        {:ok, _} -> true
+        _ -> false
+      end)
+
+    {:ok, count}
+  rescue
+    _ -> {:error, "Unable to parse the uploaded CSV file"}
   end
 
   @spec validate_golden_qa_name(String.t()) :: :ok | {:error, String.t()}

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -213,7 +213,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     count =
       path
       |> File.stream!()
-      |> CSV.decode(headers: true)
+      |> CSV.decode(headers: true, escape_max_lines: 50)
       |> Enum.count(fn
         {:ok, _} -> true
         _ -> false

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -210,16 +210,16 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   @spec count_csv_data_rows(String.t()) :: {:ok, non_neg_integer()} | {:error, String.t()}
   defp count_csv_data_rows(path) do
-    count =
-      path
-      |> File.stream!()
-      |> CSV.decode(headers: true, escape_max_lines: 50)
-      |> Enum.count(fn
-        {:ok, _} -> true
-        _ -> false
-      end)
+    path
+    |> File.stream!()
+    |> CSV.decode(headers: true, escape_max_lines: 50)
+    |> Enum.reduce_while({:ok, 0}, fn
+      {:ok, _row}, {:ok, acc} ->
+        {:cont, {:ok, acc + 1}}
 
-    {:ok, count}
+      {:error, _reason}, _acc ->
+        {:halt, {:error, "Unable to parse the uploaded CSV file"}}
+    end)
   rescue
     _ -> {:error, "Unable to parse the uploaded CSV file"}
   end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -106,7 +106,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
-         :ok <- validate_golden_qa_question_limit(file, factor),
+         {:ok, row_count} <- validate_csv_structure(file),
+         :ok <- validate_golden_qa_question_limit(row_count, factor),
          {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
@@ -188,40 +189,47 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end)
   end
 
-  @spec validate_golden_qa_question_limit(struct(), integer()) :: :ok | {:error, String.t()}
-  defp validate_golden_qa_question_limit(%{path: path}, factor) do
-    case count_csv_data_rows(path) do
-      {:ok, count} ->
-        total = count * factor
-
-        if total <= @max_golden_qa_evaluations do
-          :ok
-        else
-          {:error,
-           "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
-             "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
-             "Please reduce the number of questions in the CSV or the duplication factor."}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  @spec count_csv_data_rows(String.t()) :: {:ok, non_neg_integer()} | {:error, String.t()}
-  defp count_csv_data_rows(path) do
+  @spec validate_csv_structure(struct()) :: {:ok, non_neg_integer()} | {:error, String.t()}
+  defp validate_csv_structure(%{path: path}) do
     path
     |> File.stream!()
-    |> CSV.decode(headers: true, escape_max_lines: 50)
-    |> Enum.reduce_while({:ok, 0}, fn
-      {:ok, _row}, {:ok, acc} ->
-        {:cont, {:ok, acc + 1}}
+    |> CSV.decode(headers: false, escape_max_lines: 50)
+    |> Enum.reduce_while({:await_header, 0}, fn
+      {:ok, row}, {:await_header, _} ->
+        if row == ["question", "answer"] do
+          {:cont, {:count, 0}}
+        else
+          {:halt, {:error, "CSV must have exactly two columns: 'question' and 'answer'"}}
+        end
+
+      {:ok, _row}, {:count, n} ->
+        {:cont, {:count, n + 1}}
 
       {:error, _reason}, _acc ->
         {:halt, {:error, "Unable to parse the uploaded CSV file"}}
     end)
+    |> case do
+      {:count, n} -> {:ok, n}
+      {:await_header, _} -> {:error, "The uploaded CSV file is empty"}
+      {:error, _} = err -> err
+    end
   rescue
     _ -> {:error, "Unable to parse the uploaded CSV file"}
+  end
+
+  @spec validate_golden_qa_question_limit(non_neg_integer(), integer()) ::
+          :ok | {:error, String.t()}
+  defp validate_golden_qa_question_limit(count, factor) do
+    total = count * factor
+
+    if total <= @max_golden_qa_evaluations do
+      :ok
+    else
+      {:error,
+       "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
+         "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
+         "Please reduce the number of questions in the CSV or the duplication factor."}
+    end
   end
 
   @spec validate_golden_qa_name(String.t()) :: :ok | {:error, String.t()}

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -702,19 +702,17 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
-    test "counts only valid CSV rows, ignoring malformed rows with escape sequence errors", %{
+    test "returns error when CSV contains malformed rows (escape sequence errors)", %{
       staff: user
     } do
-      # An unclosed quote at EOF causes the CSV library to emit {:error, _} for that row,
-      # hitting the _ -> false branch. The row is counted as 0 questions.
+      # Unclosed quote triggers {:error, _} from CSV.decode; reduce_while halts immediately
       csv_path =
         Path.join(
           System.tmp_dir!(),
           "malformed_csv_#{System.unique_integer([:positive])}.csv"
         )
 
-      # 16 valid rows × 5 = 80 (at limit); if malformed row were counted: 17 × 5 = 85 → would fail
-      good_rows = for i <- 1..16, do: "Question #{i}?,Answer #{i}"
+      good_rows = for i <- 1..5, do: "Question #{i}?,Answer #{i}"
       content = Enum.join(["question,answer" | good_rows] ++ ["\"unclosed quote"], "\n")
       File.write!(csv_path, content)
       on_exit(fn -> File.rm(csv_path) end)
@@ -725,29 +723,20 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
         filename: "malformed.csv"
       }
 
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{
-            status: 200,
-            body: %{data: %{dataset_name: "valid_name", dataset_id: "99004"}}
-          }
-      end)
-
       args = %{
         input: %{
           name: "valid_name",
           file: upload,
-          duplication_factor: 5
+          duplication_factor: 1
         }
       }
 
       resolution = %{context: %{current_user: user}}
 
-      # Malformed row is not counted; 16 × 5 = 80 ≤ 80 → request succeeds
-      assert {:ok, %{golden_qa: golden_qa}} =
+      assert {:ok, %{errors: [%{message: msg}]}} =
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
-      assert golden_qa.name == "valid_name"
+      assert msg == "Unable to parse the uploaded CSV file"
     end
 
     test "accepts valid name with underscores and numbers", %{

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -525,6 +525,156 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert reason == "Timeout occurred, please try again."
     end
 
+    test "returns error when questions × duplication_factor exceeds 80", %{staff: user} do
+      csv_path = create_csv_with_rows(41)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "large_golden_qa.csv"
+      }
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 2
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
+        assert {:ok, %{errors: [%{message: msg}]}} =
+                 AIEvaluations.create_golden_qa(nil, args, resolution)
+
+        assert msg =~
+                 "exceeds the maximum allowed limit of 80"
+
+        assert msg =~ "41 questions"
+        assert msg =~ "2 duplication factor"
+        assert msg =~ "82"
+
+        assert called(
+                 Glific.Metrics.increment(
+                   @create_golden_qa_failure_metric,
+                   user.organization_id
+                 )
+               )
+      end
+    end
+
+    test "succeeds when questions × duplication_factor equals exactly 80 (boundary)", %{
+      staff: user
+    } do
+      csv_path = create_csv_with_rows(40)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "boundary_golden_qa.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99001"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 2
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
+    test "succeeds when questions × duplication_factor is well under 80", %{staff: user} do
+      csv_path = create_csv_with_rows(5)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "small_golden_qa.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99002"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 3
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
+    test "succeeds when CSV has only a header row (0 questions)", %{staff: user} do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "empty_golden_qa_#{System.unique_integer([:positive])}.csv"
+        )
+
+      File.write!(csv_path, "question,answer\n")
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "empty_golden_qa.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99003"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 5
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
     test "accepts valid name with underscores and numbers", %{
       staff: user,
       upload: upload
@@ -1261,6 +1411,25 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
     on_exit(fn -> File.rm(tmp_path) end)
 
     {:ok, upload: upload}
+  end
+
+  # Creates a CSV with a header row and the given number of data rows.
+  # Returns the path to the temporary file.
+  defp create_csv_with_rows(num_rows) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "csv_rows_#{num_rows}_#{System.unique_integer([:positive])}.csv"
+      )
+
+    rows =
+      for i <- 1..num_rows do
+        "Question #{i}?,Answer #{i}"
+      end
+
+    content = Enum.join(["question,answer" | rows], "\n") <> "\n"
+    File.write!(path, content)
+    path
   end
 
   # Creates a file of size (megabytes) MB for testing file size validation.

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -675,6 +675,80 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert golden_qa.name == "valid_name"
     end
 
+    test "returns error when CSV file cannot be parsed due to stream error", %{staff: user} do
+      # A directory path passes File.stat (tiny metadata size < 1MB) but raises
+      # File.Error with :eisdir when File.stream! is enumerated, triggering the rescue
+      dir_path = System.tmp_dir!()
+
+      upload = %Plug.Upload{
+        path: dir_path,
+        content_type: "text/csv",
+        filename: "bad.csv"
+      }
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 1
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg == "Unable to parse the uploaded CSV file"
+    end
+
+    test "counts only valid CSV rows, ignoring malformed rows with escape sequence errors", %{
+      staff: user
+    } do
+      # An unclosed quote at EOF causes the CSV library to emit {:error, _} for that row,
+      # hitting the _ -> false branch. The row is counted as 0 questions.
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "malformed_csv_#{System.unique_integer([:positive])}.csv"
+        )
+
+      good_rows = for i <- 1..5, do: "Question #{i}?,Answer #{i}"
+      content = Enum.join(["question,answer" | good_rows] ++ ["\"unclosed quote"], "\n")
+      File.write!(csv_path, content)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "malformed.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99004"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 1
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      # 5 valid rows × 1 = 5 <= 80; malformed row not counted; request succeeds
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
     test "accepts valid name with underscores and numbers", %{
       staff: user,
       upload: upload

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -713,7 +713,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
           "malformed_csv_#{System.unique_integer([:positive])}.csv"
         )
 
-      good_rows = for i <- 1..5, do: "Question #{i}?,Answer #{i}"
+      # 16 valid rows × 5 = 80 (at limit); if malformed row were counted: 17 × 5 = 85 → would fail
+      good_rows = for i <- 1..16, do: "Question #{i}?,Answer #{i}"
       content = Enum.join(["question,answer" | good_rows] ++ ["\"unclosed quote"], "\n")
       File.write!(csv_path, content)
       on_exit(fn -> File.rm(csv_path) end)
@@ -736,13 +737,13 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
         input: %{
           name: "valid_name",
           file: upload,
-          duplication_factor: 1
+          duplication_factor: 5
         }
       }
 
       resolution = %{context: %{current_user: user}}
 
-      # 5 valid rows × 1 = 5 <= 80; malformed row not counted; request succeeds
+      # Malformed row is not counted; 16 × 5 = 80 ≤ 80 → request succeeds
       assert {:ok, %{golden_qa: golden_qa}} =
                AIEvaluations.create_golden_qa(nil, args, resolution)
 

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -739,6 +739,58 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
+    test "returns error when CSV columns are not exactly 'question' and 'answer'", %{
+      staff: user
+    } do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "wrong_cols_#{System.unique_integer([:positive])}.csv"
+        )
+
+      File.write!(csv_path, "name,response\nWhat is Glific?,A platform\n")
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "wrong_cols.csv"
+      }
+
+      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg == "CSV must have exactly two columns: 'question' and 'answer'"
+    end
+
+    test "returns error when CSV file is empty (no rows at all)", %{staff: user} do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "empty_file_#{System.unique_integer([:positive])}.csv"
+        )
+
+      File.write!(csv_path, "")
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "empty.csv"
+      }
+
+      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg == "The uploaded CSV file is empty"
+    end
+
     test "accepts valid name with underscores and numbers", %{
       staff: user,
       upload: upload


### PR DESCRIPTION
## Summary

- Adds `validate_golden_qa_question_limit/2` in the `create_golden_qa` resolver that counts CSV data rows and multiplies by the duplication factor
- Rejects the request **before** uploading to Kaapi if the product exceeds 80, returning a descriptive error that includes the question count, factor, total, and limit
- Uses the existing `csv ~> 3.2` library (`CSV.decode/2` with `headers: true`) to skip the header row and count only data rows

## Test plan

- [x] `returns error when questions × duplication_factor exceeds 80` (41 × 2 = 82)
- [x] `succeeds when questions × duplication_factor equals exactly 80 (boundary)` (40 × 2 = 80)
- [x] `succeeds when questions × duplication_factor is well under 80` (5 × 3 = 15)
- [x] `succeeds when CSV has only a header row (0 questions)` (0 × 5 = 0)
- [x] All 55 existing tests pass
- [x] `mix check` passes (Credo, Dialyzer, format, doctor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Golden QA creation now enforces a maximum limit on total questions (CSV rows × duplication factor) and rejects uploads that exceed it.
  * Enhanced CSV validation with clearer error messages for invalid formats and empty files.

* **Bug Fixes**
  * Improved reliability of evaluation score retrieval by increasing request timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->