### PR TITLE
autofix: harden GcsWorker against GCS download timeouts (incident #139)

### DIFF
--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -34,6 +34,9 @@ defmodule Glific.GCS.GcsWorker do
   @provider_shortcode "google_cloud_storage"
 
   @nightly_interval_hrs 20
+  # How long (in seconds) to snooze a job after a transient download timeout before
+  # Oban retries it. Downloading is idempotent so a bounded snooze+retry is safe.
+  @download_timeout_snooze_seconds 60
   @doc """
   This is called from the cron job on a regular schedule. we sweep the message media url  table
   and queue them up for delivery to gcs
@@ -196,8 +199,8 @@ defmodule Glific.GCS.GcsWorker do
   Standard perform method to use Oban worker
   """
   @impl Oban.Worker
-  @spec perform(Oban.Job.t()) :: :ok | {:error, String.t()} | {:discard, String.t()}
-  def perform(%Oban.Job{args: %{"media" => media}}) do
+  @spec perform(Oban.Job.t()) :: :ok | {:snooze, pos_integer()} | {:discard, String.t()}
+  def perform(%Oban.Job{args: %{"media" => media}, attempt: attempt, max_attempts: max_attempts}) do
     Logger.info("GCSWORKER: Performing gcs media for media id: #{media["id"]}")
 
     Repo.put_process_state(media["organization_id"])
@@ -228,8 +231,16 @@ defmodule Glific.GCS.GcsWorker do
           "GCSWORKER: GCS Download timeout for org_id: #{media["organization_id"]}, media_id: #{media["id"]}"
 
         Logger.info(error)
-        add_message_media_error(media, error)
-        {:error, error}
+
+        # Downloading is idempotent — safe to retry. Snooze instead of returning
+        # {:error, _} so Oban does not raise Oban.PerformError and flood AppSignal.
+        # On the final attempt, discard the job so it stops looping.
+        if attempt < max_attempts do
+          {:snooze, @download_timeout_snooze_seconds}
+        else
+          add_message_media_error(media, error)
+          {:discard, error}
+        end
 
       {:error, error} ->
         error =

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -69,6 +69,69 @@ defmodule Glific.GcsWorkerTest do
     end
   end
 
+  test "perform/1 snoozes on download timeout when attempts remain (incident #139)", attrs do
+    GCS.insert_gcs_jobs(attrs.organization_id)
+    media_item = Fixtures.message_media_fixture(%{organization_id: attrs.organization_id})
+
+    with_mock(
+      Tesla,
+      [],
+      get: fn _url, _opts -> {:error, :timeout} end
+    ) do
+      # Simulate attempt 1 of 2 — should snooze, not fail or discard.
+      job = %Oban.Job{
+        args: %{
+          "media" => %{
+            "id" => media_item.id,
+            "url" => "https://example.com/file.mp3",
+            "type" => "audio",
+            "contact_id" => 1,
+            "flow_id" => 0,
+            "organization_id" => attrs.organization_id,
+            "sync_phase" => "incremental"
+          }
+        },
+        attempt: 1,
+        max_attempts: 2
+      }
+
+      assert {:snooze, snooze_secs} = GcsWorker.perform(job)
+      assert snooze_secs > 0
+    end
+  end
+
+  test "perform/1 discards on download timeout when final attempt is exhausted (incident #139)",
+       attrs do
+    GCS.insert_gcs_jobs(attrs.organization_id)
+    media_item = Fixtures.message_media_fixture(%{organization_id: attrs.organization_id})
+
+    with_mock(
+      Tesla,
+      [],
+      get: fn _url, _opts -> {:error, :timeout} end
+    ) do
+      # Simulate attempt 2 of 2 (final) — should discard, not raise Oban.PerformError.
+      job = %Oban.Job{
+        args: %{
+          "media" => %{
+            "id" => media_item.id,
+            "url" => "https://example.com/file.mp3",
+            "type" => "audio",
+            "contact_id" => 1,
+            "flow_id" => 0,
+            "organization_id" => attrs.organization_id,
+            "sync_phase" => "unsynced"
+          }
+        },
+        attempt: 2,
+        max_attempts: 2
+      }
+
+      assert {:discard, reason} = GcsWorker.perform(job)
+      assert reason =~ "GCS Download timeout"
+    end
+  end
+
   test "upload_media/3 returns an error tuple (no crash) when the GCS upload raises", attrs do
     with_mock(
       Waffle.Storage.Google.CloudStorage,


### PR DESCRIPTION
## Root cause

`Glific.GCS.GcsWorker.perform/1` was returning `{:error, error_string}` when a media file download timed out. Oban treats `{:error, _}` as a job failure, re-raises it as `Oban.PerformError`, and re-queues the job until `max_attempts` is exhausted. Each attempt emits a new AppSignal `Oban.PerformError` event, causing 1,638 new occurrences in 7 days (139,798 total — the highest-volume failure this week).

**References:**
- AppSignal incident #139: https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/139
- GitHub issue: https://github.com/glific/glific/issues/4232

## Root cause analysis

The `perform/1` function had:
- `{:error, :timeout}` on download timeout → causes `Oban.PerformError` on every failed attempt
- `{:discard, error}` for other download errors → correct, does not raise
- Worker has `max_attempts: 2` so it retried once before exhausting, but both attempts raised AppSignal errors

## Resilience change

Changed the `{:error, :timeout}` branch in `perform/1` to:

1. **Snooze** (`{:snooze, 60}`) when `attempt < max_attempts` — Oban delays the retry without raising `Oban.PerformError`, so AppSignal is not spammed.
2. **Discard** (`{:discard, reason}`) on the final attempt — the job stops looping and is moved cleanly to the dead-letter bucket; the `gcs_error` field on `MessageMedia` is set (for unsynced phase) so the failure is visible.

The worker already has `max_attempts: 2`, so behaviour is: attempt 1 times out → snooze 60 s → attempt 2 times out → discard. Two attempts maximum, zero `Oban.PerformError` events raised.

**Idempotency note:** The snooze only triggers a retry of the *download* step, which is a read (idempotent). The *upload* to GCS is only attempted after a successful download — no blind retry was added around the side-effecting upload.

## Files changed

- `lib/glific/third_party/gcs/gcs_worker.ex` — `perform/1` now pattern-matches `attempt` and `max_attempts` from the job struct; `{:error, :timeout}` becomes `{:snooze, 60}` or `{:discard, reason}` depending on remaining attempts. Module attribute `@download_timeout_snooze_seconds` added.
- `test/glific/gcs_worker_test.exs` — two new regression tests assert the snooze/discard boundary.

## Test result

```
7 tests, 0 failures
```

All 7 tests pass including the two new regression tests for incident #139.

🤖 Generated with [Claude Code](https://claude.com/claude-code)