### PR TITLE
fix(security): harden flow-expression EEx guard

### DIFF
--- a/lib/glific.ex
+++ b/lib/glific.ex
@@ -217,16 +217,51 @@ defmodule Glific do
     Glific.SafeLog.safe_inspect(stacktrace)
   end
 
-  @not_allowed ["Repo.", "IO.", "File.", "Code."]
+  # A substring denylist. Tokens are chosen to be prose-safe: module-qualified
+  # forms (with a trailing "." or an Erlang ":") and paren call-forms, so they
+  # do not collide with ordinary message text ("apply for...", "you will
+  # receive...") that also flows through execute_eex/1 via set_run_result,
+  # contact fields, and templating.
+  @not_allowed [
+    # module / data access
+    "Repo.",
+    "IO.",
+    "File.",
+    "Code.",
+    # OS command execution and low-level runtime
+    "System.",
+    ":os.",
+    ":erlang.",
+    ":erpc.",
+    "Port.",
+    "Node.",
+    # indirection used to reach the above via a bare-atom module argument,
+    # e.g. apply(System, :cmd, ...) / apply(:os, :cmd, ...)
+    "apply(",
+    "spawn(",
+    "Kernel.",
+    "Function.",
+    "Module.",
+    "Macro.",
+    # concurrency primitives that can run arbitrary functions
+    "Task.",
+    "Agent.",
+    "GenServer.",
+    "Process.",
+    # meta-evaluation
+    "EEx."
+  ]
 
   @doc """
-  Really simple function to ensure folks do not add Repo and/or IO calls
-  to an EEx snippet. This is an extremely short term fix to avoid shooting
-  ourselves in the foot, but we should move to lua for flows scripting in the
-  near future
+  Really simple function to ensure folks do not add dangerous calls to an EEx
+  snippet. This is an extremely short term fix to avoid shooting ourselves in
+  the foot, but we should move to a sandboxed, non-Turing-complete evaluator
+  (e.g. Lua) for flows scripting in the near future.
 
-  Note that folks can potentially find other ways to access the same modules, so
-  this by no means should be considered remotely secure
+  IMPORTANT: this is a denylist and a denylist can never be complete — every
+  omitted token (aliasing tricks, module attributes, etc.) is a potential
+  bypass. This by no means should be considered remotely secure; it only raises
+  the bar until flow expressions no longer evaluate arbitrary Elixir.
   """
   @spec suspicious_code(String.t()) :: boolean()
   def suspicious_code(code),
@@ -238,7 +273,9 @@ defmodule Glific do
   @spec execute_eex(String.t()) :: String.t()
   def execute_eex(content) do
     if suspicious_code(content) do
-      Logger.error("EEx suspicious code: #{content}")
+      # Route to AppSignal (not just Logger) so attempts to smuggle disallowed
+      # calls into flow expressions are visible to operators.
+      log_error("EEx suspicious code blocked: #{content}")
       "Suspicious Code. Please change your code. #{content}"
     else
       content

--- a/lib/glific/flows/wait.ex
+++ b/lib/glific/flows/wait.ex
@@ -67,10 +67,14 @@ defmodule Glific.Flows.Wait do
   end
 
   @doc """
-  Validate a wait, this is a no-op
+  Validate a wait. Guards the dynamic `timeout.expression` path — which is
+  evaluated as EEx at runtime (`get_wait_timeout/2`) but was previously not
+  checked at publish/import time — against disallowed code.
   """
   @spec validate(Wait.t(), Keyword.t(), map()) :: Keyword.t()
   def validate(wait, errors, flow) do
+    errors = validate_expression(wait, errors)
+
     cond do
       is_nil(wait.seconds) ->
         errors
@@ -86,6 +90,19 @@ defmodule Glific.Flows.Wait do
         errors
     end
   end
