### PR TITLE
fix: surface actionable error when Google Sheets API is disabled (#5185)

### DIFF
--- a/lib/glific/third_party/sheets/google_sheets.ex
+++ b/lib/glific/third_party/sheets/google_sheets.ex
@@ -58,9 +58,59 @@ defmodule Glific.Sheets.GoogleSheets do
         body: %{majorDimension: "ROWS", values: data}
       ]
 
-      Spreadsheets.sheets_spreadsheets_values_append(conn, spreadsheet_id, range, params)
+      case Spreadsheets.sheets_spreadsheets_values_append(conn, spreadsheet_id, range, params) do
+        {:ok, result} ->
+          {:ok, result}
+
+        {:error, %Tesla.Env{status: 403, body: body} = reason} ->
+          if sheets_api_disabled?(body) do
+            Glific.log_error(
+              "Google Sheets API is not enabled for organization #{org_id}. Enable it in the GCP console at https://console.developers.google.com/apis/api/sheets.googleapis.com/overview?project=<project-id> then retry."
+            )
+
+            {:error, reason}
+          else
+            message =
+              "Google Sheets API write failed for organization #{org_id}, spreadsheet #{spreadsheet_id}: #{safe_inspect(reason)}"
+
+            Glific.log_error(message)
+            {:error, reason}
+          end
+
+        {:error, reason} ->
+          message =
+            "Google Sheets API write failed for organization #{org_id}, spreadsheet #{spreadsheet_id}: #{safe_inspect(reason)}"
+
+          Glific.log_error(message)
+          {:error, reason}
+      end
     end
   end
+
+  @spec sheets_api_disabled?(any()) :: boolean()
+  defp sheets_api_disabled?(body) when is_binary(body) do
+    disabled? =
+      body
+      |> String.downcase()
+      |> String.contains?(["has not been used in project", "it is disabled"])
+
+    if disabled? do
+      true
+    else
+      case Jason.decode(body) do
+        {:ok, decoded_body} -> sheets_api_disabled?(decoded_body)
+        {:error, _} -> false
+      end
+    end
+  end
+
+  defp sheets_api_disabled?(%{"error" => %{"message" => message}}) when is_binary(message) do
+    message
+    |> String.downcase()
+    |> String.contains?(["has not been used in project", "it is disabled"])
+  end
+
+  defp sheets_api_disabled?(_body), do: false
 
   @doc false
   @spec fetch_credentials(non_neg_integer) :: nil | {:ok, any} | {:error, any}

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -1328,12 +1328,20 @@ defmodule Glific.SheetsTest do
 
         params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
 
-        capture_log(fn ->
-          result = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+        log =
+          capture_log(fn ->
+            result = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
 
-          assert match?({:error, _reason}, result)
-          refute match?({:ok, _result}, result)
-        end)
+            assert {:error, %Tesla.Env{status: 403}} = result
+            refute match?({:ok, _result}, result)
+          end)
+
+        assert log =~
+                 "Google Sheets API write failed for organization #{organization_id}, spreadsheet #{@spreadsheet_id}"
+
+        assert log =~ "The caller does not have permission"
+        refute log =~ "Google Sheets API is not enabled"
+        refute log =~ "console.developers.google.com"
       end
     end
 

--- a/test/glific/sheets_test.exs
+++ b/test/glific/sheets_test.exs
@@ -3,6 +3,7 @@ defmodule Glific.SheetsTest do
   use Oban.Pro.Testing, repo: Glific.Repo
 
   import Ecto.Query
