### PR TITLE
fix(superset): re-enable RLS org scoping on embed token requests

### DIFF
--- a/lib/glific/third_party/superset/api_client.ex
+++ b/lib/glific/third_party/superset/api_client.ex
@@ -39,13 +39,13 @@ defmodule Glific.ThirdParty.Superset.ApiClient do
 
   """
   @spec get_embed_token(non_neg_integer()) :: {:ok, map()} | {:error, any()}
-  def get_embed_token(_organization_id) do
+  def get_embed_token(organization_id) do
     username = superset_config(:username)
     password = superset_config(:password)
 
     with {:ok, %{access_token: token}} <- get_access_token(username, password),
          {:ok, %{result: csrf_token, cookie: cookie}} <- get_csrf_token(token) do
-      fetch_embed_token(token, csrf_token, cookie)
+      fetch_embed_token(token, csrf_token, cookie, organization_id)
     end
   end
 
@@ -71,9 +71,9 @@ defmodule Glific.ThirdParty.Superset.ApiClient do
     |> parse_response()
   end
 
-  @spec fetch_embed_token(String.t(), String.t(), String.t()) ::
+  @spec fetch_embed_token(String.t(), String.t(), String.t(), non_neg_integer()) ::
           {:ok, map()} | {:error, any()}
-  defp fetch_embed_token(access_token, csrf_token, cookie) do
+  defp fetch_embed_token(access_token, csrf_token, cookie, organization_id) do
     payload = %{
       user: %{
         username: superset_config(:guest_username),
@@ -81,10 +81,7 @@ defmodule Glific.ThirdParty.Superset.ApiClient do
         last_name: "Dev"
       },
       resources: [%{type: "dashboard", id: superset_config(:dashboard_id)}],
-      # RLS temporarily disabled to allow org filtering via the Superset UI.
-      # Restore by adding organization_id as a parameter and setting:
-      # rls: [%{clause: "organization_id = #{organization_id}"}]
-      rls: []
+      rls: [%{clause: "organization_id = #{organization_id}"}]
     }
 
     access_token

--- a/test/glific/third_party/superset/api_client_test.exs
+++ b/test/glific/third_party/superset/api_client_test.exs
@@ -36,6 +36,42 @@ defmodule Glific.ThirdParty.Superset.ApiClientTest do
       assert {:ok, %{token: "embed_token_xyz"}} = ApiClient.get_embed_token(organization_id)
     end
 
+    test "scopes the guest token request to the given organization_id via an rls clause",
+         %{organization_id: organization_id} do
+      test_pid = self()
+
+      mock(fn
+        %{method: :post, url: url} when url == @base_url <> "/security/login" ->
+          %Tesla.Env{
+            status: 200,
+            body: %{access_token: "test_token"},
+            headers: []
+          }
+
+        %{method: :get, url: url} when url == @base_url <> "/security/csrf_token/" ->
+          %Tesla.Env{
+            status: 200,
+            body: %{result: "csrf123"},
+            headers: [{"set-cookie", "session=abc123; Path=/"}]
+          }
+
+        %{method: :post, url: url, body: body}
+        when url == @base_url <> "/security/guest_token/" ->
+          send(test_pid, {:guest_token_body, body})
+
+          %Tesla.Env{
+            status: 200,
+            body: %{token: "embed_token_xyz"},
+            headers: []
+          }
+      end)
+
+      assert {:ok, %{token: "embed_token_xyz"}} = ApiClient.get_embed_token(organization_id)
+      assert_receive {:guest_token_body, body}
+      decoded = Jason.decode!(body)
+      assert decoded["rls"] == [%{"clause" => "organization_id = #{organization_id}"}]
+    end
+
     test "returns {:error, %{status: 401, body: _}} when login returns 401",
          %{organization_id: organization_id} do
       mock(fn

--- a/test/glific_web/controllers/api/v1/superset_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/superset_controller_test.exs
@@ -84,7 +84,7 @@ defmodule GlificWeb.API.V1.SupersetControllerTest do
                "Please retry, or contact support if the issue persists."
     end
 
-    test "sends an empty rls list in guest token request (UI-level org filtering active)",
+    test "sends an rls clause scoped to the current user's organization_id in guest token request",
          %{conn: conn, organization_id: organization_id} do
       FunWithFlags.enable(:superset_enabled, for_actor: %{organization_id: organization_id})
       test_pid = self()
@@ -107,13 +107,16 @@ defmodule GlificWeb.API.V1.SupersetControllerTest do
       end)
 
       post(
-        api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]})),
+        api_auth_conn(
+          conn,
+          Fixtures.user_fixture(%{roles: ["staff"], organization_id: organization_id})
+        ),
         "/api/v1/get-embed-token"
       )
 
       assert_receive {:guest_token_body, body}
       decoded = Jason.decode!(body)
-      assert decoded["rls"] == []
+      assert decoded["rls"] == [%{"clause" => "organization_id = #{organization_id}"}]
     end
   end
 end


### PR DESCRIPTION

## Summary
 Restores the Superset guest-token RLS clause that was temporarily disabled during the initial rollout (`rls: []`) in favor of UI-level org filtering. The guest embed token now carries `rls: [%{clause: "organization_id = <org_id>"}]`, scoped to the requesting user's `organization_id`, so data isolation is enforced server-side rather than relying solely on the Superset UI.

- `Glific.ThirdParty.Superset.ApiClient.get_embed_token/1` now threads `organization_id` through to the guest-token request instead of discarding it.
- Updated `api_client_test.exs` and `superset_controller_test.exs` to assert the RLS clause is present and scoped to the caller's organization, replacing the prior test that asserted an empty `rls` list.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] Fixed behavior is covered by updated/new test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. (N/A — no new API, existing endpoint)
- [x] Coding standard and conventions are followed.

## Notes
`mix check --except dialyzer` (compiler, credo, doctor, ex_doc, format, unused_deps) passes clean; Dialyzer was skipped for turnaround time since this change doesn't touch typespecs beyond adding an existing parameter to a private function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)