+
+  # The wait timeout expression is evaluated as EEx at runtime, so it must clear
+  # the same guard as router operands. Runs regardless of `seconds` because a
+  # dynamic wait carries an expression with `seconds` typically nil.
+  @spec validate_expression(Wait.t(), Keyword.t()) :: Keyword.t()
+  defp validate_expression(%{expression: expression}, errors)
+       when expression not in ["", nil] do
+    if Glific.suspicious_code(expression),
+      do: [{EEx, "Wait timeout has unsupported expression", "Critical"} | errors],
+      else: errors
+  end
+
+  defp validate_expression(_wait, errors), do: errors
 
   @doc """
   Execute a wait, given a message stream.

--- a/test/glific/flows/wait_test.exs
+++ b/test/glific/flows/wait_test.exs
@@ -1,0 +1,30 @@
+defmodule Glific.Flows.WaitTest do
+  use ExUnit.Case, async: true
+
+  alias Glific.Flows.{Flow, Wait}
+
+  describe "validate/3 timeout expression guard" do
+    test "flags a dynamic timeout expression carrying disallowed code" do
+      wait = %Wait{type: "msg", seconds: nil, expression: "<%= System.cmd(\"id\", []) %>"}
+
+      errors = Wait.validate(wait, [], %Flow{})
+
+      assert Enum.any?(errors, fn
+               {EEx, message, "Critical"} -> message =~ "unsupported expression"
+               _ -> false
+             end)
+    end
+
+    test "allows a safe dynamic timeout expression" do
+      wait = %Wait{type: "msg", seconds: nil, expression: "<%= 5 * 60 %>"}
+
+      assert Wait.validate(wait, [], %Flow{}) == []
+    end
+
+    test "is a no-op when there is no expression" do
+      wait = %Wait{type: "msg", seconds: 60, expression: nil}
+
+      assert Wait.validate(wait, [], %Flow{}) == []
+    end
+  end
+end

--- a/test/glific_test.exs
+++ b/test/glific_test.exs
@@ -1,0 +1,54 @@
+defmodule GlificTest do
+  use ExUnit.Case, async: true
+
+  describe "execute_eex/1 flow-expression guard" do
+    @blocked_marker "Suspicious Code. Please change your code."
+
+    test "evaluates a legitimate, safe expression" do
+      assert Glific.execute_eex("<%= rem(5, 2) %>") == "1"
+    end
+
+    test "blocks OS command execution via System.cmd/2" do
+      payload = ~s|<%= System.cmd("touch", ["/tmp/glific_poc_marker"]) %>|
+      assert Glific.suspicious_code(payload)
+      assert Glific.execute_eex(payload) =~ @blocked_marker
+      refute File.exists?("/tmp/glific_poc_marker")
+    end
+
+    test "blocks command output exfiltration via System.cmd/2" do
+      payload = ~s|<%= elem(System.cmd("id", []), 0) %>|
+      assert Glific.execute_eex(payload) =~ @blocked_marker
+    end
+
+    test "blocks the omitted tokens" do
+      for payload <- [
+            ~s|<%= System.get_env("HOME") %>|,
+            ~s|<%= :os.cmd(~c"id") %>|,
+            ~s|<%= :erlang.halt() %>|,
+            ~s|<%= apply(System, :cmd, ["id", []]) %>|,
+            ~s|<%= apply(:os, :cmd, [~c"id"]) %>|,
+            ~s|<%= spawn(fn -> :ok end) %>|,
+            ~s|<%= Process.list() %>|,
+            ~s|<%= File.read!("/etc/hostname") %>|,
+            ~s|<%= IO.inspect("x") %>|,
+            ~s|<%= Code.eval_string("1") %>|
+          ] do
+        assert Glific.suspicious_code(payload), "expected #{payload} to be flagged"
+        assert Glific.execute_eex(payload) =~ @blocked_marker
+      end
+    end
+
+    test "does not flag ordinary message text that merely contains the words" do
+      # These flow through execute_eex/1 via set_run_result, contact fields and
+      # templating; they must not be mistaken for code.
+      for text <- [
+            "Please apply for the scholarship before Friday",
+            "You will receive a confirmation shortly",
+            "Thanks for reaching out to our support agent",
+            "Import your contacts from the dashboard"
+          ] do
+        refute Glific.suspicious_code(text), "expected #{text} to be allowed"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Mitigates a server-side code-execution issue in flow-expression evaluation.

User-authored flow expressions are evaluated as live Elixir through `EEx.eval_string/1`, gated only by a substring denylist that covered `Repo.`/`IO.`/`File.`/`Code.` but **omitted `System.`, `:os.`, `:erlang.`, `apply`, `spawn`**. A flow expression such as `<%= System.cmd("id", []) %>` passed the guard and executed as a host OS command. Flow authorship only requires the org-scoped `:manager` role, so a lower-privileged operator could reach code execution.

> ⚠️ This is an **interim stopgap**, not the final fix. A substring denylist can never be complete. The durable fix is to stop evaluating flow expressions as arbitrary Elixir and move to a sandboxed, non-Turing-complete evaluator (e.g. Lua) — tracked separately.

## Changes

- **Expand the denylist** (`lib/glific.ex`) with the OS / runtime / concurrency / meta tokens the original list missed. Tokens are kept prose-safe — module-qualified `.`/`:` forms and paren call-forms — so ordinary message text that also flows through `execute_eex/1` (`set_run_result`, contact fields, templating) is not false-flagged.
- **Surface attempts in AppSignal**: blocked detections now go through `Glific.log_error/2` instead of a bare `Logger.error`, so smuggling attempts are visible to operators.
- **Close the wait-timeout gap**: `Wait.validate/3` now runs the same guard at publish/import time (`timeout.expression` was previously only evaluated at runtime), independently of `seconds` since a dynamic wait carries a nil `seconds`.
- **Regression tests** covering the exploit payloads (`System.cmd`, `:os.cmd`, `apply/3`, `spawn`, `Process.*`), the previously-covered tokens, the wait-expression validation gap, and prose that must **not** be flagged.

## Testing

- `mix test test/glific_test.exs test/glific/flows/wait_test.exs` — green
- Existing flow suites (`router`, `templating`, `action`, `contact_action`, `contact_field`) — 74 tests, 0 failures (no false positives from the expanded list)
- `mix credo` / `mix format` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)