### PR TITLE
docs: update CLAUDE.md with learnings from week of 2026-06-04

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,12 @@ An open source two-way communication platform for the social sector (WhatsApp-ba
 
 ```
 glific/
+├── .claude/             # Claude Code project configuration
+│   ├── settings.json    # Permission rules (deny list for secret files)
+│   └── skills/          # Project-specific Claude skills
+│       ├── fix-flaky-tests/
+│       ├── improve-code-coverage/
+│       └── make-branch-ready-for-review/
 ├── api.docs/            # API documentation (Bruno collections, examples)
 ├── assets/              # Frontend assets (JS, CSS, Tailwind, GQL)
 ├── build_scripts/       # Deployment scripts (Gigalixir)
@@ -25,7 +31,8 @@ glific/
 │   │   ├── messages/    # Message handling
 │   │   ├── contacts/    # Contact management
 │   │   ├── providers/   # BSP integrations (Gupshup, Maytapi)
-│   │   ├── third_party/ # External services (BigQuery, Dialogflow, GCS, Gemini, etc.)
+│   │   ├── scripts/     # Admin IEx console helper scripts (not web-facing)
+│   │   ├── third_party/ # External services (BigQuery, Dialogflow, GCS, Gemini, Discord, etc.)
 │   │   └── ...          # ~49 context modules at root level
 │   └── glific_web/      # Web layer
 │       ├── controllers/ # REST API controllers
@@ -129,6 +136,7 @@ glific/
 - **Module Attributes**: `@valid_attrs` and `@invalid_attrs` for test data
 - **HTTP Mocking**: Tesla.Mock for external API calls
 - **Coverage**: ExCoveralls with `mix test_full` task
+- **Deterministic ordering**: Always add a secondary `asc: t.id` sort when ordering by `inserted_at` — timestamp ties (common in rapid test inserts) cause non-deterministic ordering and flaky assertions
 
 ## Error Handling Patterns
 
@@ -178,10 +186,27 @@ glific/
 - **Repo**: `Glific.Repo` (primary) + `Glific.RepoReplica` (read-only replica, points to primary in tests)
 - **Migrations**: Timestamp-based naming `YYYYMMDDhhmmss_description.exs`
 - **Soft deletes**: `deleted_at` field with partial indexes (`WHERE deleted_at IS NULL`)
+- **Partial unique indexes**: Used for boolean-flag uniqueness (e.g., only one `is_primary = true` row per group); named explicitly (e.g., `wa_groups_phones_one_primary`) and enforced via `unique_constraint/3` with the `name:` option in the changeset
 - **Timestamps**: Always `timestamps(type: :utc_datetime)`
 - **Seeds**: Modular seed files (`seeds_dev.exs`, `seeds_credentials.exs`, `seeds_optins.exs`, `seeds_scale.exs`)
 - **Query helpers**: Centralized in `RepoHelpers` - `list_filter/5`, `filter_with/2`, `opts_with_name/2`, `opts_with_field/3`
 - **Audit**: `ExAudit.Repo` for change tracking
+
+## Admin Scripts
+
+- **Location**: `lib/glific/scripts/` — IEx console helper modules, not web-facing or Oban workers
+- **Purpose**: One-off or manual admin operations run from the production console (e.g., `gigalixir remote_console`)
+- **Pattern**: Each script module is self-contained with a clear `@moduledoc` showing the exact IEx invocation
+- **Naming**: `Glific.Scripts.<Domain>` (e.g., `Glific.Scripts.Evals`)
+- Always call `Repo.put_organization_id/1` at the top of any script function that touches org-scoped data
+
+## Claude Code Project Configuration
+
+- **Settings**: `.claude/settings.json` — project-level permission rules; `permissions.deny` blocks reads of secret config files (`config/.env.dev`, `config/dev.secret.exs`)
+- **Skills**: `.claude/skills/` — project-specific Claude Code skills:
+  - `fix-flaky-tests` — evidence-first workflow for diagnosing and fixing flaky tests
+  - `improve-code-coverage` — guides coverage improvements with a local check script (`check_codecov_local.py`)
+  - `make-branch-ready-for-review` — runs Credo, Dialyzer, format, and coverage checks before opening a PR
 
 ## Code Quality & Formatting
 


### PR DESCRIPTION
## Summary

Updates CLAUDE.md to reflect new patterns, directories, and conventions introduced in the 16 commits merged to master between 2026-05-28 and 2026-06-04.

- **Directory structure**: Added `.claude/` root entry (settings + skills) and `lib/glific/scripts/` to the tree; added Discord to the `third_party/` comment
- **Testing conventions**: New rule — always add a secondary `asc: t.id` sort when ordering by `inserted_at` to avoid flaky test failures from timestamp ties (from #5180)
- **Database conventions**: New partial unique index pattern — boolean-flag uniqueness via named partial index + `unique_constraint/3` with `name:` option (from `WAGroupPhone.is_primary` in #5151)
- **Admin Scripts** (new section): Documents `lib/glific/scripts/` for IEx console helpers, naming convention (`Glific.Scripts.<Domain>`), and the requirement to call `Repo.put_organization_id/1` at the top (from #5170)
- **Claude Code Project Configuration** (new section): Documents `.claude/settings.json` permission deny rules and the three project skills added in #5178 and #5179

## Commits covered

| SHA | Description |
|---|---|
| #5151 | Add WAGroupPhone schema and migration for multi-phone support |
| #5157 | Validate BigQuery service account permissions at setup time |
| #5159 | Weekly email report for orgs with disabled BQ/GCS credentials |
| #5167 | Reduce PR stale period from 90 to 30 days |
| #5170 | Add IEx helper to approve eval access with Langfuse credentials |
| #5173 | Increase recv_timeout for evaluations API call |
| #5178 | Deny Claude from reading secret config files |
| #5179 | Add Claude skills: fix-flaky-tests, improve-code-coverage, make-branch-ready-for-review |
| #5180 | Fix deterministic ordering in fetch_support_tickets |
| #5181 | Restrict golden QA when questions × duplication_factor > 80 |

## Test plan

- [ ] Review each added/changed bullet for accuracy against the linked PRs
- [ ] Confirm no existing conventions were accidentally removed or altered

---
_Generated by [Claude Code](https://claude.ai/code/session_01AvhxjWwmQY5cvzEUg5g8tH)_