### PR TITLE
fix(flows): handle invalid Google Sheet URL during flow import

### DIFF
--- a/assets/gql/flows/import_flow.gql
+++ b/assets/gql/flows/import_flow.gql
@@ -4,6 +4,7 @@ mutation importFlow($flow: Json!) {
       flowName
       status
       assistantNodeUuids
+      invalidSheetNodeUuids
     }
   }
 }

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -1034,7 +1034,7 @@ defmodule Glific.Flows do
                keywords: flow_revision["keywords"],
                organization_id: organization_id
              }),
-           {cleaned_definition, assistant_node_uuids} <-
+           {cleaned_definition, assistant_node_uuids, invalid_sheet_node_uuids} <-
              clean_flow_definition(
                flow_revision["definition"],
                interactive_template_list,
@@ -1053,7 +1053,8 @@ defmodule Glific.Flows do
         %{
           flow_name: flow.name,
           status: "Successfully imported",
-          assistant_node_uuids: assistant_node_uuids
+          assistant_node_uuids: assistant_node_uuids,
+          invalid_sheet_node_uuids: invalid_sheet_node_uuids
         }
       else
         {:error, error} ->
@@ -1069,35 +1070,40 @@ defmodule Glific.Flows do
 
           Logger.error("Failed to import flow #{flow_name}: #{error_message}, #{inspect(errors)}")
 
-          %{flow_name: flow_name, status: error_message, assistant_node_uuids: []}
+          %{
+            flow_name: flow_name,
+            status: error_message,
+            assistant_node_uuids: [],
+            invalid_sheet_node_uuids: []
+          }
       end
     end)
   end
 
-  @spec clean_flow_definition(map(), list(), non_neg_integer()) :: term()
+  @spec clean_flow_definition(map(), list(), non_neg_integer()) :: {map(), list(), list()}
   defp clean_flow_definition(definition, interactive_template_list, organization_id) do
     flow_info = %{
       flow_uuid: definition["uuid"],
       flow_name: definition["name"]
     }
 
-    {nodes, assistant_node_uuids} =
+    {nodes, assistant_node_uuids, invalid_sheet_node_uuids} =
       definition
       |> Map.get("nodes", [])
       |> Enum.reduce(
-        {[], []},
-        fn node, {nodes_acc, uuids_acc} ->
-          {processed_nodes, node_uuids} =
+        {[], [], []},
+        fn node, {nodes_acc, assistant_acc, sheet_acc} ->
+          {processed_nodes, assistant_uuids, sheet_uuids} =
             process_node_actions(node, interactive_template_list, flow_info, organization_id)
 
-          {nodes_acc ++ processed_nodes, uuids_acc ++ node_uuids}
+          {nodes_acc ++ processed_nodes, assistant_acc ++ assistant_uuids, sheet_acc ++ sheet_uuids}
         end
       )
 
-    {put_in(definition, ["nodes"], nodes), assistant_node_uuids}
+    {put_in(definition, ["nodes"], nodes), assistant_node_uuids, invalid_sheet_node_uuids}
   end
 
-  @spec process_node_actions(map(), list(), map(), non_neg_integer()) :: {list(), list()}
+  @spec process_node_actions(map(), list(), map(), non_neg_integer()) :: {list(), list(), list()}
   defp process_node_actions(
          %{"actions" => actions} = node,
          _interactive_template_list,
@@ -1105,7 +1111,7 @@ defmodule Glific.Flows do
          _org_id
        )
        when actions == [],
-       do: {[node], []}
+       do: {[node], [], []}
 
   defp process_node_actions(
          %{"actions" => actions} = node,
@@ -1113,20 +1119,24 @@ defmodule Glific.Flows do
          flow_info,
          org_id
        ) do