+  import ExUnit.CaptureLog
   import Mock
 
   alias Glific.{
@@ -1217,6 +1218,151 @@ defmodule Glific.SheetsTest do
     test "returns error when Google API is not active", %{organization_id: organization_id} do
       assert {:error, "Google API is not active"} =
                GoogleSheets.get_headers(organization_id, @spreadsheet_id)
+    end
+  end
+
+  describe "GoogleSheets.insert_row/3 error surfacing" do
+    test "insert_row/3 surfaces an actionable error and logs when the Sheets API is disabled",
+         %{organization_id: organization_id} do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        Tesla.Mock.mock(fn
+          %{method: :post} ->
+            %Tesla.Env{
+              status: 403,
+              body:
+                Jason.encode!(%{
+                  "error" => %{
+                    "code" => 403,
+                    "status" => "PERMISSION_DENIED",
+                    "message" =>
+                      "Google Sheets API has not been used in project 123456789 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sheets.googleapis.com/overview?project=123456789 then retry."
+                  }
+                })
+            }
+        end)
+
+        params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
+
+        log =
+          capture_log(fn ->
+            result = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+
+            assert {:error, %Tesla.Env{status: 403}} = result
+            refute match?({:ok, _result}, result)
+          end)
+
+        assert log =~ "console.developers.google.com"
+        assert log =~ "organization #{organization_id}"
+      end
+    end
+
+    test "insert_row/3 classifies a decoded JSON map error body as API-disabled", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        Tesla.Mock.mock(fn
+          %{method: :post} ->
+            %Tesla.Env{
+              status: 403,
+              body: %{
+                "error" => %{
+                  "code" => 403,
+                  "status" => "PERMISSION_DENIED",
+                  "message" =>
+                    "Google Sheets API has not been used in project 123456789 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/sheets.googleapis.com/overview?project=123456789 then retry."
+                }
+              }
+            }
+        end)
+
+        params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
+
+        log =
+          capture_log(fn ->
+            result = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+
+            assert {:error, %Tesla.Env{status: 403}} = result
+            refute match?({:ok, _result}, result)
+          end)
+
+        assert log =~ "console.developers.google.com"
+        assert log =~ "organization #{organization_id}"
+      end
+    end
+
+    test "insert_row/3 surfaces non-disabled 403 errors without treating them as API-disabled",
+         %{organization_id: organization_id} do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        Tesla.Mock.mock(fn
+          %{method: :post} ->
+            %Tesla.Env{
+              status: 403,
+              body:
+                Jason.encode!(%{
+                  "error" => %{
+                    "code" => 403,
+                    "status" => "PERMISSION_DENIED",
+                    "message" => "The caller does not have permission"
+                  }
+                })
+            }
+        end)
+
+        params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
+
+        capture_log(fn ->
+          result = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+
+          assert match?({:error, _reason}, result)
+          refute match?({:ok, _result}, result)
+        end)
+      end
+    end
+
+    test "insert_row/3 returns {:ok, _} on a successful append", %{
+      organization_id: organization_id
+    } do
+      with_mock(Goth.Token, [],
+        fetch: fn _url ->
+          {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+        end
+      ) do
+        setup_google_sheets_credential(organization_id)
+
+        Tesla.Mock.mock(fn
+          %{method: :post} ->
+            %Tesla.Env{
+              status: 200,
+              body:
+                Jason.encode!(%{
+                  spreadsheetId: @spreadsheet_id,
+                  updates: %{updatedRows: 1}
+                })
+            }
+        end)
+
+        params = %{range: "Sheet1!A:A", data: [["Alice", "30"]]}
+
+        assert {:ok, _} = GoogleSheets.insert_row(organization_id, @spreadsheet_id, params)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Target issue is #5185

When an organization has a Google service account configured but the Google Sheets API itself is not enabled in their GCP project, every sheet write failed silently. The append call returns `{:error, %Tesla.Env{status: 403, body: ...}}` whose body says the Sheets API "has not been used in project N before or it is disabled", but `insert_row/3` returned that tuple unhandled: nothing was logged, no AppSignal incident was raised, and the flow proceeded as if the write had succeeded.

This change makes `insert_row/3` handle the append result explicitly:

- Detects the API-disabled 403 via a new private `sheets_api_disabled?/1` helper that matches both a raw JSON string body (the wire shape) and a decoded `%{"error" => %{"message" => _}}` map, and surfaces an actionable operator message through `Glific.log_error/1` (Logger + AppSignal) that includes the GCP console enable link.
- Returns the original `%Tesla.Env{status: 403}` so the existing `Glific.Sheets.execute/2` notification path (`format_notification_message/2`) still extracts Google's `error.message` and shows the actionable enable URL to the end user, instead of falling through to the generic "Unknown error occurred" message.
- Logs and surfaces any other error (non-disabled 403, other 4xx/5xx, timeouts) via `Glific.log_error/1` + `safe_inspect/1` rather than swallowing it.
- Returns `{:ok, result}` unchanged on a successful append.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] If you've fixed a bug or added code that is tested and has test cases.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

(No new API surface was added, so no postman request applies.)

## Notes
Added tests in `test/glific/sheets_test.exs` covering the disabled-API 403 (raw-string and decoded-map bodies, asserting the actionable message is logged), a non-disabled 403 (surfaced as an error rather than treated as disabled), and the happy path.

`safe_inspect/1` is used for the generic error message so a `Tesla.Env` reason never leaks OAuth tokens into logs.

The change is format-clean per the standalone Elixir formatter and both touched files parse cleanly; `mix setup` / full `mix test` were not run in my environment, so please confirm CI runs them.

Fixes #5185
