### PR TITLE
fix: rewrite "contact Kaapi" to "contact the Glific Team" in STT/TTS failure text

### DIFF
--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -651,8 +651,7 @@ defmodule Glific.Flows.Webhook do
     output_type = get_in(output, ["type"])
     conversation_id = response_data["conversation_id"]
 
-    message = get_in(output, ["content", "value"])
-    message = if output_type == "audio", do: message, else: sanitize_kaapi_wording(message)
+    message = get_in(output, ["content", "value"]) |> sanitize_kaapi_wording()
 
     metadata
     |> Map.put("thread_id", conversation_id)

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -651,10 +651,13 @@ defmodule Glific.Flows.Webhook do
     output_type = get_in(output, ["type"])
     conversation_id = response_data["conversation_id"]
 
+    message = get_in(output, ["content", "value"])
+    message = if output_type == "audio", do: message, else: sanitize_kaapi_wording(message)
+
     metadata
     |> Map.put("thread_id", conversation_id)
     |> Map.put("output_type", output_type)
-    |> Map.put("message", get_in(output, ["content", "value"]))
+    |> Map.put("message", message)
   end
 
   # Fallback for unexpected formats
@@ -684,12 +687,21 @@ defmodule Glific.Flows.Webhook do
   defp tts_aware_log_message(result, response) do
     %{
       success: result["success"],
-      message: response["message"] || result["error"],
+      message: response["message"] || sanitize_kaapi_wording(result["error"]),
       error_type: result["error_type"],
-      reason: result["reason"],
+      reason: sanitize_kaapi_wording(result["reason"]),
       thread_id: response["thread_id"]
     }
   end
