### PR TITLE
docs: sync CLAUDE.md with conventions from last week's merges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,9 @@ paths. **Oban workers and resolver by-id lookups have extra rules** — see
 
 - **Formatter**: `mix format` (imports from `:ecto`, `:ecto_sql`, `:phoenix`)
 - **Linter**: Credo (non-strict locally; `--strict` in CI)
+- **Custom Credo checks** (`.credo/checks/`): e.g. `GlificCredo.Checks.NoRawInspect` (`GL1001`)
+  forbids raw `inspect/1,2` in non-test `lib/` code — use `Glific.SafeLog.safe_inspect/1`
+  instead so credentials (e.g. a `%Tesla.Env{}`'s live bearer token) never leak into logs.
 - **Type checking**: Dialyzer (PLTs in `priv/plts/`)
 - **CI**: `MIX_ENV=test mix check` — Credo + Dialyzer + Doctor + Format + compile with
   warnings-as-errors

--- a/lib/glific/CLAUDE.md
+++ b/lib/glific/CLAUDE.md
@@ -110,7 +110,9 @@ end
   middleware chain, including live `Authorization: Bearer …` tokens; plain `inspect` leaks them
   into logs. `safe_inspect/1` strips `__client__` and passes everything else through unchanged.
   This applies to BSP/provider HTTP error paths (e.g. Gupshup partner API responses) where the
-  error term is the raw `{:ok|:error, Tesla.Env}` tuple.
+  error term is the raw `{:ok|:error, Tesla.Env}` tuple. Enforced by a custom Credo check
+  (`GlificCredo.Checks.NoRawInspect`, `GL1001`, in `.credo/checks/`) — `mix credo --strict`
+  fails on any raw `inspect/1,2` call in non-test `lib/` code.
 
 ## Caching (Cachex, bucket `:glific_cache`)
 

--- a/lib/glific_web/CLAUDE.md
+++ b/lib/glific_web/CLAUDE.md
@@ -93,6 +93,11 @@ end
   Do **not** trust that `prepare_query` alone is enough for mutations/reads keyed by a
   client-supplied id — always pass `organization_id` explicitly. Omitting it is a tenant-isolation
   bug (an attacker passes another org's id).
+- **Organization-level endpoints ignore any client-supplied `id` outright** — resolvers like
+  `organization`, `update_organization`, `delete_organization_test_data` derive the target
+  solely from `current_user.organization_id`; the `id` arg (if still present for API
+  compatibility) is never read. There is no "other org's id" to re-scope against if the argument
+  is never trusted in the first place.
 
 ### 3. Wire into `schema.ex` (BOTH steps, or the field won't exist)
 
@@ -113,6 +118,10 @@ Role hierarchy (high→low): `glific_admin > admin > manager > staff > none`. Co
 - **Reads** (`field`, `list`, `count`): `middleware(Authorize, :staff)`
 - **Writes** (create/update/delete): `middleware(Authorize, :manager)`
 - Admin/SaaS-only operations: `:admin` / `:glific_admin`. Open endpoints: `:any`.
+- **Full org lifecycle mutations require `:glific_admin`, not `:admin`** — `create_organization`,
+  `delete_organization`, `delete_organization_test_data`, `delete_inactive_organization`,
+  `reset_organization`. `:admin` is scoped to staff of a single org; these operations act across
+  tenants and are SaaS-operator-only.
 
 Other per-field middleware: `AddOrganization` (injects org context), `RequireFeatureFlag`
 (gates by `FunWithFlags`), `SafeResolution` (wraps resolvers so an unexpected raise becomes a


### PR DESCRIPTION
## Summary
Target issue is N/A — routine CLAUDE.md maintenance.

Reviewed all commits merged to `master` in the last 7 days and updated `CLAUDE.md` (root + layered docs) with the two changes that introduced conventions worth tracking for future work:

- **#5304** (`fix(credo): enforce SafeLog.safe_inspect over raw inspect`) added a custom Credo check, `GlificCredo.Checks.NoRawInspect` (`GL1001`), that forbids raw `inspect/1,2` in non-test `lib/` code. Documented it in:
  - Root `CLAUDE.md` → `Code Quality & Formatting`
  - `lib/glific/CLAUDE.md` → the existing `SafeLog.safe_inspect/1` guidance now notes it's Credo-enforced, not just convention.
- **#5327** (`fix(security): enforce tenant isolation and glific_admin on organization endpoints`) fixed an IDOR on organization GraphQL endpoints and tightened authorization on org-lifecycle mutations. Documented the pattern in `lib/glific_web/CLAUDE.md`:
  - Organization-level resolvers (`organization`, `update_organization`, `delete_organization_test_data`) ignore any client-supplied `id` and derive the target solely from `current_user.organization_id`.
  - Full org-lifecycle mutations (`create_organization`, `delete_organization`, `delete_organization_test_data`, `delete_inactive_organization`, `reset_organization`) require `:glific_admin`, not `:admin`.

Other commits from the last week (version bumps, GCS TTL tuning, Google Sheet import validation, bhasini webhook removal, credential auto-re-enable) were reviewed but didn't introduce new conventions/patterns beyond what's already documented, so no doc changes were needed for those.

## Checklist
- [x] Ran `mix setup` in the repository root and test. (docs-only change, no code affected)
- [ ] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Notes
Docs-only change — no application code touched. Please review for accuracy and whether the level of detail added matches how the team wants these layered CLAUDE.md files maintained.


---
_Generated by [Claude Code](https://claude.ai/code/session_015NwZqiyugXRuUcyhmhvGjF)_