### PR TITLE
added email field in get api

### DIFF
--- a/assets/gql/users/fields.frag.gql
+++ b/assets/gql/users/fields.frag.gql
@@ -3,6 +3,7 @@ fragment UserFields on UserResult {
     id
     name
     phone
+    email
     roles
     isRestricted
     groups {

--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -36,7 +36,9 @@ defmodule GlificWeb.Resolvers.Users do
   @spec current_user(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, any} | {:error, any}
   def current_user(_, _, %{context: %{current_user: current_user}}) do
-    {:ok, %{user: current_user}}
+    with {:ok, user} <-
+           Repo.fetch_by(User, %{id: current_user.id, organization_id: current_user.organization_id}),
+         do: {:ok, %{user: user}}
   end
 
   @doc """

--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -37,7 +37,10 @@ defmodule GlificWeb.Resolvers.Users do
           {:ok, any} | {:error, any}
   def current_user(_, _, %{context: %{current_user: current_user}}) do
     with {:ok, user} <-
-           Repo.fetch_by(User, %{id: current_user.id, organization_id: current_user.organization_id}),
+           Repo.fetch_by(User, %{
+             id: current_user.id,
+             organization_id: current_user.organization_id
+           }),
          do: {:ok, %{user: user}}
   end
 


### PR DESCRIPTION
## Summary

Linked to this frontend issue
https://github.com/glific/glific-frontend/issues/3435

When a user updated their email and logged out then back in, the updated email would disappear. Two root causes were fixed:

1. **Email missing from GQL fragment** — `UserFields` fragment did not include `email`, so `currentUser` and `updateCurrentUser` responses never returned it to the frontend. This caused the frontend to send `email: null` on any subsequent update, silently wiping the stored value from the database.

2. **Stale session cache** — `currentUser` resolver was returning the user struct cached at login time instead of fetching fresh from the database, so email updates were not reflected until the user logged out and back in.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Notes

- `email` is nullable — returns `null` safely for accounts with no email set, no frontend error handling needed for the missing-email case.
- No schema or migration changes required; the `email` field already existed on the `User` type and `users` table.

## Verifying the changes

Following commands were used :
- `curl -k -X POST https://localhost:4001/api   -H "Content-Type: application/json"   -H "authorization: <authorization-key>"   -d '{"query": "{ currentUser { user { id name email } } }"}'`
<img width="851" height="212" alt="Screenshot from 2026-07-08 13-32-07" src="https://github.com/user-attachments/assets/3cd778e6-ba80-4c1e-88d4-7dad36cf8304" />

- Changes further verified in frontend
<img width="1518" height="1012" alt="Screenshot from 2026-07-08 12-57-23" src="https://github.com/user-attachments/assets/1b671de1-5e5b-4121-b4ff-2bdc4be505bc" />

## Running test
- All related test files ran succesfully
- Command used:
   - `mix test \
  test/glific_web/schema/user_test.exs \
  test/glific/users_test.exs \
  test/glific_web/schema/user_group_test.exs
`