-    {updated_actions, has_assistant?} =
-      Enum.reduce(actions, {[], false}, fn action, {actions_acc, has_assistant_acc} ->
+    {updated_actions, tags} =
+      Enum.reduce(actions, {[], MapSet.new()}, fn action, {actions_acc, tags_acc} ->
         case process_action(action, node, interactive_template_list, flow_info, org_id) do
           {:ok, updated_action} ->
-            {actions_acc ++ [updated_action], has_assistant_acc}
+            {actions_acc ++ [updated_action], tags_acc}
 
-          {:ok, updated_action, :assistant} ->
-            {actions_acc ++ [updated_action], true}
+          {:ok, updated_action, tag} ->
+            {actions_acc ++ [updated_action], MapSet.put(tags_acc, tag)}
         end
       end)
 
     updated_node = Map.put(node, "actions", updated_actions)
-    node_uuids = if has_assistant?, do: [node_label(node["uuid"])], else: []
-    {[updated_node], node_uuids}
+    label = node_label(node["uuid"])
+
+    assistant_uuids = if MapSet.member?(tags, :assistant), do: [label], else: []
+    invalid_sheet_uuids = if MapSet.member?(tags, :invalid_sheet), do: [label], else: []
+
+    {[updated_node], assistant_uuids, invalid_sheet_uuids}
   end
 
   # The flow editor labels each node with the last 4 chars of its UUID
@@ -1162,11 +1172,17 @@ defmodule Glific.Flows do
          _flow_info,
          _org_id
        ) do
-    sheet_url = action["url"]
-    sheet_name = action["name"]
-    sheet = get_or_create_sheet(sheet_url, sheet_name)
-    updated_action = Map.put(action, "sheet_id", sheet.id)
-    {:ok, updated_action}
+    case get_or_create_sheet(action["url"], action["name"]) do
+      {:ok, sheet} ->
+        {:ok, Map.put(action, "sheet_id", sheet.id)}
+
+      {:error, _reason} ->
+        # The sheet URL is invalid or not set up in this org. Import the action
+        # without a linked sheet_id (dropping any stale id from the source org) so
+        # the user can fix it manually, and tag the node so the import status can
+        # warn about it instead of crashing the whole import.
+        {:ok, Map.delete(action, "sheet_id"), :invalid_sheet}
+    end
   end
 
   defp process_action(
@@ -1231,6 +1247,8 @@ defmodule Glific.Flows do
     Map.has_key?(action, "templating") and template_uuid not in template_uuid_list
   end
 
+  @spec get_or_create_sheet(String.t() | nil, String.t() | nil) ::
+          {:ok, Sheet.t()} | {:error, any()}
   defp get_or_create_sheet(sheet_url, sheet_name) do
     current_user = Repo.get_current_user()
 
@@ -1242,11 +1260,10 @@ defmodule Glific.Flows do
 
     case Repo.fetch_by(Sheet, %{url: sheet_url}) do
       {:ok, sheet} ->
-        sheet
+        {:ok, sheet}
 
       {:error, _} ->
-        {:ok, sheet} = Sheets.create_sheet(attrs)
-        sheet
+        Sheets.create_sheet(attrs)
     end
   end
 

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -1096,7 +1096,8 @@ defmodule Glific.Flows do
           {processed_nodes, assistant_uuids, sheet_uuids} =
             process_node_actions(node, interactive_template_list, flow_info, organization_id)
 
-          {nodes_acc ++ processed_nodes, assistant_acc ++ assistant_uuids, sheet_acc ++ sheet_uuids}
+          {nodes_acc ++ processed_nodes, assistant_acc ++ assistant_uuids,
+           sheet_acc ++ sheet_uuids}
         end
       )
 
@@ -1119,22 +1120,25 @@ defmodule Glific.Flows do
          flow_info,
          org_id
        ) do