+
+  # Kaapi's error copy sometimes tells the user to "contact Kaapi" directly — an internal
+  # AI service NGO staff have no account with or way to reach. Point them to Glific support
+  # instead, since that's who can actually act on the report.
+  @spec sanitize_kaapi_wording(String.t() | nil) :: String.t() | nil
+  defp sanitize_kaapi_wording(text) when is_binary(text),
+    do: String.replace(text, "contact Kaapi", "contact the Glific Team")
+
+  defp sanitize_kaapi_wording(text), do: text
 
   @doc """
   Upload base64 TTS audio (when present) to GCS, replacing the inline payload

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -481,7 +481,7 @@ defmodule Glific.Flows.WebhookTest do
       assert response["message"] =~ "contact the Glific Team"
     end
 
-    test "leaves audio output messages (base64 TTS content) untouched" do
+    test "applies the sanitizer to audio output messages too, as a no-op on base64 TTS content" do
       audio_content = Base.encode64("contact Kaapi fake audio bytes")
 
       params = %{

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -457,6 +457,52 @@ defmodule Glific.Flows.WebhookTest do
     end
   end
 
+  describe "Webhook.parse_callback_response/1 Kaapi wording sanitization" do
+    test "rewrites 'contact Kaapi' to 'contact the Glific Team' in a text output message" do
+      params = %{
+        "data" => %{
+          "response" => %{
+            "output" => %{
+              "type" => "text",
+              "content" => %{
+                "value" =>
+                  "STT response is missing transcribed text. Gemini returned an empty result. If the issue persists, contact Kaapi."
+              }
+            }
+          }
+        },
+        "metadata" => %{"organization_id" => 1},
+        "success" => false
+      }
+
+      response = Webhook.parse_callback_response(params)
+
+      refute response["message"] =~ "contact Kaapi"
+      assert response["message"] =~ "contact the Glific Team"
+    end
+
+    test "leaves audio output messages (base64 TTS content) untouched" do
+      audio_content = Base.encode64("contact Kaapi fake audio bytes")
+
+      params = %{
+        "data" => %{
+          "response" => %{
+            "output" => %{
+              "type" => "audio",
+              "content" => %{"value" => audio_content}
+            }
+          }
+        },
+        "metadata" => %{"organization_id" => 1},
+        "success" => true
+      }
+
+      response = Webhook.parse_callback_response(params)
+
+      assert response["message"] == audio_content
+    end
+  end
+
   test "execute a webhook with a POST request, consecutive webhook calls should not work",
        attrs do
     Tesla.Mock.mock(fn
@@ -702,5 +748,4 @@ defmodule Glific.Flows.WebhookTest do
     [job] = all_enqueued(worker: Webhook, prefix: "global")
     assert job.queue == "custom_certificate"
   end
-
 end

--- a/test/glific_web/flows/flow_resume_controller_test.exs
+++ b/test/glific_web/flows/flow_resume_controller_test.exs
@@ -379,6 +379,72 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
       assert message.body == "failure"
     end
 
+    test "rewrites 'contact Kaapi' in the STT failure reason before logging it", %{
+      conn: %{assigns: %{organization_id: organization_id}} = conn
+    } do
+      contact = Fixtures.contact_fixture()
+      webhook_log = Fixtures.webhook_log_fixture(%{organization_id: organization_id})
+      timestamp = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+      flow = Flow.get_loaded_flow(organization_id, "published", %{keyword: "call_and_wait"})
+      [node | _tail] = flow.nodes
+
+      signature_payload = %{
+        "organization_id" => organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp
+      }
+
+      signature =
+        Glific.signature(
+          organization_id,
+          Jason.encode!(signature_payload),
+          timestamp
+        )
+
+      params = %{
+        "data" => %{},
+        "metadata" => %{
+          "organization_id" => organization_id,
+          "flow_id" => flow.id,
+          "contact_id" => contact.id,
+          "signature" => signature,
+          "timestamp" => timestamp,
+          "webhook_log_id" => webhook_log.id,
+          "result_name" => "response"
+        },
+        "success" => false,
+        "error_type" => "transcription_failed",
+        "reason" =>
+          "STT response is missing transcribed text. Gemini returned an empty result. If the issue persists, contact Kaapi."
+      }
+
+      {:ok, _context} =
+        FlowContext.create_flow_context(%{
+          contact_id: contact.id,
+          flow_id: flow.id,
+          flow_uuid: flow.uuid,
+          uuid_map: %{},
+          organization_id: organization_id,
+          wakeup_at: DateTime.add(DateTime.utc_now(), 60),
+          is_await_result: true,
+          node_uuid: node.uuid
+        })
+
+      conn = post(conn, "/webhook/flow_resume", params)
+      assert json_response(conn, 200) == ""
+
+      await_flow_message(contact.id, "failure")
+
+      updated_webhook_log = Repo.get!(WebhookLog, webhook_log.id)
+
+      refute updated_webhook_log.error =~ "contact Kaapi"
+      assert updated_webhook_log.error =~ "contact the Glific Team"
+      refute updated_webhook_log.response_json["reason"] =~ "contact Kaapi"
+      assert updated_webhook_log.response_json["reason"] =~ "contact the Glific Team"
+    end
+
     test "returns 200 and ignores request when signature is invalid", %{
       conn: %{assigns: %{organization_id: organization_id}} = conn
     } do


### PR DESCRIPTION
## Summary
Target issue is #5141

Kaapi's STT/TTS failure copy sometimes tells the end user to "contact Kaapi" directly — an internal AI service NGO staff have no account with or way to reach. This rewrites that wording before it can reach the webhook log or a flow's exposed response text, so any support request reaches the Glific Team instead.

- `Webhook.parse_callback_response/1` sanitizes the callback's text-output message (audio/TTS content is left untouched).
- `Webhook.tts_aware_log_message/2` sanitizes the top-level `reason`/`error` fields before they're persisted to the webhook log.

## Test plan
- [x] `mix test test/glific/flows/webhook_test.exs test/glific_web/flows/flow_resume_controller_test.exs` — new unit + end-to-end tests covering the rewrite, all passing
- [x] `mix compile --warnings-as-errors` clean
- [x] Full `test/glific/flows/` + `test/glific_web/flows/` suite passing (463 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)