### PR TITLE
fix: .gitignore symlink ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,10 @@
 # The directory Mix will write compiled artifacts to.
-/_build/
 /_build
 
 # If you run "mix test --cover", coverage assets end up here.
 /cover/
 
 # The directory Mix downloads your dependencies sources to.
-/deps/
 /deps
 
 # Where 3rd-party dependencies like ExDoc output generated docs.
@@ -54,7 +52,6 @@ npm-debug.log
 .DS_Store
 
 # ignore the certificate files
-/priv/cert/
 /priv/cert
 
 # don't commit mnesia files

--- a/_build
+++ b/_build
@@ -1,1 +1,0 @@
-/Users/rvignesh/code/projecttech4dev/glific/_build

--- a/deps
+++ b/deps
@@ -1,1 +1,0 @@
-/Users/rvignesh/code/projecttech4dev/glific/deps

--- a/priv/cert
+++ b/priv/cert
@@ -1,1 +1,0 @@
-/Users/rvignesh/code/projecttech4dev/glific/priv/cert


### PR DESCRIPTION
In https://github.com/glific/glific/pull/5187/changes some .gitignore symlinks were added while experimenting with wokrtrees. This PR removes it by changing the patterns to not only filter folders but also files.