-    {updated_actions, tags} =
-      Enum.reduce(actions, {[], MapSet.new()}, fn action, {actions_acc, tags_acc} ->
+    {updated_actions, has_assistant?, has_invalid_sheet?} =
+      Enum.reduce(actions, {[], false, false}, fn action, {acc, assistant?, invalid_sheet?} ->
         case process_action(action, node, interactive_template_list, flow_info, org_id) do
           {:ok, updated_action} ->
-            {actions_acc ++ [updated_action], tags_acc}
+            {acc ++ [updated_action], assistant?, invalid_sheet?}
 
-          {:ok, updated_action, tag} ->
-            {actions_acc ++ [updated_action], MapSet.put(tags_acc, tag)}
+          {:ok, updated_action, :assistant} ->
+            {acc ++ [updated_action], true, invalid_sheet?}
+
+          {:ok, updated_action, :invalid_sheet} ->
+            {acc ++ [updated_action], assistant?, true}
         end
       end)
 
     updated_node = Map.put(node, "actions", updated_actions)
     label = node_label(node["uuid"])
 
-    assistant_uuids = if MapSet.member?(tags, :assistant), do: [label], else: []
-    invalid_sheet_uuids = if MapSet.member?(tags, :invalid_sheet), do: [label], else: []
+    assistant_uuids = if has_assistant?, do: [label], else: []
+    invalid_sheet_uuids = if has_invalid_sheet?, do: [label], else: []
 
     {[updated_node], assistant_uuids, invalid_sheet_uuids}
   end

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -1169,18 +1169,22 @@ defmodule Glific.Flows do
          %{"type" => "link_google_sheet"} = action,
          _node,
          _interactive_template_list,
-         _flow_info,
+         flow_info,
          _org_id
        ) do
     case get_or_create_sheet(action["url"], action["name"]) do
       {:ok, sheet} ->
         {:ok, Map.put(action, "sheet_id", sheet.id)}
 
-      {:error, _reason} ->
-        # The sheet URL is invalid or not set up in this org. Import the action
-        # without a linked sheet_id (dropping any stale id from the source org) so
-        # the user can fix it manually, and tag the node so the import status can
-        # warn about it instead of crashing the whole import.
+      {:error, reason} ->
+        # We always import the action without a linked sheet_id (dropping any stale
+        # id from the source org) and tag the node so the import status can warn the
+        # user, instead of crashing the whole import. But we still surface *why* the
+        # sheet could not be linked: a plain "Invalid sheet URL" is expected user input
+        # (benign), whereas anything else (missing credentials, 403/no access, network)
+        # is an integration failure that should reach AppSignal so it isn't silently
+        # swallowed. See get_or_create_sheet/2 and Sheets.create_sheet/1.
+        log_sheet_link_failure(reason, action["url"], flow_info)
         {:ok, Map.delete(action, "sheet_id"), :invalid_sheet}
     end
   end
@@ -1224,6 +1228,27 @@ defmodule Glific.Flows do
 
   defp process_action(action, _node, _interactive_template_list, _flow_info, _org_id),
     do: {:ok, action}
+
+  # "Invalid sheet URL" is expected user input (placeholder/invalid url) — log it
+  # for visibility but don't page anyone via AppSignal. Any other reason is an
+  # integration failure (missing credentials, no edit/read access, network) and
+  # must surface to AppSignal so it isn't silently degraded to a blank import.
+  @spec log_sheet_link_failure(any(), String.t() | nil, map()) :: :ok
+  defp log_sheet_link_failure("Invalid sheet URL" = reason, url, flow_info) do
+    Logger.info(
+      "Skipping Google Sheet link for flow #{flow_info[:flow_name]} (#{flow_info[:flow_uuid]}): #{reason}, url: #{inspect(url)}"
+    )
+
+    :ok
+  end
+
+  defp log_sheet_link_failure(reason, url, flow_info) do
+    Glific.log_error(
+      "Failed to link Google Sheet during import for flow #{flow_info[:flow_name]} (#{flow_info[:flow_uuid]}): #{inspect(reason)}, url: #{inspect(url)}"
+    )
+
+    :ok
+  end
 
   @spec clear_assistant_id(map()) :: {:ok, map()} | :no_assistant
   defp clear_assistant_id(action) do

--- a/lib/glific_web/schema/flow_types.ex
+++ b/lib/glific_web/schema/flow_types.ex
@@ -47,6 +47,7 @@ defmodule GlificWeb.Schema.FlowTypes do
     field :flow_name, non_null(:string)
     field :status, non_null(:string)
     field :assistant_node_uuids, list_of(:string)
+    field :invalid_sheet_node_uuids, list_of(:string)
   end
 
   object :flow do

--- a/test/glific_web/schema/flow_test.exs
+++ b/test/glific_web/schema/flow_test.exs
@@ -971,7 +971,7 @@ defmodule GlificWeb.Schema.FlowTest do
     revision =
       FlowRevision
       |> where([fr], fr.flow_id == ^flow.id)
