### PR TITLE
 fix: send GPT vision images inline as base64 to avoid OpenAI fetch timeouts

### DIFF
--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -13,6 +13,7 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.Groups.WAGroup
   alias Glific.OpenAI.ChatGPT
   alias Glific.Partners
+  alias Glific.Providers.Gupshup.ApiClient, as: GupshupClient
   alias Glific.Providers.Maytapi
   alias Glific.Repo
   alias Glific.SafeLog
@@ -22,7 +23,6 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.ThirdParty.Kaapi.ApiClient
   alias Glific.WAGroup.WAManagedPhone
   alias Glific.WAGroup.WaPoll
-  alias Glific.Providers.Gupshup.ApiClient, as: GupshupClient
 
   require Logger
 

--- a/lib/glific/clients/common_webhook.ex
+++ b/lib/glific/clients/common_webhook.ex
@@ -22,6 +22,7 @@ defmodule Glific.Clients.CommonWebhook do
   alias Glific.ThirdParty.Kaapi.ApiClient
   alias Glific.WAGroup.WAManagedPhone
   alias Glific.WAGroup.WaPoll
+  alias Glific.Providers.Gupshup.ApiClient, as: GupshupClient
 
   require Logger
 
@@ -245,6 +246,7 @@ defmodule Glific.Clients.CommonWebhook do
     with_failure_reporting("parse_via_gpt_vision", org_id, fn ->
       # validating if the url passed is a valid image url
       with %{is_valid: true} <- Glific.Messages.validate_media(url, "image"),
+           {:ok, fields} <- maybe_inline_image(fields, url, org_id),
            {:ok, fields} <- parse_response_format(fields),
            {:ok, response} <- ChatGPT.gpt_vision(fields) do
         %{success: true, response: parse_gpt_response(response)}
@@ -726,6 +728,31 @@ defmodule Glific.Clients.CommonWebhook do
       _ -> nil
     end
   end
+
+  @spec maybe_inline_image(map(), String.t(), non_neg_integer() | nil) ::
+          {:ok, map()} | {:error, String.t()}
+  defp maybe_inline_image(fields, image_url, org_id) do
+    if FunWithFlags.enabled?(:is_gpt_vision_base64_enabled, for: %{organization_id: org_id}) do
+      case GupshupClient.download_media_content(image_url, org_id) do
+        {:ok, encoded_image, content_type} ->
+          # OpenAI needs a data URL (data:<mime>;base64,<...>), not bare base64.
+          # Use the server's Content-Type since Gupshup media URLs carry no extension.
+          mime = normalize_image_mime(content_type)
+          {:ok, Map.put(fields, "url", "data:#{mime};base64,#{encoded_image}")}
+
+        {:error, _reason} ->
+          {:error, "Failed to download image for vision parsing"}
+      end
+    else
+      {:ok, fields}
+    end
+  end
+
+  @spec normalize_image_mime(String.t() | nil) :: String.t()
+  defp normalize_image_mime(nil), do: "image/jpeg"
+
+  defp normalize_image_mime(content_type),
+    do: content_type |> String.split(";") |> hd() |> String.trim()
 
   # Webhook param validation hook. Single check today; convert to a
   # short-circuiting `with` once there's more than one field to validate.

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -529,7 +529,8 @@ defmodule Glific.Flags do
       :is_ask_glific_enabled,
       :is_whatsapp_forms_enabled,
       :high_trigger_tps_enabled,
-      :ai_evaluations
+      :ai_evaluations,
+      :is_gpt_vision_base64_enabled
     ]
     |> Enum.each(fn flag ->
       if !FunWithFlags.enabled?(

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -1446,7 +1446,9 @@ defmodule Glific.Partners do
         Flags.get_flag_enabled(:high_trigger_tps_enabled, organization),
       "ai_evaluations_enabled" => Flags.get_flag_enabled(:ai_evaluations, organization),
       "assistant_config_versions_enabled" =>
-        Flags.get_assistant_config_versions_enabled(organization)
+        Flags.get_assistant_config_versions_enabled(organization),
+      "gpt_vision_base64_enabled" =>
+        Flags.get_flag_enabled(:is_gpt_vision_base64_enabled, organization)
     }
   end
 

--- a/lib/glific/providers/gupshup/api_client.ex
+++ b/lib/glific/providers/gupshup/api_client.ex
@@ -70,10 +70,11 @@ defmodule Glific.Providers.Gupshup.ApiClient do
   end
 
   @doc """
-  Downloads the media content, and Base64 encodes the content.
+  Downloads the media content, Base64 encodes it, and returns the response's
+  Content-Type (nil if the server didn't send one) so callers can build a data URL.
   """
   @spec download_media_content(String.t(), non_neg_integer()) ::
-          {:ok, String.t()} | {:error, :download_failed}
+          {:ok, String.t(), String.t() | nil} | {:error, :download_failed}
   def download_media_content(audio_url, organization_id) do
     # Using a separate client as Logger middleware throws errors
     # if debug is not disabled since it does not handle bitstrings.
@@ -88,8 +89,8 @@ defmodule Glific.Providers.Gupshup.ApiClient do
     client
     |> Tesla.get(audio_url)
     |> case do
-      {:ok, %{status: 200, body: content}} ->
-        {:ok, Base.encode64(content)}
+      {:ok, %Tesla.Env{status: 200, body: content} = env} ->
+        {:ok, Base.encode64(content), Tesla.get_header(env, "content-type")}
 
       {:ok, %Tesla.Env{status: status_code, body: body}} ->
         Glific.log_exception(%Error{

--- a/lib/glific/third_party/gemini.ex
+++ b/lib/glific/third_party/gemini.ex
@@ -48,7 +48,8 @@ defmodule Glific.ThirdParty.Gemini do
   """
   @spec speech_to_text(String.t(), non_neg_integer()) :: map() | String.t()
   def speech_to_text(audio_url, organization_id) do
-    with {:ok, encoded_audio} <- GupshupClient.download_media_content(audio_url, organization_id),
+    with {:ok, encoded_audio, _content_type} <-
+           GupshupClient.download_media_content(audio_url, organization_id),
          %{success: true} = response <- ApiClient.speech_to_text(encoded_audio, organization_id) do
       Metrics.increment("Gemini STT Success", organization_id)
 

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -351,7 +351,8 @@ defmodule Glific.ThirdParty.Kaapi do
   """
   @spec speech_to_text(String.t(), String.t(), map(), non_neg_integer(), map()) :: map()
   def speech_to_text(audio_url, callback_url, request_metadata, organization_id, opts \\ %{}) do
-    with {:ok, encoded_audio} <- GupshupClient.download_media_content(audio_url, organization_id),
+    with {:ok, encoded_audio, _content_type} <-
+           GupshupClient.download_media_content(audio_url, organization_id),
          {:ok, secrets} <- fetch_kaapi_creds(organization_id),
          payload = stt_payload(encoded_audio, callback_url, request_metadata, opts),
          {:ok, body} <- ApiClient.call_llm(payload, secrets["api_key"]) do

--- a/test/glific/flows/common_webhook_test.exs
+++ b/test/glific/flows/common_webhook_test.exs
@@ -381,6 +381,74 @@ defmodule Glific.Flows.CommonWebhookTest do
     end
   end
 
+  test "parse_via_gpt_vision with base64 flag on downloads the image and sends it inline" do
+    FunWithFlags.enable(:is_gpt_vision_base64_enabled, for_actor: %{organization_id: 1})
+
+    try do
+      with_mock(
+        Messages,
+        validate_media: fn _, _ -> %{is_valid: true, message: "success"} end
+      ) do
+        image_bytes = <<137, 80, 78, 71, 13, 10, 26, 10>>
+
+        Tesla.Mock.mock(fn
+          %{method: :get, url: "https://example.com/image.png"} ->
+            %Tesla.Env{status: 200, body: image_bytes, headers: [{"content-type", "image/png"}]}
+
+          %{method: :post, url: "https://api.openai.com/v1/chat/completions", body: body} ->
+            assert body =~ "data:image/png;base64,#{Base.encode64(image_bytes)}"
+            refute body =~ "https://example.com/image.png"
+
+            %Tesla.Env{
+              status: 200,
+              body: %{"choices" => [%{"message" => %{"content" => "{\"answer\": 10}"}}]}
+            }
+        end)
+
+        fields = %{
+          "prompt" => "what's the answer",
+          "url" => "https://example.com/image.png",
+          "model" => "gpt-4o",
+          "organization_id" => "1",
+          "response_format" => %{"type" => "json_object"}
+        }
+
+        assert %{success: true, response: %{"answer" => 10}} =
+                 CommonWebhook.webhook("parse_via_gpt_vision", fields)
+      end
+    after
+      FunWithFlags.disable(:is_gpt_vision_base64_enabled, for_actor: %{organization_id: 1})
+    end
+  end
+
+  test "parse_via_gpt_vision with base64 flag on routes to Failure when image download fails" do
+    FunWithFlags.enable(:is_gpt_vision_base64_enabled, for_actor: %{organization_id: 1})
+
+    try do
+      with_mock(
+        Messages,
+        validate_media: fn _, _ -> %{is_valid: true, message: "success"} end
+      ) do
+        Tesla.Mock.mock(fn
+          %{method: :get, url: "https://example.com/missing.png"} ->
+            {:error, :timeout}
+        end)
+
+        fields = %{
+          "prompt" => "what's the answer",
+          "url" => "https://example.com/missing.png",
+          "model" => "gpt-4o",
+          "organization_id" => "1"
+        }
+
+        assert "Failed to download image for vision parsing" ==
+                 CommonWebhook.webhook("parse_via_gpt_vision", fields)
+      end
+    after
+      FunWithFlags.disable(:is_gpt_vision_base64_enabled, for_actor: %{organization_id: 1})
+    end
+  end
+
   test "parse_via_gpt_vision with response_format param as invalid json_schema, trying to get valid json" do
     with_mock(
       Messages,

--- a/test/glific/providers/gupshup/api_client_test.exs
+++ b/test/glific/providers/gupshup/api_client_test.exs
@@ -4,20 +4,31 @@ defmodule Glific.Providers.Gupshup.ApiClientTest do
   alias Glific.Providers.Gupshup.ApiClient
 
   describe "download_media_content/2" do
-    test "returns base64 encoded content on successful download" do
+    test "returns base64 encoded content and content-type on successful download" do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://example.com/media/audio.mp3"} ->
           %Tesla.Env{
             status: 200,
-            body: <<0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46>>
+            body: <<0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46>>,
+            headers: [{"content-type", "audio/mpeg"}]
           }
       end)
 
-      assert {:ok, encoded} =
+      assert {:ok, encoded, "audio/mpeg"} =
                ApiClient.download_media_content("https://example.com/media/audio.mp3", 1)
 
       assert encoded ==
                Base.encode64(<<0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46>>)
+    end
+
+    test "returns nil content-type when the server omits the header" do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://example.com/media/audio.mp3"} ->
+          %Tesla.Env{status: 200, body: <<0xFF, 0xD8>>}
+      end)
+
+      assert {:ok, _encoded, nil} =
+               ApiClient.download_media_content("https://example.com/media/audio.mp3", 1)
     end
 
     test "returns error on non-200 status code" do


### PR DESCRIPTION
## Summary

Behind the per-org :is_gpt_vision_base64_enabled flag, we now download the image ourselves and send it inline as a base64 data URL, removing OpenAI's dependency on fetching the URL. Flag defaults off; toggled via /feature-flags.

  - Reuse Gupshup.ApiClient.download_media_content/2, extended to also return the response Content-Type so we can build a [correct data:<mime>;base64](https://developers.openai.com/api/docs/guides/images-vision) URL (Gupshup media URLs have no extension to infer the type from).
  - Download failures return a bare string -> flow routes to the Failure category.
  - Update the two STT callers (Gemini, Kaapi) to the new 3-tuple return.