### PR TITLE
autofix: handle {:error, Cachex.ExecutionError} in Periodic.init_common_flow (incident #4)

### DIFF
--- a/lib/glific/flows/periodic.ex
+++ b/lib/glific/flows/periodic.ex
@@ -13,6 +13,8 @@ defmodule Glific.Flows.Periodic do
   """
   use Publicist
 
+  require Logger
+
   alias Glific.{
     Flows,
     Flows.FlowContext,
@@ -143,11 +145,18 @@ defmodule Glific.Flows.Periodic do
     do: common_flow(state, period, message, since)
 
   defp init_common_flow(state, flow_id, message) do
-    {:ok, flow} =
-      Flows.get_cached_flow(message.organization_id, {:flow_id, flow_id, @final_phrase})
+    case Flows.get_cached_flow(message.organization_id, {:flow_id, flow_id, @final_phrase}) do
+      {:ok, flow} ->
+        opts = Keyword.put(Keyword.new(), :flow_keyword, message.body)
+        FlowContext.init_context(flow, message.contact, @final_phrase, opts)
+        {state, true}
 
-    opts = Keyword.put(Keyword.new(), :flow_keyword, message.body)
-    FlowContext.init_context(flow, message.contact, @final_phrase, opts)
-    {state, true}
+      {:error, error} ->
+        Logger.error(
+          "Periodic: failed to load flow #{flow_id} for org #{message.organization_id}: #{inspect(error)}"
+        )
+
+        {state, false}
+    end
   end
 end

--- a/test/glific/flows/periodic_test.exs
+++ b/test/glific/flows/periodic_test.exs
@@ -142,4 +142,19 @@ defmodule Glific.Flows.PeriodicTest do
     assert {state, false} == Periodic.periodic_flow(state, "monday", nil, monday)
     assert {state, false} == Periodic.periodic_flow(state, "wednesday", nil, monday)
   end
+
+  test "init_common_flow returns {state, false} when flow has no published revision (incident #4)",
+       %{organization_id: organization_id} = attrs do
+    # Simulate the production incident: a flow_id exists in flow_keywords_map but its
+    # published revision is missing, causing get_cached_flow to return {:error, _}.
+    # Before the fix, this triggered a MatchError crash; now it must return {state, false}.
+    message = Fixtures.message_fixture(attrs) |> Repo.preload(:contact)
+    state = Periodic.map_flow_ids(%{organization_id: organization_id})
+
+    # Flow ID 0 does not exist in the database, so get_cached_flow will return {:error, _}.
+    nonexistent_flow_id = 0
+
+    assert {^state, false} =
+             Periodic.init_common_flow(state, nonexistent_flow_id, message)
+  end
 end


### PR DESCRIPTION
## AppSignal incident

https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/4

52 occurrences in the last 7 days, 23,731 total.

## Root cause

`init_common_flow/3` in `lib/glific/flows/periodic.ex` (line 146 before this fix) used a bare pattern-match:

```elixir
{:ok, flow} = Flows.get_cached_flow(...)
```

`get_cached_flow/2` returns `{:error, %Cachex.ExecutionError{}}` when the requested flow ID has no published revision — for example, when a flow referenced in `flow_keywords_map` was deleted or its published revision was removed. The bare match raises a `MatchError`, which crashes the message processor for that contact.

## Fix

Replace the bare match with a `case` expression:

- `{:ok, flow}` — happy path, unchanged behaviour.
- `{:error, error}` — logs the error via `Logger.error/1` and returns `{state, false}`, skipping this periodic flow gracefully without crashing.

Only 2 files changed (`lib/glific/flows/periodic.ex`, `test/glific/flows/periodic_test.exs`). No unrelated code touched.

## Test

New test added to `test/glific/flows/periodic_test.exs`:

```
test "init_common_flow returns {state, false} when flow has no published revision (incident #4)"
```

Calls `init_common_flow/3` directly (exposed via `Publicist`) with flow ID `0` (non-existent in DB), which causes `get_cached_flow` to return `{:error, _}`. Asserts the result is `{state, false}` — not a crash.

## Test result

```
Running ExUnit with seed: 37927, max_cases: 24
Excluding tags: [:pending]

.....
Finished in 0.4 seconds (0.00s async, 0.4s sync)
5 tests, 0 failures
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)