-      |> order_by([fr], desc: fr.inserted_at)
+      |> order_by([fr], desc: fr.inserted_at, desc: fr.id)
       |> limit(1)
       |> Repo.one!()
 

--- a/test/glific_web/schema/flow_test.exs
+++ b/test/glific_web/schema/flow_test.exs
@@ -985,6 +985,82 @@ defmodule GlificWeb.Schema.FlowTest do
     refute Map.has_key?(sheet_action, "sheet_id")
   end
 
+  test "import flow with a valid google sheet url links the existing sheet",
+       %{manager: user} do
+    sheet_node_uuid = "a1b2c3d4-5555-6666-7777-88889999bbbb"
+
+    # A sheet with this url already exists in the org, so `get_or_create_sheet/2`
+    # resolves it via `Repo.fetch_by/2` (the happy path) instead of hitting the network.
+    existing_sheet = Fixtures.sheet_fixture(%{organization_id: user.organization_id})
+
+    import_data = %{
+      "flows" => [
+        %{
+          "keywords" => ["validsheetimporttest"],
+          "definition" => %{
+            "name" => "Valid Sheet Import Flow",
+            "uuid" => Ecto.UUID.generate(),
+            "nodes" => [
+              %{
+                "uuid" => sheet_node_uuid,
+                "actions" => [
+                  %{
+                    "type" => "link_google_sheet",
+                    "uuid" => Ecto.UUID.generate(),
+                    "name" => existing_sheet.label,
+                    "url" => existing_sheet.url,
+                    # A stale sheet_id from the source org that must be replaced with
+                    # the resolved sheet's real id.
+                    "sheet_id" => 999
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "contact_field" => [],
+      "collections" => [],
+      "interactive_templates" => []
+    }
+
+    import_flow = Jason.encode!(import_data)
+    result = auth_query_gql_by(:import_flow, user, variables: %{"flow" => import_flow})
+    assert {:ok, query_data} = result
+
+    import_status = get_in(query_data, [:data, "importFlow", "status", Access.at(0)])
+
+    assert import_status["flowName"] == "Valid Sheet Import Flow"
+    assert import_status["status"] == "Successfully imported"
+
+    # The node is not flagged because the sheet linked successfully.
+    assert import_status["invalidSheetNodeUuids"] == []
+    assert import_status["assistantNodeUuids"] == []
+
+    {:ok, flow} =
+      Repo.fetch_by(Flow, %{
+        name: "Valid Sheet Import Flow",
+        organization_id: user.organization_id
+      })
+
+    revision =
+      FlowRevision
+      |> where([fr], fr.flow_id == ^flow.id)
+      |> order_by([fr], desc: fr.inserted_at, desc: fr.id)
+      |> limit(1)
+      |> Repo.one!()
+
+    sheet_action =
+      revision.definition
+      |> Map.fetch!("nodes")
+      |> hd()
+      |> Map.fetch!("actions")
+      |> hd()
+
+    # The stale sheet_id is replaced with the resolved sheet's real id.
+    assert sheet_action["sheet_id"] == existing_sheet.id
+  end
+
   test "terminate inactive flows", attrs do
     {:ok, context} =
       FlowContext.create_flow_context(%{

--- a/test/glific_web/schema/flow_test.exs
+++ b/test/glific_web/schema/flow_test.exs
@@ -914,6 +914,77 @@ defmodule GlificWeb.Schema.FlowTest do
     assert Enum.all?(imported_assistant_ids, &(&1 == ""))
   end
 
+  test "import flow with an invalid google sheet url does not crash and reports the node",
+       %{manager: user} do
+    sheet_node_uuid = "f23c5b9a-1111-2222-3333-44445555aaaa"
+    # No "type" key in the imported sheet action, so `Sheets.create_sheet/1` rejects it with
+    # `{:error, "Invalid sheet URL"}` rather than hitting the network.
+    sheet_url = "https://docs.google.com/spreadsheets/d/placeholder-invalid/edit"
+
+    import_data = %{
+      "flows" => [
+        %{
+          "keywords" => ["sheetimporttest"],
+          "definition" => %{
+            "name" => "Sheet Import Flow",
+            "uuid" => Ecto.UUID.generate(),
+            "nodes" => [
+              %{
+                "uuid" => sheet_node_uuid,
+                "actions" => [
+                  %{
+                    "type" => "link_google_sheet",
+                    "uuid" => Ecto.UUID.generate(),
+                    "name" => "My Sheet",
+                    "url" => sheet_url,
+                    "sheet_id" => 999
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "contact_field" => [],
+      "collections" => [],
+      "interactive_templates" => []
+    }
+
+    import_flow = Jason.encode!(import_data)
+    result = auth_query_gql_by(:import_flow, user, variables: %{"flow" => import_flow})
+    assert {:ok, query_data} = result
+
+    import_status = get_in(query_data, [:data, "importFlow", "status", Access.at(0)])
+
+    # The import succeeds instead of crashing with a MatchError.
+    assert import_status["flowName"] == "Sheet Import Flow"
+    assert import_status["status"] == "Successfully imported"
+
+    # The offending node is surfaced by its last-4 UUID label.
+    assert import_status["invalidSheetNodeUuids"] == [String.slice(sheet_node_uuid, -4..-1//1)]
+    assert import_status["assistantNodeUuids"] == []
+
+    # The flow is saved without a linked sheet_id so the user can fix it manually.
+    {:ok, flow} =
+      Repo.fetch_by(Flow, %{name: "Sheet Import Flow", organization_id: user.organization_id})
+
+    revision =
+      FlowRevision
+      |> where([fr], fr.flow_id == ^flow.id)
+      |> order_by([fr], desc: fr.inserted_at)
+      |> limit(1)
+      |> Repo.one!()
+
+    sheet_action =
+      revision.definition
+      |> Map.fetch!("nodes")
+      |> hd()
+      |> Map.fetch!("actions")
+      |> hd()
+
+    refute Map.has_key?(sheet_action, "sheet_id")
+  end
+
   test "terminate inactive flows", attrs do
     {:ok, context} =
       FlowContext.create_flow_context(%{


### PR DESCRIPTION
## Problem

Closes: https://github.com/glific/glific/issues/5177

Frontend pr: https://github.com/glific/glific-frontend/pull/4012

Importing a flow that contains a **Link Google Sheet** node whose URL is invalid or a placeholder crashed the entire import batch with an unhandled `MatchError`. It was thrown in `get_or_create_sheet/2` at `{:ok, sheet} = Sheets.create_sheet(...)` when `create_sheet` returned `{:error, "Invalid sheet URL"}`. As a result none of the flows in the batch imported and the user saw a 500-level error with no actionable message.

## Fix

- `get_or_create_sheet/2` now returns a tagged tuple (`{:ok, sheet}` / `{:error, reason}`) instead of crashing on a hard match.
- The `link_google_sheet` action handler catches the error, imports the action **without** a linked `sheet_id` (dropping any stale id from the source org), and tags the node `:invalid_sheet`.
- `process_node_actions/4` and `clean_flow_definition/3` collect `invalid_sheet_node_uuids` alongside `assistant_node_uuids`; `import_flow/2` surfaces them in the status map.
- New `invalid_sheet_node_uuids` field on the `import_flow_status` GraphQL object, mirroring `assistant_node_uuids`.

## Acceptance criteria

- [x] Importing a flow with an invalid Google Sheet URL no longer crashes — the rest of the batch imports successfully.
- [x] The Import Flow Status dialog can identify the affected node(s) by UUID (via `invalidSheetNodeUuids`), like assistant node UUIDs today.
- [x] The imported flow is saved without the `sheet_id` linked, so the user can fix it manually.
- [x] Flows without Google Sheet nodes are unaffected.

## Tests

Added `test/glific_web/schema/flow_test.exs` → "import flow with an invalid google sheet url does not crash and reports the node": asserts the import succeeds, the node UUID is reported in `invalidSheetNodeUuids`, and the persisted revision has no `sheet_id`.

> Frontend changes (Import Flow Status dialog rendering `invalidSheetNodeUuids`) are in a companion PR in glific-frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)