### PR TITLE
docs: update CLAUDE.md with learnings from week of 2026-06-22

### DIFF
--- a/lib/glific/CLAUDE.md
+++ b/lib/glific/CLAUDE.md
@@ -100,6 +100,18 @@ end
   wrappers centralize Logger + AppSignal and suppress known-benign beneficiary errors
   (`ignore_error?/1`).
 - Bang functions raise; non-bang return tagged tuples. Don't mix the two contracts in one fn.
+- **Custom `defexception` pattern** — subsystems that need isolated AppSignal error-rate triggers
+  define a local `Error` module with a `:reason` field and explicit `message/1`:
+  ```elixir
+  defmodule MyModule.Error do
+    defexception [:message, :reason]
+    def message(%__MODULE__{} = e), do: "#{e.message} reason: #{e.reason}"
+  end
+  @appsignal_namespace "my_subsystem"
+  ```
+  Pass the namespace when logging: `Glific.log_exception(error, namespace: @appsignal_namespace)`.
+  This builds an isolated error-rate trigger in AppSignal per subsystem (e.g. `"prompt_generator"`).
+  See `Glific.PromptGenerator` and `Glific.Providers.Gupshup.PartnerAPI` for examples.
 
 ## Caching (Cachex, bucket `:glific_cache`)
 
@@ -144,6 +156,25 @@ Request headers are automatically scrubbed by `Glific.Flows.Webhook.HeaderRedact
 being persisted to `webhook_logs` — credentials (Authorization, X-Api-Key, etc.) are
 redacted. Do not special-case credential fields in individual webhook modules.
 
+## Async external-service callback pattern
+
+Used by `Glific.PromptGenerator` (Kaapi LLM) and similar integrations where an external
+service accepts a request and POSTs back later. The correlation key is a UUID we generate:
+
+1. Generate `request_id = Ecto.UUID.generate()` before calling the external service.
+2. Embed it in the outbound payload (e.g. `request_metadata.request_id`).
+3. Persist a row with `status: :in_progress` and the `request_id`.
+4. External service echoes the `request_id` in the async callback body — use it for lookup
+   via `Repo.fetch_by(Schema, %{request_id: request_id})`.
+5. **Terminal-state guard**: always short-circuit if the row is already in a terminal state
+   (`:ready` or `:failed`) to make callbacks idempotent:
+   ```elixir
+   defp apply_callback(%Schema{status: s} = row, _) when s in [:ready, :failed], do: {:ok, row}
+   ```
+6. Record AppSignal telemetry on each real transition (latency, success/failure count).
+
+The callback endpoint must return 200 even for unknown `request_id` (log + ignore).
+
 ## Large subsystems — read before touching
 
 These are old, dense, and pattern-divergent. Read the subtree and nearby tests **before**
@@ -154,7 +185,17 @@ editing or "cleaning up":
   `flows/webhooks/core/Dispatcher` — see the Webhook framework section above.
 - `providers/` (25 modules) — BSP integrations (Gupshup, Gupshup Enterprise, Maytapi). Outbound
   message sending, webhooks, workers. Tesla-based HTTP; mocked with `Tesla.Mock` in tests.
-- `third_party/` — BigQuery, Dialogflow, GCS, Gemini, Sheets, Kaapi, etc.
+  `Glific.Providers.Gupshup.PartnerAPI` uses `GUPSHUP_PARTNER_CLIENT_SECRET` (app env
+  `:gupshup_partner_client_secret`) — not the ISV password — to fetch partner tokens.
+- `third_party/` — BigQuery, Dialogflow, GCS, Gemini, Sheets, Kaapi, etc. **BigQuery rule**:
+  table partitioning/clustering is set **only** in `create_table/2` (new org/table creation).
+  `alter_table/2` (schema evolution) must **never** set these — BigQuery cannot repartition an
+  existing table. New orgs get MONTH-partitioned + clustered tables; existing org tables are
+  intentionally untouched.
+- `prompt_generator.ex` / `prompt_generator/` — async Kaapi LLM-based WhatsApp chatbot
+  system-prompt generation. `PromptGenerationRequest` tracks status (`:in_progress` → `:ready` /
+  `:failed`). Uses the async callback correlation pattern above. Gated by the
+  `is_prompt_generator_enabled` feature flag (set per-org in `Glific.Flags`).
 - `partners.ex` / `partners/` — organizations, providers, credentials, billing. Central to
   multi-tenancy and caching.
 


### PR DESCRIPTION
## Summary

Updates `lib/glific/CLAUDE.md` to capture new patterns and subsystems introduced in the 10 commits merged to master between 2026-06-15 and 2026-06-22.

### Changes

- **Custom `defexception` pattern** (Error handling section): Documents the `defexception [:message, :reason]` + `@appsignal_namespace` convention now used in both `Glific.PromptGenerator` (#5254) and `Glific.Providers.Gupshup.PartnerAPI` (#5257) to build isolated AppSignal error-rate triggers per subsystem.

- **Async external-service callback pattern** (new section): Documents the UUID `request_id` correlation pattern used by `PromptGenerator` (#5254, #5256) — generate UUID, embed in outbound payload, external service echoes it back, look up row by `request_id`. Covers the mandatory terminal-state guard (`:ready`/`:failed` rows are idempotent) and the AppSignal telemetry convention on each real transition.

- **Large subsystems** (updated entries):
  - `providers/`: Notes that `PartnerAPI` now uses `GUPSHUP_PARTNER_CLIENT_SECRET` env var (`:gupshup_partner_client_secret` app config) — not the ISV password — to fetch partner tokens (#5257).
  - `third_party/`: Adds the BigQuery rule: partitioning/clustering is set only in `create_table/2` (new-org/new-table creation), never in `alter_table/2` — BigQuery cannot repartition existing tables (#5230).
  - `prompt_generator.ex` / `prompt_generator/`: New entry documenting the async Kaapi LLM prompt-generation subsystem, its `PromptGenerationRequest` status machine, and the `is_prompt_generator_enabled` feature flag gate (#5254, #5256).

### Commits covered

| SHA | PR | Description |
|---|---|---|
| `fb34831` | #5254 | Prompt generator M1 — backend engine (Kaapi, no UI) |
| `c0f60ef` | #5256 | Prompt generator M2 — GraphQL surface + Kaapi webhook |
| `2c4bf4b` | #5257 | Gupshup partner token via client secret |
| `0eed016` | #5230 | BigQuery MONTH partitioning + clustering for new-org tables |

### Intentionally skipped

- Version bumps (#5236, #5244, #5266) — no pattern-relevant changes
- `fix: remove phone sync call from sync_wa_groups` (#5243) — hotfix, no new pattern
- `Fix: sync wa_groups_phones table to BigQuery` (#5242) — bugfix, no new pattern
- Bhashini webhook deprecation (#5252) — `Action.validate/3` detail, internal to `flows/`; no new cross-cutting convention
- Copy node feature flag (#5233) — uses existing `FunWithFlags` pattern already documented

## Test plan

- [ ] Review each addition for accuracy against the linked PRs
- [ ] Confirm no existing conventions were accidentally removed or altered
- [ ] Confirm the `defexception` example matches the actual `PromptGenerator.Error` and `PartnerAPI.Error` contracts
- [ ] Confirm the async callback steps match the actual `PromptGenerator.generate_prompt/3` + `handle_callback/1` flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PMLt1KKhPFtZnLmNCQuzHu

---
_Generated by [Claude Code](https://claude.ai/code/session_01PMLt1KKhPFtZnLmNCQuzHu)_