### PR TITLE
fix: handle invalid Google Sheet URL during flow import instead of crashing

### DIFF
--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -1164,9 +1164,15 @@ defmodule Glific.Flows do
        ) do
     sheet_url = action["url"]
     sheet_name = action["name"]
-    sheet = get_or_create_sheet(sheet_url, sheet_name)
-    updated_action = Map.put(action, "sheet_id", sheet.id)
-    {:ok, updated_action}
+    sheet_type = action["action_type"] || "READ"
+
+    case get_or_create_sheet(sheet_url, sheet_name, sheet_type) do
+      nil ->
+        {:ok, Map.put(action, "sheet_id", nil)}
+
+      sheet ->
+        {:ok, Map.put(action, "sheet_id", sheet.id)}
+    end
   end
 
   defp process_action(
@@ -1231,12 +1237,13 @@ defmodule Glific.Flows do
     Map.has_key?(action, "templating") and template_uuid not in template_uuid_list
   end
 
-  defp get_or_create_sheet(sheet_url, sheet_name) do
+  defp get_or_create_sheet(sheet_url, sheet_name, sheet_type) do
     current_user = Repo.get_current_user()
 
     attrs = %{
       url: sheet_url,
       label: sheet_name,
+      type: sheet_type,
       organization_id: current_user.organization_id
     }
 
@@ -1245,8 +1252,18 @@ defmodule Glific.Flows do
         sheet
 
       {:error, _} ->
-        {:ok, sheet} = Sheets.create_sheet(attrs)
-        sheet
+        case Sheets.create_sheet(attrs) do
+          {:ok, sheet} ->
+            sheet
+
+          {:error, reason} ->
+            Logger.warning(
+              "Unable to create Google Sheet while importing flow action for URL " <>
+                "#{inspect(sheet_url)}: #{inspect(reason)}"
+            )
+
+            nil
+        end
     end
   end
 

--- a/test/glific/flows_test.exs
+++ b/test/glific/flows_test.exs
@@ -1,6 +1,8 @@
 defmodule Glific.FLowsTest do
   use Glific.DataCase
 
+  import ExUnit.CaptureLog
+
   alias Glific.{
     Fixtures,
     Flows,
@@ -15,7 +17,8 @@ defmodule Glific.FLowsTest do
     Processor.ConsumerFlow,
     Processor.ConsumerWorker,
     Repo,
-    Seeds.SeedsDev
+    Seeds.SeedsDev,
+    Sheets.Sheet
   }
 
   describe "flows" do
@@ -555,6 +558,87 @@ defmodule Glific.FLowsTest do
       assert {:error, %Ecto.Changeset{}} = Flows.copy_flow(flow, %{})
     end
 
+    test "import_flow/2 links valid google sheet actions",
+         %{organization_id: organization_id} do
+      mock_google_sheet_requests()
+
+      flow_name = unique_import_flow_name("valid-sheet")
+      sheet_url = valid_google_sheet_url()
+
+      import_flow = import_flow_payload([flow_revision_with_sheet_action(flow_name, sheet_url)])
+
+      assert [%{flow_name: ^flow_name, status: "Successfully imported"}] =
+               Flows.import_flow(import_flow, organization_id)
+
+      assert {:ok, sheet} = Repo.fetch_by(Sheet, %{url: sheet_url})
+
+      action = imported_google_sheet_action(flow_name)
+      assert action["sheet_id"] == sheet.id
+    end
+
+    test "import_flow/2 preserves sheet_id and logs a warning for invalid google sheet URLs",
+         %{organization_id: organization_id} do
+      mock_google_sheet_requests()
+
+      flow_name = unique_import_flow_name("invalid-sheet")
+      sheet_url = "Add Sheet URL"
+
+      import_flow =
+        import_flow_payload([
+          flow_revision_with_sheet_action(flow_name, sheet_url, sheet_id: 1234)
+        ])
+
+      log =
+        capture_log(fn ->
+          assert [%{flow_name: ^flow_name, status: "Successfully imported"}] =
+                   Flows.import_flow(import_flow, organization_id)
+        end)
+
+      action = imported_google_sheet_action(flow_name)
+      assert Map.has_key?(action, "sheet_id")
+      assert is_nil(action["sheet_id"])
+      assert log =~ "Unable to create Google Sheet while importing flow action"
+      assert log =~ sheet_url
+
+      assert {:ok, flow} = Repo.fetch_by(Flow, %{name: flow_name})
+      assert %Flow{} = Flow.get_loaded_flow(organization_id, "draft", %{id: flow.id})
+      assert is_list(Flow.validate_flow(organization_id, "draft", %{id: flow.id}))
+    end
+
+    test "import_flow/2 continues importing a batch when one google sheet URL is invalid",
+         %{organization_id: organization_id} do
+      mock_google_sheet_requests()
+
+      invalid_flow_name = unique_import_flow_name("batch-invalid-sheet")
+      valid_flow_name = unique_import_flow_name("batch-valid-sheet")
+      valid_sheet_url = valid_google_sheet_url()
+
+      import_flow =
+        import_flow_payload([
+          flow_revision_with_sheet_action(invalid_flow_name, "Add Sheet URL", sheet_id: 1234),
+          flow_revision_with_sheet_action(valid_flow_name, valid_sheet_url)
+        ])
+
+      log =
+        capture_log(fn ->
+          assert [
+                   %{flow_name: ^invalid_flow_name, status: "Successfully imported"},
+                   %{flow_name: ^valid_flow_name, status: "Successfully imported"}
+                 ] = Flows.import_flow(import_flow, organization_id)
+        end)
+
+      assert log =~ "Add Sheet URL"
+      assert {:ok, _flow} = Repo.fetch_by(Flow, %{name: invalid_flow_name})
+      assert {:ok, _flow} = Repo.fetch_by(Flow, %{name: valid_flow_name})
+
+      invalid_action = imported_google_sheet_action(invalid_flow_name)
+      valid_action = imported_google_sheet_action(valid_flow_name)
+
+      assert Map.has_key?(invalid_action, "sheet_id")
+      assert is_nil(invalid_action["sheet_id"])
+      assert is_integer(valid_action["sheet_id"])
+    end
+
     test "flow keyword map keys are always in lower case", attrs do
       flow = flow_fixture()
 
@@ -568,6 +652,105 @@ defmodule Glific.FLowsTest do
                  keyword != Glific.string_clean(keyword)
                end)
     end
