### PR TITLE
feat: add grouped HSM templates API for revamped template list view

### DIFF
--- a/assets/gql/session_templates/grouped_list.gql
+++ b/assets/gql/session_templates/grouped_list.gql
@@ -1,0 +1,25 @@
+query groupedHsmTemplates($filter: SessionTemplateFilter, $opts: Opts) {
+  groupedHsmTemplates(filter: $filter, opts: $opts) {
+    shortcode
+    label
+    body
+    category
+    tag {
+      id
+      label
+    }
+    languageVariants {
+      id
+      bspId
+      language {
+        id
+        label
+      }
+      status
+      quality
+      reason
+      updatedAt
+      isActive
+    }
+  }
+}

--- a/assets/gql/session_templates/grouped_list.gql
+++ b/assets/gql/session_templates/grouped_list.gql
@@ -2,7 +2,6 @@ query groupedHsmTemplates($filter: SessionTemplateFilter, $opts: Opts) {
   groupedHsmTemplates(filter: $filter, opts: $opts) {
     shortcode
     label
-    body
     category
     tag {
       id
@@ -11,6 +10,8 @@ query groupedHsmTemplates($filter: SessionTemplateFilter, $opts: Opts) {
     languageVariants {
       id
       bspId
+      body
+      category
       language {
         id
         label

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -79,6 +79,7 @@ defmodule Glific.Templates do
     args
     |> Map.update(:filter, %{is_hsm: true}, &Map.put(&1, :is_hsm, true))
     |> list_session_templates()
+    |> Repo.preload([:language, :tag])
     |> Enum.group_by(& &1.shortcode)
     |> Enum.map(fn {shortcode, [first | _rest] = variants} ->
       %{
@@ -86,13 +87,13 @@ defmodule Glific.Templates do
         label: first.label,
         body: first.body,
         category: first.category,
-        tag_id: first.tag_id,
+        tag: first.tag,
         language_variants:
           Enum.map(variants, fn t ->
             %{
               id: t.id,
               bsp_id: t.bsp_id,
-              language_id: t.language_id,
+              language: t.language,
               status: t.status,
               quality: t.quality,
               reason: t.reason,

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -77,7 +77,10 @@ defmodule Glific.Templates do
   @spec list_grouped_hsm_templates(map()) :: [map()]
   def list_grouped_hsm_templates(args) do
     args
-    |> Map.update(:filter, %{is_hsm: true}, &Map.put(&1, :is_hsm, true))
+    |> Map.update(:filter, %{is_hsm: true}, fn
+      nil -> %{is_hsm: true}
+      filter -> Map.put(filter, :is_hsm, true)
+    end)
     |> list_session_templates()
     |> Repo.preload([:language, :tag])
     |> Enum.group_by(& &1.shortcode)

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -63,6 +63,47 @@ defmodule Glific.Templates do
   def count_session_templates(args),
     do: Repo.count_filter(args, SessionTemplate, &filter_with/2)
 
+  @doc """
+  List HSM session templates grouped by shortcode.
+  Each returned map represents one template family with all its language variants.
+  The grouping is done in memory on top of the existing list query — no migration needed.
+
+  ## Examples
+
+      iex> list_grouped_hsm_templates(%{filter: %{status: "APPROVED"}})
+      [%{shortcode: "otp_verify", label: "OTP Verification", ...}, ...]
+
+  """
+  @spec list_grouped_hsm_templates(map()) :: [map()]
+  def list_grouped_hsm_templates(args) do
+    args
+    |> Map.update(:filter, %{is_hsm: true}, &Map.put(&1, :is_hsm, true))
+    |> list_session_templates()
+    |> Enum.group_by(& &1.shortcode)
+    |> Enum.map(fn {shortcode, [first | _rest] = variants} ->
+      %{
+        shortcode: shortcode,
+        label: first.label,
+        body: first.body,
+        category: first.category,
+        tag_id: first.tag_id,
+        language_variants:
+          Enum.map(variants, fn t ->
+            %{
+              id: t.id,
+              bsp_id: t.bsp_id,
+              language_id: t.language_id,
+              status: t.status,
+              quality: t.quality,
+              reason: t.reason,
+              updated_at: t.updated_at,
+              is_active: t.is_active
+            }
+          end)
+      }
+    end)
+  end
+
   # codebeat:disable[ABC,LOC]
   @spec filter_with(Ecto.Queryable.t(), %{optional(atom()) => any}) :: Ecto.Queryable.t()
   defp filter_with(query, filter) do

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -88,7 +88,6 @@ defmodule Glific.Templates do
       %{
         shortcode: shortcode,
         label: first.label,
-        body: first.body,
         category: first.category,
         tag: first.tag,
         language_variants:
@@ -96,6 +95,8 @@ defmodule Glific.Templates do
             %{
               id: t.id,
               bsp_id: t.bsp_id,
+              body: t.body,
+              category: t.category,
               language: t.language,
               status: t.status,
               quality: t.quality,

--- a/lib/glific_web/resolvers/templates.ex
+++ b/lib/glific_web/resolvers/templates.ex
@@ -43,6 +43,15 @@ defmodule GlificWeb.Resolvers.Templates do
     {:ok, Templates.count_session_templates(args)}
   end
 
+  @doc """
+  Get HSM templates grouped by shortcode for the expandable list view
+  """
+  @spec grouped_hsm_templates(Absinthe.Resolution.t(), map(), %{context: map()}) ::
+          {:ok, [map()]}
+  def grouped_hsm_templates(_, args, _) do
+    {:ok, Templates.list_grouped_hsm_templates(args)}
+  end
+
   @doc false
   @spec create_session_template(Absinthe.Resolution.t(), %{input: map()}, %{context: map()}) ::
           {:ok, any} | {:error, any}

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -90,7 +90,7 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :is_active, :boolean
 
     field :language, :language do
-      resolve(dataloader(Repo))
+      resolve(fn variant, _, _ -> {:ok, variant.language} end)
     end
   end
 
@@ -101,7 +101,7 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :category, :string
 
     field :tag, :tag do
-      resolve(dataloader(Repo))
+      resolve(fn group, _, _ -> {:ok, group.tag} end)
     end
 
     field :language_variants, list_of(:template_language_variant)

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -83,6 +83,8 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
   object :template_language_variant do
     field :id, :id
     field :bsp_id, :string
+    field :body, :string
+    field :category, :string
     field :status, :string
     field :quality, :string
     field :reason, :string
@@ -97,7 +99,6 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
   object :grouped_hsm_template do
     field :shortcode, :string
     field :label, :string
-    field :body, :string
     field :category, :string
 
     field :tag, :tag do

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -80,6 +80,33 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
   end
 
   @desc "Filtering options for session_templates"
+  object :template_language_variant do
+    field :id, :id
+    field :bsp_id, :string
+    field :status, :string
+    field :quality, :string
+    field :reason, :string
+    field :updated_at, :datetime
+    field :is_active, :boolean
+
+    field :language, :language do
+      resolve(dataloader(Repo))
+    end
+  end
+
+  object :grouped_hsm_template do
+    field :shortcode, :string
+    field :label, :string
+    field :body, :string
+    field :category, :string
+
+    field :tag, :tag do
+      resolve(dataloader(Repo))
+    end
+
+    field :language_variants, list_of(:template_language_variant)
+  end
+
   input_object :session_template_filter do
     @desc "Match term with label and associated tag of template"
     field(:term, :string)
@@ -192,6 +219,14 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
       arg(:filter, :session_template_filter)
       middleware(Authorize, :manager)
       resolve(&Resolvers.Templates.count_session_templates/3)
+    end
+
+    @desc "Get HSM templates grouped by shortcode for the expandable list view"
+    field :grouped_hsm_templates, list_of(:grouped_hsm_template) do
+      arg(:filter, :session_template_filter)
+      arg(:opts, :opts)
+      middleware(Authorize, :staff)
+      resolve(&Resolvers.Templates.grouped_hsm_templates/3)
     end
   end
 

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -38,6 +38,12 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     "assets/gql/session_templates/create_from_message.gql"
   )
 
+  load_gql(
+    :grouped_list,
+    GlificWeb.Schema,
+    "assets/gql/session_templates/grouped_list.gql"
+  )
+
   test "session templates field returns list of session_templates", %{manager: user} do
     result = auth_query_gql_by(:list, user)
     assert {:ok, query_data} = result
@@ -225,6 +231,70 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     assert {:ok, query_data} = result
     session_templates = get_in(query_data, [:data, "sessionTemplates"])
     assert length(session_templates) == 3
+  end
+
+  test "grouped_hsm_templates returns templates grouped by shortcode", %{staff: user} do
+    result = auth_query_gql_by(:grouped_list, user, variables: %{"filter" => %{"isHsm" => true}})
+    assert {:ok, query_data} = result
+
+    groups = get_in(query_data, [:data, "groupedHsmTemplates"])
+    assert is_list(groups)
+    assert length(groups) > 0
+
+    # each group must have the expected shape
+    [first_group | _] = groups
+    assert Map.has_key?(first_group, "shortcode")
+    assert Map.has_key?(first_group, "label")
+    assert Map.has_key?(first_group, "body")
+    assert Map.has_key?(first_group, "category")
+    assert Map.has_key?(first_group, "languageVariants")
+
+    # each group must have at least one language variant
+    Enum.each(groups, fn group ->
+      variants = get_in(group, ["languageVariants"])
+      assert is_list(variants)
+      assert length(variants) >= 1
+
+      [variant | _] = variants
+      assert Map.has_key?(variant, "id")
+      assert Map.has_key?(variant, "status")
+      assert Map.has_key?(variant, "language")
+    end)
+
+    # shortcodes are unique per group — grouping is correct
+    shortcodes = Enum.map(groups, & &1["shortcode"])
+    assert shortcodes == Enum.uniq(shortcodes)
+  end
+
+  test "grouped_hsm_templates filters by status and only returns matching groups", %{staff: user} do
+    # seed has: missed_message=PENDING, otp=REJECTED, user-registration=REJECTED
+    result =
+      auth_query_gql_by(:grouped_list, user,
+        variables: %{"filter" => %{"isHsm" => true, "status" => "REJECTED"}}
+      )
+
+    assert {:ok, query_data} = result
+    rejected_groups = get_in(query_data, [:data, "groupedHsmTemplates"])
+    assert length(rejected_groups) >= 1
+
+    Enum.each(rejected_groups, fn group ->
+      Enum.each(group["languageVariants"], fn variant ->
+        assert variant["status"] == "REJECTED"
+      end)
+    end)
+
+    # PENDING filter should return only missed_message group
+    result =
+      auth_query_gql_by(:grouped_list, user,
+        variables: %{"filter" => %{"isHsm" => true, "status" => "PENDING"}}
+      )
+
+    assert {:ok, query_data} = result
+    pending_groups = get_in(query_data, [:data, "groupedHsmTemplates"])
+    assert length(pending_groups) >= 1
+
+    shortcodes = Enum.map(pending_groups, & &1["shortcode"])
+    assert "missed_message" in shortcodes
   end
 
   test "session_template by id returns one session_template or nil", %{manager: user} do

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -245,7 +245,6 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     [first_group | _] = groups
     assert Map.has_key?(first_group, "shortcode")
     assert Map.has_key?(first_group, "label")
-    assert Map.has_key?(first_group, "body")
     assert Map.has_key?(first_group, "category")
     assert Map.has_key?(first_group, "languageVariants")
 
@@ -257,6 +256,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
       [variant | _] = variants
       assert Map.has_key?(variant, "id")
+      assert Map.has_key?(variant, "body")
       assert Map.has_key?(variant, "status")
       assert Map.has_key?(variant, "language")
     end)


### PR DESCRIPTION
## Summary

Part of the HSM Template Management Revamp — Epic [#5258](https://github.com/glific/glific/issues/5258).
Closes [#5259](https://github.com/glific/glific/issues/5259).

The current `sessionTemplates` query returns a **flat list** — one row per language per template. The revamped frontend needs templates **grouped by shortcode** so it can render an expandable table where each row is a template family and each expanded sub-row is a language variant.

This PR adds that grouped query entirely on the backend, with no database migration.

### What changed

####  `lib/glific/templates.ex`
Added `list_grouped_hsm_templates/1`:
- Calls the existing `list_session_templates/1` (no new DB query)
- Forces `is_hsm: true` into the filter automatically
- Groups the flat result by `shortcode` using `Enum.group_by/2` in memory
- Reshapes each group into `%{shortcode, label, body, category, tag_id, language_variants: [...]}`

####  `lib/glific_web/schema/session_template_type.ex`
Added two new GraphQL object types:
- `:template_language_variant` — one language row inside a group (`id`, `bsp_id`, `status`, `quality`, `reason`, `updated_at`, `is_active`, `language` via dataloader)
- `:grouped_hsm_template` — one shortcode family (`shortcode`, `label`, `body`, `category`, `tag` via dataloader, `language_variants`)

Added new query field inside the existing `session_template_queries` object:
```graphql
groupedHsmTemplates(filter: SessionTemplateFilter, opts: Opts): [GroupedHsmTemplate]
```
Reuses the existing `session_template_filter` input — no new input type needed.

####  `lib/glific_web/resolvers/templates.ex`
Added `grouped_hsm_templates/3` resolver — thin bridge to the context function.

####  `assets/gql/session_templates/grouped_list.gql`
New GQL operation file used by tests and as API documentation.

####  `test/glific_web/schema/session_template_test.exs`
Added two test cases:
- **Shape test** — asserts the response is grouped (not flat), each group has the expected fields, and shortcodes are unique across groups
- **Filter test** — asserts `status: REJECTED` returns only REJECTED variants, and `status: PENDING` returns the `missed_message` template (matches seed data)

### Design decisions

- **No migration** — grouping is a pure Elixir transform (`Enum.group_by`) on top of the existing flat query. Zero schema changes.
- **No new input type** — reuses `:session_template_filter` so the frontend can already filter by `status`, `category`, `tag_ids`, and `term`.
- **No changes to existing queries** — `sessionTemplates` (flat list) is untouched. Both queries coexist.
- **Authorize level: `:staff`** — consistent with the existing `sessionTemplates` field.