### PR TITLE
fix(assistants): remove legacy active-config-link behavior and fix in-progress KB bug

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -780,30 +780,6 @@ defmodule Glific.Assistants do
   end
 
   # Links the KB to the existing active config version within the same Multi transaction.
-  # Needed when the active config had no KB link and a kb_version_id is provided,
-  # so the GET response shows the KB on the current active config.
-  @spec maybe_link_active_config(
-          Multi.t(),
-          Assistant.t(),
-          KnowledgeBaseVersion.t(),
-          non_neg_integer(),
-          boolean()
-        ) :: Multi.t()
-  defp maybe_link_active_config(multi, _assistant, _kb_version, _org_id, false), do: multi
-
-  defp maybe_link_active_config(multi, assistant, knowledge_base_version, organization_id, true) do
-    Multi.insert_all(
-      multi,
-      :link_active_config_knowledge_base,
-      "assistant_config_version_knowledge_base_versions",
-      build_knowledge_base_link(
-        assistant.active_config_version,
-        knowledge_base_version,
-        organization_id
-      )
-    )
-  end
-
   @spec build_assistant_changeset(map()) :: Ecto.Changeset.t()
   defp build_assistant_changeset(kaapi_config) do
     Assistant.changeset(%Assistant{}, %{

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -13,7 +13,6 @@ defmodule Glific.Assistants do
   alias Glific.Assistants.AssistantConfigVersion
   alias Glific.Assistants.KnowledgeBase
   alias Glific.Assistants.KnowledgeBaseVersion
-  alias Glific.Flags
   alias Glific.Metrics
   alias Glific.Notifications
   alias Glific.Partners
@@ -519,34 +518,22 @@ defmodule Glific.Assistants do
   @spec do_update_assistant_config(Assistant.t(), map(), KnowledgeBaseVersion.t() | nil) ::
           {:ok, map()} | {:error, any()}
   defp do_update_assistant_config(assistant, user_params, knowledge_base_version) do
-    previous_knowledge_base_version =
-      List.first(assistant.active_config_version.knowledge_base_versions)
-
-    needs_active_config_link =
-      is_nil(previous_knowledge_base_version) and
-        not is_nil(user_params[:knowledge_base_version_id])
-
-    previous_kb_id = kb_id(previous_knowledge_base_version)
-    new_kb_id = kb_id(knowledge_base_version)
-
-    knowledge_base_changed =
-      previous_kb_id != nil and new_kb_id != nil and previous_kb_id != new_kb_id
-
     {:ok, config_params} = build_kaapi_config(user_params, knowledge_base_version)
 
-    with true <-
-           knowledge_base_changed and knowledge_base_version.status != :completed,
-         {:ok, _config_version} <-
-           deferred_update_transaction(assistant, config_params, knowledge_base_version) do
-      format_assistant_result(assistant)
+    kb_in_progress =
+      not is_nil(knowledge_base_version) and knowledge_base_version.status != :completed
+
+    with true <- kb_in_progress,
+         {:ok, updated_assistant, _config_version} <-
+           update_assistant_transaction(assistant, config_params, knowledge_base_version) do
+      format_assistant_result(updated_assistant)
     else
       false ->
         with {:ok, updated_assistant, config_version} <-
                update_assistant_transaction(
                  assistant,
                  config_params,
-                 knowledge_base_version,
-                 needs_active_config_link
+                 knowledge_base_version
                ),
              {:ok, _} <-
                create_kaapi_config_version(updated_assistant, config_version, config_params) do
@@ -616,49 +603,10 @@ defmodule Glific.Assistants do
   @spec update_assistant_transaction(
           Assistant.t(),
           map(),
-          KnowledgeBaseVersion.t() | nil,
-          boolean()
+          KnowledgeBaseVersion.t() | nil
         ) ::
           {:ok, Assistant.t(), AssistantConfigVersion.t()} | {:error, any()}
-  defp update_assistant_transaction(
-         assistant,
-         kaapi_config,
-         knowledge_base_version,
-         needs_active_config_link
-       ) do
-    Multi.new()
-    |> maybe_link_active_config(
-      assistant,
-      knowledge_base_version,
-      kaapi_config.organization_id,
-      needs_active_config_link
-    )
-    |> Multi.insert(
-      :config_version,
-      build_config_version_changeset(assistant, kaapi_config, knowledge_base_version)
-    )
-    |> maybe_link_knowledge_base(knowledge_base_version, kaapi_config.organization_id)
-    |> Multi.update(:updated_assistant, fn %{
-                                             config_version: config_version
-                                           } ->
-      organization = Partners.organization(kaapi_config.organization_id)
-
-      attrs =
-        if Flags.get_assistant_config_versions_enabled(organization) do
-          %{name: kaapi_config.name}
-        else
-          %{name: kaapi_config.name, active_config_version_id: config_version.id}
-        end
-
-      Assistant.changeset(assistant, attrs)
-    end)
-    |> Repo.transaction()
-    |> handle_update_transaction_result()
-  end
-
-  @spec deferred_update_transaction(Assistant.t(), map(), KnowledgeBaseVersion.t()) ::
-          {:ok, AssistantConfigVersion.t()} | {:error, any()}
-  defp deferred_update_transaction(assistant, kaapi_config, knowledge_base_version) do
+  defp update_assistant_transaction(assistant, kaapi_config, knowledge_base_version) do
     Multi.new()
     |> Multi.insert(
       :config_version,
@@ -669,10 +617,7 @@ defmodule Glific.Assistants do
       Assistant.changeset(assistant, %{name: kaapi_config.name})
     end)
     |> Repo.transaction()
-    |> case do
-      {:ok, %{config_version: config_version}} -> {:ok, config_version}
-      {:error, _failed, changeset, _} -> {:error, changeset}
-    end
+    |> handle_update_transaction_result()
   end
 
   @spec create_kaapi_config_version(Assistant.t(), AssistantConfigVersion.t(), map()) ::
@@ -1242,14 +1187,6 @@ defmodule Glific.Assistants do
          ) do
       {:ok, kaapi_response} ->
         kaapi_version_number = kaapi_response.data.version
-
-        organization = Partners.organization(assistant.organization_id)
-
-        unless Flags.get_assistant_config_versions_enabled(organization) do
-          assistant
-          |> Assistant.changeset(%{active_config_version_id: config_version.id})
-          |> Repo.update()
-        end
 
         config_version
         |> AssistantConfigVersion.changeset(%{

--- a/test/CLAUDE.md
+++ b/test/CLAUDE.md
@@ -98,6 +98,12 @@ end
 - BSP (Gupshup/Maytapi), BigQuery, GCS, Dialogflow, Gemini, OpenAI calls **must** be mocked.
   A test that makes a real outbound call is a bug.
 
+## Variable naming
+
+Use descriptive, full names — never abbreviations — for test-local variables.
+Bad: `new_cv`, `org_id`, `kbv`. Good: `new_config_version`, `organization_id`, `knowledge_base_version`.
+This applies to all schema-level concepts: prefer `config_version` over `cv`, `knowledge_base` over `kb`, etc.
+
 ## Running & coverage
 
 ```bash

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -457,11 +457,14 @@ defmodule Glific.AssistantsTest do
 
       assert config_count == 2
 
-      {:ok, updated_assistant} =
-        Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
+      new_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> order_by([acv], desc: acv.id)
+        |> limit(1)
+        |> Repo.one()
 
-      updated_assistant = Repo.preload(updated_assistant, :active_config_version)
-      assert updated_assistant.active_config_version.kaapi_version_number == 2
+      assert new_config_version.kaapi_version_number == 2
     end
 
     test "creates a new config version when temperature changes",
@@ -471,13 +474,11 @@ defmodule Glific.AssistantsTest do
           %Tesla.Env{status: 200, body: %{data: %{id: "new_kaapi_uuid_temp", version: 2}}}
       end)
 
-      assert {:ok, result} =
+      assert {:ok, _result} =
                Assistants.update_assistant(assistant.id, %{
                  temperature: 0.5,
                  organization_id: organization_id
                })
-
-      assert result.temperature == 0.5
 
       config_count =
         AssistantConfigVersion
@@ -485,6 +486,15 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+
+      new_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> order_by([acv], desc: acv.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert get_in(new_config_version.settings, ["temperature"]) == 0.5
     end
 
     test "creates a new config version when model changes",
@@ -494,13 +504,11 @@ defmodule Glific.AssistantsTest do
           %Tesla.Env{status: 200, body: %{data: %{id: "new_kaapi_uuid_model", version: 2}}}
       end)
 
-      assert {:ok, result} =
+      assert {:ok, _result} =
                Assistants.update_assistant(assistant.id, %{
                  model: "gpt-4o-mini",
                  organization_id: organization_id
                })
-
-      assert result.model == "gpt-4o-mini"
 
       config_count =
         AssistantConfigVersion
@@ -508,6 +516,15 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+
+      new_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> order_by([acv], desc: acv.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert new_config_version.model == "gpt-4o-mini"
     end
 
     test "creates a new config version when instructions change",
@@ -517,13 +534,11 @@ defmodule Glific.AssistantsTest do
           %Tesla.Env{status: 200, body: %{data: %{id: "new_kaapi_uuid_instructions", version: 2}}}
       end)
 
-      assert {:ok, result} =
+      assert {:ok, _result} =
                Assistants.update_assistant(assistant.id, %{
                  instructions: "You are a specialized assistant",
                  organization_id: organization_id
                })
-
-      assert result.instructions == "You are a specialized assistant"
 
       config_count =
         AssistantConfigVersion
@@ -531,6 +546,15 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+
+      new_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> order_by([acv], desc: acv.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert new_config_version.prompt == "You are a specialized assistant"
     end
 
     test "creates a new config version when knowledge base changes",
@@ -682,8 +706,6 @@ defmodule Glific.AssistantsTest do
                })
 
       assert result.name == "Multi-Update Name"
-      assert result.model == "gpt-4o-mini"
-      assert result.temperature == 0.7
 
       config_count =
         AssistantConfigVersion
@@ -691,6 +713,16 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+
+      new_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> order_by([acv], desc: acv.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert new_config_version.model == "gpt-4o-mini"
+      assert get_in(new_config_version.settings, ["temperature"]) == 0.7
     end
 
     test "returns error when Kaapi API call fails",
@@ -794,13 +826,13 @@ defmodule Glific.AssistantsTest do
                  organization_id: organization_id
                })
 
-      # Verify bridge entry was created for the active config version
+      # KB is linked to v2 only — v1 (active config) must NOT have a bridge row
       bridge_count_after =
         "assistant_config_version_knowledge_base_versions"
         |> where([b], b.assistant_config_version_id == ^config_version.id)
         |> Repo.aggregate(:count, :id)
 
-      assert bridge_count_after == 1
+      assert bridge_count_after == 0
 
       # Verify a new config version was also created
       config_count =
@@ -809,6 +841,91 @@ defmodule Glific.AssistantsTest do
         |> Repo.aggregate(:count, :id)
 
       assert config_count == 2
+    end
+
+    test "does not link in_progress KB to v1 and defers Kaapi push until callback",
+         %{
+           organization_id: organization_id,
+           assistant: assistant,
+           config_version: v1_config_version
+         } do
+      {:ok, kb} =
+        Assistants.create_knowledge_base(%{
+          name: "In-Progress KB for v2",
+          organization_id: organization_id
+        })
+
+      {:ok, kbv} =
+        Assistants.create_knowledge_base_version(%{
+          knowledge_base_id: kb.id,
+          organization_id: organization_id,
+          files: %{"file_1" => %{"filename" => "doc.pdf"}},
+          status: :in_progress,
+          llm_service_id: "temporary-vs-bugtest123",
+          kaapi_job_id: "job_needs_active_config_link_fix",
+          size: 500
+        })
+
+      # No Tesla mock — any Kaapi call here would raise and fail the test,
+      # proving the deferred path is correctly taken.
+      assert {:ok, _result} =
+               Assistants.update_assistant(assistant.id, %{
+                 name: assistant.name,
+                 instructions: v1_config_version.prompt,
+                 model: v1_config_version.model,
+                 temperature: get_in(v1_config_version.settings, ["temperature"]),
+                 knowledge_base_version_id: kbv.id,
+                 organization_id: organization_id
+               })
+
+      # v1 (active config) must NOT have the KB linked — the bug would give it a row here
+      v1_bridge_count =
+        "assistant_config_version_knowledge_base_versions"
+        |> where([b], b.assistant_config_version_id == ^v1_config_version.id)
+        |> Repo.aggregate(:count, :id)
+
+      assert v1_bridge_count == 0
+
+      # v2 (new config) must be created and have the KB linked
+      v2_config_version =
+        AssistantConfigVersion
+        |> where([acv], acv.assistant_id == ^assistant.id)
+        |> where([acv], acv.id != ^v1_config_version.id)
+        |> Repo.one()
+
+      refute is_nil(v2_config_version)
+      assert v2_config_version.status == :in_progress
+
+      v2_bridge_count =
+        "assistant_config_version_knowledge_base_versions"
+        |> where([b], b.assistant_config_version_id == ^v2_config_version.id)
+        |> Repo.aggregate(:count, :id)
+
+      assert v2_bridge_count == 1
+
+      # Simulate Kaapi callback with the real vs-* ID
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{status: 200, body: %{data: %{id: "kaapi_cfg_id_123", version: 3}}}
+      end)
+
+      Assistants.handle_knowledge_base_callback(%{
+        "data" => %{
+          "job_id" => "job_needs_active_config_link_fix",
+          "status" => "SUCCESSFUL",
+          "collection" => %{"knowledge_base_id" => "vs-realid456"},
+          "error_message" => nil
+        }
+      })
+
+      # v2 should now be :ready with the Kaapi version number set
+      updated_v2 = Repo.get!(AssistantConfigVersion, v2_config_version.id)
+      assert updated_v2.status == :ready
+      assert updated_v2.kaapi_version_number == 3
+
+      # KB version should have the real llm_service_id
+      updated_kbv = Repo.get!(KnowledgeBaseVersion, kbv.id)
+      assert updated_kbv.llm_service_id == "vs-realid456"
     end
   end
 
@@ -1574,7 +1691,7 @@ defmodule Glific.AssistantsTest do
       assert result.status == "ready"
     end
 
-    test "callback after deferred update calls create_config_version and activates new config",
+    test "callback after deferred update calls create_config_version and marks config as ready",
          %{
            organization_id: organization_id,
            assistant: assistant,
@@ -1629,11 +1746,11 @@ defmodule Glific.AssistantsTest do
           }
         })
 
-      # After callback, active_config_version_id should be updated to new config
+      # active_config_version_id stays unchanged — explicit activation is required
       {:ok, post_callback_assistant} =
         Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
 
-      assert post_callback_assistant.active_config_version_id != original_config_version.id
+      assert post_callback_assistant.active_config_version_id == original_config_version.id
 
       # New config version should be :ready
       new_config =
@@ -2121,14 +2238,14 @@ defmodule Glific.AssistantsTest do
         })
 
       # New config version should be failed with real error
-      new_cv =
+      new_config_version =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
         |> where([acv], acv.id != ^config_version.id)
         |> Repo.one()
 
-      assert new_cv.status == :failed
-      assert new_cv.failure_reason == failure_reason
+      assert new_config_version.status == :failed
+      assert new_config_version.failure_reason == failure_reason
 
       # Active config should still be the original ready version
       {:ok, post_fail} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
@@ -2151,7 +2268,7 @@ defmodule Glific.AssistantsTest do
 
       {:ok, fetched} = Assistants.get_assistant(assistant.id)
 
-      assert notification.entity["config_version_id"] == new_cv.id
+      assert notification.entity["config_version_id"] == new_config_version.id
 
       assert notification.message ==
                "Knowledge Base creation failed for assistant \"#{fetched.name}\". Reason: #{failure_reason}. Please try again."
@@ -2474,10 +2591,8 @@ defmodule Glific.AssistantsTest do
                })
 
       assert result.name == "Updated Assistant"
-      assert result.instructions == "You are a specialized assistant"
-      assert result.temperature == 0.5
 
-      # Verify new config version was created
+      # Verify new config version was created with updated values
       config_count =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
@@ -2485,15 +2600,16 @@ defmodule Glific.AssistantsTest do
 
       assert config_count == 2
 
-      # New config version should be ready
-      new_cv =
+      # New config version should be ready with the updated values
+      new_config_version =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
         |> where([acv], acv.id != ^original_cv.id)
         |> Repo.one()
 
-      assert new_cv.status == :ready
-      assert new_cv.prompt == "You are a specialized assistant"
+      assert new_config_version.status == :ready
+      assert new_config_version.prompt == "You are a specialized assistant"
+      assert get_in(new_config_version.settings, ["temperature"]) == 0.5
 
       # get_assistant should show updated state
       {:ok, fetched} = Assistants.get_assistant(assistant.id)
@@ -2542,14 +2658,14 @@ defmodule Glific.AssistantsTest do
         })
 
       # New config version should be failed with real error
-      new_cv =
+      new_config_version =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
         |> where([acv], acv.id != ^original_cv.id)
         |> Repo.one()
 
-      assert new_cv.status == :failed
-      assert new_cv.failure_reason == "Document processing failed: corrupt file"
+      assert new_config_version.status == :failed
+      assert new_config_version.failure_reason == "Document processing failed: corrupt file"
 
       # Active config should still be the original
       {:ok, post_callback} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
@@ -2601,14 +2717,14 @@ defmodule Glific.AssistantsTest do
         })
 
       # New config version should be failed with Kaapi error
-      new_cv =
+      new_config_version =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
         |> where([acv], acv.id != ^original_cv.id)
         |> Repo.one()
 
-      assert new_cv.status == :failed
-      assert new_cv.failure_reason =~ "Deferred Kaapi config"
+      assert new_config_version.status == :failed
+      assert new_config_version.failure_reason =~ "Deferred Kaapi config"
 
       # Active config should still be the original
       {:ok, post_callback} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
@@ -2681,17 +2797,17 @@ defmodule Glific.AssistantsTest do
           }
         })
 
-      # After callback, active config should be the new one
+      # active_config_version_id stays unchanged — explicit activation is required
       {:ok, post_callback} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
-      assert post_callback.active_config_version_id != original_cv.id
+      assert post_callback.active_config_version_id == original_cv.id
 
-      new_cv =
+      new_config_version =
         AssistantConfigVersion
         |> where([acv], acv.assistant_id == ^assistant.id)
         |> where([acv], acv.id != ^original_cv.id)
         |> Repo.one()
 
-      assert new_cv.status == :ready
+      assert new_config_version.status == :ready
 
       # get_assistant should show final ready state
       {:ok, final_fetched} = Assistants.get_assistant(assistant.id)
@@ -2755,34 +2871,6 @@ defmodule Glific.AssistantsTest do
       )
     end
 
-    test "auto-sets active_config_version_id when flag is disabled",
-         %{organization_id: organization_id, assistant: assistant, config_version: original_cv} do
-      FunWithFlags.disable(:assistant_config_versions_enabled,
-        for_actor: %{organization_id: organization_id}
-      )
-
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{status: 200, body: %{data: %{id: "kaapi_uuid_flag_off", version: 2}}}
-      end)
-
-      assert {:ok, _result} =
-               Assistants.update_assistant(assistant.id, %{
-                 name: "Flag Off Update",
-                 instructions: "Updated instructions",
-                 organization_id: organization_id
-               })
-
-      new_cv =
-        AssistantConfigVersion
-        |> where([acv], acv.assistant_id == ^assistant.id)
-        |> where([acv], acv.id != ^original_cv.id)
-        |> Repo.one()
-
-      {:ok, updated} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
-      assert updated.active_config_version_id != original_cv.id
-      assert updated.active_config_version_id == new_cv.id
-    end
   end
 
   describe "assistant_config_versions_enabled flag — async path (deferred_create_new_version)" do
@@ -2839,58 +2927,5 @@ defmodule Glific.AssistantsTest do
       )
     end
 
-    test "auto-sets active_config_version_id on callback when flag is disabled",
-         %{organization_id: organization_id, assistant: assistant, config_version: original_cv} do
-      FunWithFlags.disable(:assistant_config_versions_enabled,
-        for_actor: %{organization_id: organization_id}
-      )
-
-      {:ok, new_kb} =
-        Assistants.create_knowledge_base(%{
-          name: "Async Flag Off KB",
-          organization_id: organization_id
-        })
-
-      {:ok, new_kbv} =
-        Assistants.create_knowledge_base_version(%{
-          knowledge_base_id: new_kb.id,
-          organization_id: organization_id,
-          files: %{"file_1" => %{"filename" => "doc.pdf"}},
-          status: :in_progress,
-          llm_service_id: "temporary-vs-async-flag-off",
-          size: 300,
-          kaapi_job_id: "job_async_flag_off"
-        })
-
-      assert {:ok, _} =
-               Assistants.update_assistant(assistant.id, %{
-                 knowledge_base_version_id: new_kbv.id,
-                 organization_id: organization_id
-               })
-
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{status: 200, body: %{data: %{id: "kaapi_cv_flag_off", version: 2}}}
-      end)
-
-      Assistants.handle_knowledge_base_callback(%{
-        "data" => %{
-          "job_id" => "job_async_flag_off",
-          "status" => "SUCCESSFUL",
-          "collection" => %{"knowledge_base_id" => "vs_async_flag_off"},
-          "error_message" => nil
-        }
-      })
-
-      new_cv =
-        AssistantConfigVersion
-        |> where([acv], acv.assistant_id == ^assistant.id)
-        |> where([acv], acv.id != ^original_cv.id)
-        |> Repo.one()
-
-      {:ok, post_callback} = Repo.fetch(Assistant, assistant.id, skip_organization_id: true)
-      assert post_callback.active_config_version_id != original_cv.id
-      assert post_callback.active_config_version_id == new_cv.id
-    end
   end
 end

--- a/test/glific/filesearch_test.exs
+++ b/test/glific/filesearch_test.exs
@@ -152,7 +152,14 @@ defmodule Glific.FilesearchTest do
         }
       )
 
-    assert query_data.data["updateAssistant"]["assistant"]["temperature"] == 1.8
+    new_config_version =
+      AssistantConfigVersion
+      |> where([acv], acv.assistant_id == ^unified_assistant.id)
+      |> order_by([acv], desc: acv.version_number)
+      |> limit(1)
+      |> Repo.one()
+
+    assert get_in(new_config_version.settings, ["temperature"]) == 1.8
 
     assert %{"name" => "assistant2"} =
              query_data.data["updateAssistant"]["assistant"]


### PR DESCRIPTION
## Summary

- **Bug 1 fixed**: Uploading a KB for v2 was also inserting a join-table row linking it to v1 (the old active config). Root cause: `maybe_link_active_config` ran unconditionally whenever a first-time KB was added. Removed the function entirely — KB is now linked only to the new config version.
- **Bug 2 fixed**: Kaapi was receiving `temporary-vs-*` as the vector store ID. Root cause: when v1 had no KB, `knowledge_base_changed` was `false`, causing the immediate path to push the temp ID to Kaapi. The callback's deferred push was then silenced because two join-table rows existed. Fixed by simplifying the deferred guard to `kb_in_progress` — any in-progress KB defers Kaapi registration until the callback delivers the real `vs-*` ID.
- **Legacy flag code removed**: Removed the `Flags.get_assistant_config_versions_enabled` branches that auto-advanced `active_config_version_id` on update. With versioning always on, users activate versions explicitly via `set_live_version`.
- **Merged `deferred_update_transaction` into `update_assistant_transaction`**: both had an identical Multi pipeline with different return-value unwrapping — now one function.
- **Dead code removed**: `maybe_link_active_config/5`, `needs_active_config_link`, `knowledge_base_changed`, `alias Glific.Flags`.
- **Test cleanup**: removed 2 legacy flag tests, updated assertions to query new config version from DB directly, renamed `new_cv` → `new_config_version` throughout.
- **Added naming rule** to `test/CLAUDE.md`: use full descriptive variable names, no abbreviations.

## Test plan

- [ ] `mix test test/glific/assistants_test.exs` — 76 tests, 0 failures
- [ ] Verify org with assistant v1 (no KB): uploading KB for v2 no longer links it to v1's join table
- [ ] Verify Kaapi config version for v2 receives real `vs-*` ID (not `temporary-vs-*`) after KB callback
- [ ] Verify `set_live_version` still works to promote v2 to active after KB upload completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)