### PR TITLE
docs: register sheets in API docs includes list

### DIFF
--- a/api.docs/index.html.md
+++ b/api.docs/index.html.md
@@ -32,6 +32,7 @@ includes:
   - user_group
   - flows
   - import
+  - sheets
   - saas
   - types
   - scalars


### PR DESCRIPTION
## Summary

Related to glific/glific#5440 ("API docs: Update the API docs with 'sync a sheet' API").

`api.docs/includes/_sheets.md` has fully documented the Sheets API - including `syncSheet` - since #2532 (October 2022). But `api.docs/index.html.md`'s `includes:` front-matter list, which controls what Slate actually renders into the published site, was never updated to include `sheets`. As a result this content has existed for years but has never shown up on the live docs site.

This adds `sheets` to the includes list, next to `import` (the other Google-Sheets-adjacent section).

## Note on scope

`glific/slate` (the repo that builds https://glific.github.io/slate) symlinks its `source/index.html.md` to this file, but its own `source/includes/` directory doesn't have a `_sheets.md` copy yet. This PR alone won't make the section appear live until that file is also added on the slate side - flagging here since I only have read access to that repo.

## Test plan

- [ ] Confirm Slate build includes the Sheets section once glific/slate also has `source/includes/_sheets.md`