### PR TITLE
feat: default Kaapi STT/TTS to Gemini 3.1 (configurable via env)

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -187,6 +187,10 @@ config :glific, Glific.ThirdParty.Kaapi.ApiClient,
   kaapi_api_key: env!("KAAPI_API_KEY", :string, "This is not a secret"),
   upload_adapter: upload_adapter
 
+config :glific, Glific.ThirdParty.Kaapi,
+  stt_model: env!("KAAPI_STT_MODEL", :string, "gemini-3.1-pro-preview"),
+  tts_model: env!("KAAPI_TTS_MODEL", :string, "gemini-3.1-flash-tts-preview")
+
 config :glific, Glific.ThirdParty.Gemini.ApiClient,
   gemini_api_key: env!("GEMINI_API_KEY", :string, "This is not a secret"),
   stt_model: env!("GEMINI_STT_MODEL", :string, "gemini-2.5-pro"),

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -486,8 +486,6 @@ defmodule Glific.ThirdParty.Kaapi do
     Enum.find(@kaapi_error_types, "transcription_failed", &String.contains?(message, &1))
   end
 
-  # Default STT/TTS model used when the flow node doesn't pass one.
-  # Configurable via KAAPI_STT_MODEL / KAAPI_TTS_MODEL (see config/runtime.exs).
   @spec model_config(atom()) :: String.t()
   defp model_config(key), do: Application.fetch_env!(:glific, __MODULE__)[key]
 

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -486,10 +486,15 @@ defmodule Glific.ThirdParty.Kaapi do
     Enum.find(@kaapi_error_types, "transcription_failed", &String.contains?(message, &1))
   end
 
+  # Default STT/TTS model used when the flow node doesn't pass one.
+  # Configurable via KAAPI_STT_MODEL / KAAPI_TTS_MODEL (see config/runtime.exs).
+  @spec model_config(atom()) :: String.t()
+  defp model_config(key), do: Application.fetch_env!(:glific, __MODULE__)[key]
+
   @spec stt_payload(String.t(), String.t(), map(), map()) :: map()
   defp stt_payload(encoded_audio, callback_url, request_metadata, opts) do
     base_params = %{
-      model: opts[:model] || "gemini-2.5-pro",
+      model: opts[:model] || model_config(:stt_model),
       input_language: opts[:language] || "auto"
     }
 
@@ -533,7 +538,7 @@ defmodule Glific.ThirdParty.Kaapi do
             provider: opts[:provider] || "google",
             type: "tts",
             params: %{
-              model: opts[:model] || "gemini-2.5-pro-preview-tts",
+              model: opts[:model] || model_config(:tts_model),
               voice: opts[:voice] || "Kore",
               language: opts[:language] || "hindi",
               response_format: "mp3"

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -1048,7 +1048,7 @@ defmodule Glific.Flows.CommonWebhookTest do
           assert get_in(decoded, ["config", "blob", "completion", "provider"]) == "google"
 
           assert get_in(decoded, ["config", "blob", "completion", "params", "model"]) ==
-                   "gemini-2.5-pro"
+                   "gemini-3.1-pro-preview"
 
           assert get_in(decoded, ["config", "blob", "completion", "params", "input_language"]) ==
                    "auto"
@@ -1185,7 +1185,7 @@ defmodule Glific.Flows.CommonWebhookTest do
           assert get_in(decoded, ["config", "blob", "completion", "provider"]) == "google"
 
           assert get_in(decoded, ["config", "blob", "completion", "params", "model"]) ==
-                   "gemini-2.5-pro-preview-tts"
+                   "gemini-3.1-flash-tts-preview"
 
           assert get_in(decoded, ["config", "blob", "completion", "params", "voice"]) == "Kore"
 


### PR DESCRIPTION
**Summary**

For Kaapi STT and TTS calls, the default Gemini model was hardcoded to 2.5 (gemini-2.5-pro for STT, gemini-2.5-pro-preview-tts for TTS). From two weeks of webhook-observability monitoring, ~60% of our STT/TTS failures traced back to the 2.5 models. This PR sets the default to Gemini 3.1, matching the model upgrade we already made on the bhasini STT/TTS path.

The default only applies when the flow node does not pass a model — any model explicitly set on the node is still respected.

**Changes**

 - **config/runtime.exs**: new env-configurable defaults under Glific.ThirdParty.Kaapi (mirrors the existing Glific.ThirdParty.Gemini.ApiClient block):
- KAAPI_STT_MODEL → defaults to gemini-3.1-pro-preview
- KAAPI_TTS_MODEL → defaults to gemini-3.1-flash-tts-preview
