### PR TITLE
autofix: guard non-stringable map values in Router.update_context_results (incident #22)

### DIFF
--- a/lib/glific/flows/router.ex
+++ b/lib/glific/flows/router.ex
@@ -391,7 +391,7 @@ defmodule Glific.Flows.Router do
           json =
             msg.whatsapp_form_response.raw_response
             |> Map.new(fn
-              {k, v} when is_list(v) -> {k, Enum.join(v, ", ")}
+              {k, v} when is_list(v) -> {k, v |> Enum.map(&stringify_value/1) |> Enum.join(", ")}
               {k, v} -> {k, v}
             end)
 
@@ -418,6 +418,13 @@ defmodule Glific.Flows.Router do
 
     FlowContext.update_results(context, results)
   end
+
+  # Coerce a value to a string for list-join operations.
+  # Maps are JSON-encoded to preserve their structure; everything else
+  # uses the standard String.Chars protocol.
+  @spec stringify_value(term()) :: String.t()
+  defp stringify_value(v) when is_map(v), do: Jason.encode!(v)
+  defp stringify_value(v), do: to_string(v)
 
   ## Format operand and replace @fields. to @contact.fields. so that system can parse it automatically.
   ## for other router operand we are handling everything in a same way.

--- a/test/glific/flows/router_test.exs
+++ b/test/glific/flows/router_test.exs
@@ -451,6 +451,77 @@ defmodule Glific.Flows.RouterTest do
     assert updated_context.results["form_result"]["single_choice"] == "Option_1"
   end
 
+  # Regression test for AppSignal incident #22:
+  # whatsapp_form_response list values that contain maps (e.g. media payloads with
+  # file_name/id/mime_type/sha256) previously crashed with Protocol.UndefinedError
+  # because Enum.join/2 cannot call String.Chars.to_string/1 on a Map.
+  test "router with whatsapp_form_response does not crash when list values contain maps" do
+    flow = %Flow{uuid: "Flow UUID 1", id: 1}
+    exit_uuid = Ecto.UUID.generate()
+    uuid_map = %{}
+
+    json = %{
+      "uuid" => "Node UUID",
+      "actions" => [],
+      "exits" => [%{"uuid" => exit_uuid, "destination_uuid" => nil}]
+    }
+
+    {node, uuid_map} = Node.process(json, uuid_map, flow)
+
+    json = %{
+      "operand" => "@input.text",
+      "type" => "switch",
+      "default_category_uuid" => "Default Cat UUID",
+      "result_name" => "form_result",
+      "categories" => [
+        %{
+          "uuid" => "Default Cat UUID",
+          "exit_uuid" => exit_uuid,
+          "name" => "Default Category"
+        }
+      ],
+      "cases" => []
+    }
+
+    {router, uuid_map} = Router.process(json, uuid_map, node)
+
+    context = flow_context_fixture(%{uuid_map: uuid_map})
+
+    # A WhatsApp form response where one field is a list of media maps
+    # (reproduces the Protocol.UndefinedError from incident #22)
+    media_map = %{
+      "file_name" => "4D569F7B-photo.jpg",
+      "id" => 864_939_859_557_108,
+      "mime_type" => "image/jpeg",
+      "sha256" => "abc123"
+    }
+
+    raw_response = %{
+      "flow_token" => "unused",
+      "media_field" => [media_map],
+      "text_field" => "some text"
+    }
+
+    message =
+      Messages.create_temp_message(
+        Fixtures.get_org_id(),
+        "form submitted",
+        type: :whatsapp_form_response,
+        whatsapp_form_response: %{raw_response: raw_response}
+      )
+
+    # This must not raise Protocol.UndefinedError
+    {:ok, _, _} = Router.execute(router, context, [message])
+
+    updated_context = Repo.get!(FlowContext, context.id)
+
+    # The map element should be JSON-encoded and then joined into the string
+    media_json = Jason.encode!(media_map)
+    assert updated_context.results["form_result"]["media_field"] == media_json
+    # Non-list values are untouched
+    assert updated_context.results["form_result"]["text_field"] == "some text"
+  end
+
   test "router with split by groups" do
     flow = %Flow{uuid: "Flow UUID 1", id: 1}
     exit_uuid = Ecto.UUID.generate()


### PR DESCRIPTION
## AppSignal Incident

[Incident #22 — Protocol.UndefinedError in Router.update_context_results](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/22)

23 occurrences in the last 7 days (2,541 total).

## Root Cause

In `lib/glific/flows/router.ex`, the `:whatsapp_form_response` branch of `update_context_results/4` calls:

```elixir
{k, v} when is_list(v) -> {k, Enum.join(v, ", ")}
```

When a WhatsApp form field contains a list whose elements are Maps — e.g. a media attachment payload like `%{"file_name" => "photo.jpg", "id" => 864939859557108, "mime_type" => "image/jpeg", "sha256" => "..."}` — `Enum.join/2` internally calls `String.Chars.to_string/1` on each element. That protocol is not implemented for `Map`, so the call raises `Protocol.UndefinedError` and crashes the flow background worker.

## Fix

Added a private `stringify_value/1` helper that JSON-encodes maps (via `Jason.encode!/1`) and falls back to `to_string/1` for all other values. The list-joining line becomes:

```elixir
{k, v} when is_list(v) -> {k, v |> Enum.map(&stringify_value/1) |> Enum.join(", ")}
```

The normal case — lists of plain strings or atoms — is entirely unchanged. Map elements are now stored as their JSON representation instead of crashing.

## Test

Added a regression test `"router with whatsapp_form_response does not crash when list values contain maps"` in `test/glific/flows/router_test.exs`. It feeds a media map inside a list field through `Router.execute/3` and asserts:
1. No crash (no `Protocol.UndefinedError`)
2. The map element is stored as its JSON-encoded string

## Test results

```
Running ExUnit with seed: 626439, max_cases: 24
.........
Finished in 0.3 seconds (0.3s async, 0.00s sync)
9 tests, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)