### PR TITLE
chore: configure Claude worktree symlink directories

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,5 +7,14 @@
       "Read(config/.env.dev)",
       "Read(config/dev.secret.exs)"
     ]
+  },
+  "worktree": {
+    "symlinkDirectories": [
+      "_build",
+      "deps",
+      "priv/cert",
+      "config/.env.dev",
+      "config/dev.secret.exs"
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `worktree.symlinkDirectories` config to `.claude/settings.json`
- Symlinks `_build`, `deps`, `priv/cert`, `config/.env.dev`, and `config/dev.secret.exs` from the main checkout into any new Claude Code worktree

## Why

When Claude Code creates an isolated git worktree (for parallel agent tasks or `--worktree` sessions), it normally starts with an empty directory — meaning a fresh `mix deps.get` + `mix compile` on every worktree. Symlinking these paths means:

- `_build` / `deps` — the worktree agent reuses compiled Elixir artifacts immediately, no recompilation needed
- `priv/cert` — TLS certificates are available without manual setup
- `config/.env.dev` / `config/dev.secret.exs` — local dev credentials are available without duplication

## Reviewer notes

This only affects `.claude/settings.json` (a Claude Code tooling config file, not application config). No application code or runtime behaviour is changed.