+  end
+
+  defp mock_google_sheet_requests do
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "Add Sheet URL"} ->
+        {:error, :invalid_url}
+
+      %{method: :get, url: url} when is_binary(url) ->
+        if String.contains?(url, "export?format=csv") do
+          %Tesla.Env{
+            status: 200,
+            body: "Key,Day,Message English\r\nwelcome,1,Hello"
+          }
+        else
+          {:error, :unexpected_url}
+        end
+    end)
+  end
+
+  defp import_flow_payload(flow_revisions) do
+    %{
+      "flows" => flow_revisions,
+      "contact_field" => [],
+      "collections" => [],
+      "interactive_templates" => []
+    }
+  end
+
+  defp flow_revision_with_sheet_action(flow_name, sheet_url, opts \\ []) do
+    flow_uuid = Ecto.UUID.generate()
+    node_uuid = Ecto.UUID.generate()
+
+    action =
+      %{
+        "uuid" => Ecto.UUID.generate(),
+        "type" => "link_google_sheet",
+        "name" => "#{flow_name} sheet",
+        "url" => sheet_url,
+        "action_type" => "READ",
+        "result_name" => "sheet_result",
+        "sheet_id" => Keyword.get(opts, :sheet_id)
+      }
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+      |> Map.new()
+
+    %{
+      "definition" => %{
+        "name" => flow_name,
+        "uuid" => flow_uuid,
+        "spec_version" => "13.1.0",
+        "language" => "base",
+        "type" => "messaging",
+        "nodes" => [
+          %{
+            "uuid" => node_uuid,
+            "actions" => [action],
+            "exits" => []
+          }
+        ],
+        "_ui" => %{
+          "nodes" => %{
+            node_uuid => %{
+              "position" => %{
+                "top" => 0,
+                "left" => 0
+              }
+            }
+          }
+        },
+        "localization" => %{},
+        "revision" => 1,
+        "expire_after_minutes" => 10_080
+      },
+      "keywords" => []
+    }
+  end
+
+  defp imported_google_sheet_action(flow_name) do
+    {:ok, flow} = Repo.fetch_by(Flow, %{name: flow_name})
+
+    revision =
+      FlowRevision
+      |> where([fr], fr.flow_id == ^flow.id)
+      |> order_by([fr], desc: fr.id)
+      |> limit(1)
+      |> Repo.one!()
+
+    revision.definition
+    |> Map.get("nodes", [])
+    |> Enum.flat_map(fn node -> node["actions"] || [] end)
+    |> Enum.find(fn action -> action["type"] == "link_google_sheet" end)
+  end
+
+  defp unique_import_flow_name(prefix) do
+    "#{prefix}-#{System.unique_integer([:positive])}"
+  end
+
+  defp valid_google_sheet_url do
+    "https://docs.google.com/spreadsheets/d/#{Ecto.UUID.generate()}/edit#gid=0"
   end
 
   defp expected_error(str) do


### PR DESCRIPTION
## Summary

Target issue is #5177

Importing a flow that contains a `link_google_sheet` node crashed when the stored sheet URL was invalid or a placeholder. `get_or_create_sheet/2` in `lib/glific/flows.ex` matched `Sheets.create_sheet/1` with a strict `{:ok, sheet} = ...`; an invalid URL returns `{:error, "Invalid sheet URL"}` from `validate_sheet/1`, which fails the match and raises a `MatchError`, aborting the whole import batch with a 500 and no usable message in the Import Flow Status dialog.

This change handles the `{:error, reason}` branch: the action keeps `sheet_id` as `nil` and the invalid URL is logged via `Logger.warning`. The imported flow stays loadable and validatable instead of raising later in `Glific.Flows.Action.process/3`, and a batch with one bad sheet URL still imports its other flows.

## Checklist

- [x] Added test cases: valid URL links the sheet, invalid/placeholder URL imports with `sheet_id: nil` and a logged warning, and a mixed batch imports all valid flows
- [x] Coding standard and conventions followed
- [x] No new API added, so no Postman request is needed

## Notes

The happy path is unchanged. The failure path stores `sheet_id: nil` rather than deleting the key, so the `link_google_sheet` action still carries the field it requires and the flow loads without raising.

Fixes #5177
