### PR TITLE
fix(webhook): redact credentials from webhook log request headers

### DIFF
--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -230,9 +230,6 @@ defmodule Glific.Flows.Webhook do
     {:ok, webhook_log} =
       %{
         request_json: body,
-        # Redact credentials (injected X-API-KEY, user-supplied Authorization /
-        # Bearer / vendor API keys) before they are persisted to the log. The
-        # real `headers` used for the outbound HTTP call are untouched.
         request_headers: HeaderRedactor.redact(headers),
         url: action.url,
         method: action.method,

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -8,6 +8,7 @@ defmodule Glific.Flows.Webhook do
 
   alias Glific.Clients.CommonWebhook
   alias Glific.Flows.{Action, FlowContext, MessageVarParser, WebhookLog}
+  alias Glific.Flows.Webhook.HeaderRedactor
   alias Glific.Messages
   alias Glific.Messages.Message
   alias Glific.Repo
@@ -229,7 +230,10 @@ defmodule Glific.Flows.Webhook do
     {:ok, webhook_log} =
       %{
         request_json: body,
-        request_headers: headers,
+        # Redact credentials (injected X-API-KEY, user-supplied Authorization /
+        # Bearer / vendor API keys) before they are persisted to the log. The
+        # real `headers` used for the outbound HTTP call are untouched.
+        request_headers: HeaderRedactor.redact(headers),
         url: action.url,
         method: action.method,
         organization_id: context.organization_id,

--- a/lib/glific/flows/webhook/header_redactor.ex
+++ b/lib/glific/flows/webhook/header_redactor.ex
@@ -1,0 +1,105 @@
+defmodule Glific.Flows.Webhook.HeaderRedactor do
+  @moduledoc """
+  Redacts credential-bearing values from webhook request headers before they
+  are persisted to `webhook_logs`.
+
+  Webhook headers are attacker-irrelevant but operator-sensitive: they carry
+  the `X-API-KEY` Glific injects for Kaapi calls, and — for user-authored
+  GET/POST webhook nodes — whatever the NGO pastes in (Google `AIza…` keys,
+  `Authorization: Bearer …`, Stripe `sk_live_…`, etc.). Persisting them raw
+  leaks those secrets into the webhook log UI and any downstream sync.
+
+  We cannot allow-list header *names*, because a flow author can name a header
+  anything. So redaction is driven by two independent signals, applied centrally
+  in `Glific.Flows.Webhook.create_log/4` so every webhook path is covered:
+
+    1. **Key name** — the header name matches a well-known credential name
+       (`authorization`, `x-api-key`, `*-token`, `secret`, `cookie`, …).
+       This is deterministic for the keys we control (e.g. the injected
+       `X-API-KEY`).
+    2. **Value shape** — the value *looks* like a credential (scheme-prefixed
+       `Bearer …`, a JWT, a vendor-prefixed key like `sk-`/`xoxb-`/`AIza`,
+       a long high-entropy token, a 32+ char hex digest, or a UUID).
+       This catches arbitrary user-supplied secrets we can't name in advance.
+
+  A header is redacted if *either* signal fires. The real headers used for the
+  outbound HTTP call are never touched — only the copy written to the log.
+  """
+
+  @redacted "[REDACTED]"
+
+  # Header names that always carry credentials, regardless of value.
+  @sensitive_key_patterns [
+    ~r/authorization/i,
+    ~r/auth[-_]?token/i,
+    ~r/\bauth\b/i,
+    ~r/api[-_ ]?key/i,
+    ~r/access[-_ ]?token/i,
+    ~r/\btoken\b/i,
+    ~r/secret/i,
+    ~r/credential/i,
+    ~r/private[-_ ]?key/i,
+    ~r/password|passwd|pwd/i,
+    ~r/signature/i,
+    ~r/bearer/i,
+    ~r/cookie/i
+  ]
+
+  # Value shapes that indicate a credential.
+  @credential_value_patterns [
+    ~r/^(bearer|basic|token|apikey|digest)\s+\S+/i,
+    ~r/^[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}$/,
+    # AKIA…, ya29… (Stripe, Slack, OpenAI, Google, GitHub, GitLab, AWS, OAuth)
+    ~r/^(sk|pk|rk|xox[a-z]|whsec|aiza|gh[opusr]|github_pat|glpat|akia|asia|ya29|shpat|shpss)[-_]?[A-Za-z0-9\-_]{10,}/i,
+    ~r/^[a-fA-F0-9]{32,}$/,
+    ~r/^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/
+  ]
+
+  # A long, unbroken token of credential-ish characters. Gated on containing
+  # BOTH a letter and a digit so alpha-only values (MIME types, encodings like
+  # "application/json") and pure-numeric ids don't get falsely redacted.
+  @high_entropy_pattern ~r|^[A-Za-z0-9\-_/+.=:~]{20,}$|
+
+  @doc """
+  Redact credential-bearing values from a webhook headers map.
+
+  Returns the map with sensitive values replaced by `"[REDACTED]"`. Header
+  names are preserved (so logs stay debuggable). Non-map input is returned
+  unchanged.
+  """
+  @spec redact(map() | nil | any()) :: map() | nil | any()
+  def redact(headers) when is_map(headers), do: Map.new(headers, &redact_entry/1)
+  def redact(headers), do: headers
+
+  @spec redact_entry({any(), any()}) :: {any(), any()}
+  defp redact_entry({key, value}) do
+    if sensitive_key?(key) or credential_value?(value) do
+      {key, @redacted}
+    else
+      {key, value}
+    end
+  end
+
+  @spec sensitive_key?(any()) :: boolean()
+  defp sensitive_key?(key) do
+    key_string = to_string(key)
+    Enum.any?(@sensitive_key_patterns, &Regex.match?(&1, key_string))
+  end
+
+  @spec credential_value?(any()) :: boolean()
+  defp credential_value?(value) when is_binary(value) do
+    trimmed = String.trim(value)
+
+    Enum.any?(@credential_value_patterns, &Regex.match?(&1, trimmed)) or
+      high_entropy_token?(trimmed)
+  end
+
+  defp credential_value?(_value), do: false
+
+  @spec high_entropy_token?(String.t()) :: boolean()
+  defp high_entropy_token?(value) do
+    Regex.match?(@high_entropy_pattern, value) and
+      String.match?(value, ~r/[A-Za-z]/) and
+      String.match?(value, ~r/[0-9]/)
+  end
+end

--- a/test/glific/flows/webhook/header_redactor_test.exs
+++ b/test/glific/flows/webhook/header_redactor_test.exs
@@ -1,0 +1,119 @@
+defmodule Glific.Flows.Webhook.HeaderRedactorTest do
+  use ExUnit.Case, async: true
+
+  alias Glific.Flows.Webhook.HeaderRedactor
+
+  @redacted "[REDACTED]"
+
+  describe "redact/1 — non-map input" do
+    test "passes through nil and non-map values unchanged" do
+      assert HeaderRedactor.redact(nil) == nil
+      assert HeaderRedactor.redact("not a map") == "not a map"
+      assert HeaderRedactor.redact([{"a", "b"}]) == [{"a", "b"}]
+    end
+
+    test "returns an empty map unchanged" do
+      assert HeaderRedactor.redact(%{}) == %{}
+    end
+  end
+
+  describe "redact/1 — sensitive key names (redacted regardless of value)" do
+    for key <- [
+          "Authorization",
+          "authorization",
+          "X-API-KEY",
+          "x-api-key",
+          "api_key",
+          "Access-Token",
+          "X-Auth-Token",
+          "X-Secret",
+          "Cookie",
+          "Set-Cookie",
+          "Private-Key",
+          "Password",
+          "X-Glific-Signature"
+        ] do
+      test "redacts header named #{key} even with a benign value" do
+        assert %{unquote(key) => @redacted} ==
+                 HeaderRedactor.redact(%{unquote(key) => "anything"})
+      end
+    end
+
+    test "redacts atom-keyed sensitive headers" do
+      assert %{authorization: @redacted} ==
+               HeaderRedactor.redact(%{authorization: "x"})
+    end
+  end
+
+  describe "redact/1 — credential-shaped values (arbitrary key name)" do
+    credentials = [
+      {"bearer", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"},
+      {"basic", "Basic dXNlcjpwYXNzd29yZA=="},
+      {"jwt", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpMeJf36"},
+      # Obviously-fake placeholders: still match the redactor's vendor-prefix
+      # regex, but use hyphens / low entropy so GitHub push-protection's
+      # provider-specific secret detectors don't flag them as real keys.
+      {"google", "AIza-FAKE-GOOGLE-API-KEY-PLACEHOLDER"},
+      {"stripe", "sk-FAKE-STRIPE-KEY-PLACEHOLDER"},
+      {"slack", "xoxb-FAKE-SLACK-TOKEN-PLACEHOLDER"},
+      {"github", "ghp-FAKE-GITHUB-TOKEN-PLACEHOLDER"},
+      {"aws", "AKIA-FAKE-AWS-KEY-PLACEHOLDER"},
+      {"hex_digest", "a3f1c2e4b5d6a7f8e9b0c1d2e3f4a5b6"},
+      {"uuid", "550e8400-e29b-41d4-a716-446655440000"},
+      {"long_token", "Xy7Kp2Qr9Tn4Vb6Wm1Zc8Ld3Hf5Gj0"}
+    ]
+
+    for {name, value} <- credentials do
+      test "redacts #{name}-style value under an innocuous header name" do
+        assert %{"X-Custom" => @redacted} ==
+                 HeaderRedactor.redact(%{"X-Custom" => unquote(value)})
+      end
+    end
+  end
+
+  describe "redact/1 — benign values are preserved" do
+    for value <- [
+          "application/json",
+          "application/x-www-form-urlencoded",
+          "text/html; charset=utf-8",
+          "gzip, deflate, br",
+          "en-US,en;q=0.9",
+          "keep-alive",
+          "no-cache",
+          "utf-8",
+          "12345",
+          "Mozilla/5.0 (Macintosh)",
+          "max-age=3600"
+        ] do
+      test "keeps benign value #{inspect(value)}" do
+        assert %{"X-Custom" => unquote(value)} ==
+                 HeaderRedactor.redact(%{"X-Custom" => unquote(value)})
+      end
+    end
+
+    test "leaves non-binary values untouched" do
+      assert %{"X-Count" => 42, "X-Flag" => true} ==
+               HeaderRedactor.redact(%{"X-Count" => 42, "X-Flag" => true})
+    end
+  end
+
+  describe "redact/1 — mixed map" do
+    test "redacts only the sensitive entries and keeps the rest" do
+      headers = %{
+        "Accept" => "application/json",
+        "Content-Type" => "application/json",
+        "X-API-KEY" => "kp_live_secret_value_123",
+        "Authorization" => "Bearer abc.def.ghi",
+        "X-Trace-Id" => "trace-001"
+      }
+
+      assert %{
+               "Accept" => "application/json",
+               "Content-Type" => "application/json",
+               "X-API-KEY" => @redacted,
+               "Authorization" => @redacted,
+               "X-Trace-Id" => "trace-001"
+             } == HeaderRedactor.redact(headers)
+    end
+  end
+end

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -231,7 +231,7 @@ defmodule Glific.Flows.WebhookTest do
       }
 
       assert Webhook.execute(action, context) == nil
-      webhook_log = List.first(WebhookLog.list_webhook_logs(%{filter: attrs})) |> IO.inspect()
+      webhook_log = List.first(WebhookLog.list_webhook_logs(%{filter: attrs}))
 
       # benign header kept, credential-bearing headers masked
       assert webhook_log.request_headers["Accept"] == "application/json"

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -204,6 +204,41 @@ defmodule Glific.Flows.WebhookTest do
       assert webhook_log.url == "www.one.com/#{contact_id}"
     end
 
+    test "execute redacts credential headers before persisting the webhook log", attrs do
+      Tesla.Mock.mock(fn
+        %{method: :post} -> %Tesla.Env{status: 200, body: Jason.encode!(@results)}
+      end)
+
+      attrs = %{
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        contact_id: Fixtures.contact_fixture(attrs).id,
+        organization_id: attrs.organization_id
+      }
+
+      {:ok, context} = FlowContext.create_flow_context(attrs)
+      context = Repo.preload(context, [:contact, :flow])
+
+      action = %Action{
+        headers: %{
+          "Accept" => "application/json",
+          "Authorization" => "Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature",
+          "X-API-KEY" => "kp_live_super_secret_value_123"
+        },
+        method: "POST",
+        url: "some url",
+        body: Jason.encode!(@action_body)
+      }
+
+      assert Webhook.execute(action, context) == nil
+      webhook_log = List.first(WebhookLog.list_webhook_logs(%{filter: attrs})) |> IO.inspect()
+
+      # benign header kept, credential-bearing headers masked
+      assert webhook_log.request_headers["Accept"] == "application/json"
+      assert webhook_log.request_headers["Authorization"] == "[REDACTED]"
+      assert webhook_log.request_headers["X-API-KEY"] == "[REDACTED]"
+    end
+
     test "execute a webhook for post method should not break and update the webhook log in case of array/list response",
          attrs do
       Tesla.Mock.mock(fn


### PR DESCRIPTION

## Summary
New `Glific.Flows.Webhook.HeaderRedactor` masks a header value with `"[REDACTED]"` when **either** signal fires:

  1. **Key name** — the header name matches a well-known credential name (`authorization`, `x-api-key`, `*-token`, `secret`, `cookie`, `signature`, …). Deterministic for keys we control, like the injected `X-API-KEY`.
  2. **Value shape** — the value *looks* like a credential: scheme-prefixed (`Bearer`/`Basic`/`Token`), a JWT, a vendor-prefixed key (`sk-`, `xoxb- `AIza`, `ghp_`, `glpat`, `AKIA`, `ya29`…), a 32+ char hex digest, a UUID, or a long high-entropy token (≥20 chars, mixed letters+digits, unbroken).
 <img width="480" height="358" alt="Screenshot 2026-06-11 at 1 08 24 PM" src="https://github.com/user-attachments/assets/9cb27cb2-5da7-4905-850b-c841a3e937d1" />
  
