### PR TITLE
fix(gupshup): classify async frequency-cap callbacks correctly

### DIFF
--- a/lib/glific/providers/gupshup/instrumentation.ex
+++ b/lib/glific/providers/gupshup/instrumentation.ex
@@ -3,11 +3,19 @@ defmodule Glific.Providers.Gupshup.Instrumentation do
   Gupshup instrumentation adapter.
 
   Inherits the standard provider counters (`track_send/2`, `track_receive/2`,
-  `track_status/2`, `track_action/3`) from
-  `Glific.Providers.Instrumentation`, and adds Gupshup's one bit of
-  custom classification: a frequency-capped 4xx is recorded under a
-  `frequency_capped` status rather than `error`, so throttled sends don't trip
-  send-failure alerts. HSM template sync is recorded via
+  `track_status/3`, `track_action/3`) from `Glific.Providers.Instrumentation`,
+  and adds Gupshup's custom frequency-cap classification on **both** seams a cap
+  can surface on:
+
+    * `classify_send/2` — a frequency-capped 4xx in the *synchronous* send
+      response is recorded as `frequency_capped` rather than `error`.
+    * `classify_status/2` — a frequency-capped *asynchronous* failed delivery
+      callback (where Gupshup actually reports the cap, code at
+      `payload.payload.code`) is likewise recorded as `frequency_capped` on
+      `provider_status_count` rather than `error`.
+
+  Both keep throttled traffic out of the `error` bucket so it doesn't trip
+  send/status-failure alerts. HSM template sync is recorded via
   `track_action("hsm_sync", ...)`.
   """
 
@@ -24,6 +32,16 @@ defmodule Glific.Providers.Gupshup.Instrumentation do
   end
 
   def classify_send(status, context), do: super(status, context)
+
+  # A frequency cap normally surfaces as an async failed delivery callback (the
+  # send is accepted, then WhatsApp/Meta reports the cap later), so this is the
+  # seam that matters in practice; `classify_send/2` above covers the rarer
+  # synchronous case. Same `error_code` list drives both.
+  def classify_status(:error, context) do
+    if frequency_capped?(context[:error_code]), do: :frequency_capped, else: :error
+  end
+
+  def classify_status(status, context), do: super(status, context)
 
   @doc """
   Whether a Gupshup error code represents a frequency-capped send. Accepts the

--- a/lib/glific/providers/instrumentation.ex
+++ b/lib/glific/providers/instrumentation.ex
@@ -28,7 +28,9 @@ defmodule Glific.Providers.Instrumentation do
     * `provider_send_count` — outbound sends, tagged `status` (final, after
       classification) and `type` (`hsm` | `session`).
     * `provider_receive_count` — inbound messages, tagged `type`.
-    * `provider_status_count` — delivery-status callbacks, tagged `status`.
+    * `provider_status_count` — delivery-status callbacks, tagged `status`
+      (post-classification, so a frequency-capped failed callback is
+      `frequency_capped` rather than `error`).
     * `provider_action_count` — provider-specific named actions (e.g. Gupshup's
       `hsm_sync`), tagged `action` and `status` (`success` | `failure`).
 
@@ -63,8 +65,9 @@ defmodule Glific.Providers.Instrumentation do
   Injects provider-scoped instrumentation helpers into the caller.
 
   Requires `:provider` in `opts` and defines `provider/0`, `classify_send/2`
-  (overridable), and `track_send/2`, `track_receive/2`, `track_status/2`,
-  `track_action/3` that delegate to this module.
+  and `classify_status/2` (both overridable), and `track_send/2`,
+  `track_receive/2`, `track_status/3`, `track_action/3` that delegate to this
+  module.
   """
   defmacro __using__(opts) do
     provider = Keyword.fetch!(opts, :provider)
@@ -91,6 +94,20 @@ defmodule Glific.Providers.Instrumentation do
 
       defoverridable classify_send: 2
 
+      @doc """
+      Reclassify a delivery-status callback into the final status recorded on
+      `provider_status_count`.
+
+      `status` is the raw callback status (`:enqueued` | `:sent` | `:delivered`
+      | `:read` | `:error`); `context` is whatever the call site passed as opts
+      to `track_status/3` (e.g. `%{error_code: 472}` from a failed callback).
+      Override to add provider-specific classification.
+      """
+      @spec classify_status(atom(), map()) :: atom()
+      def classify_status(status, _context), do: status
+
+      defoverridable classify_status: 2
+
       @doc "See `Glific.Providers.Instrumentation.track_send/3`."
       @spec track_send(Instrumentation.send_status(), keyword()) :: :ok
       def track_send(status, opts \\ []),
@@ -101,10 +118,10 @@ defmodule Glific.Providers.Instrumentation do
       def track_receive(type, organization_id),
         do: Instrumentation.track_receive(__MODULE__, type, organization_id)
 
-      @doc "See `Glific.Providers.Instrumentation.track_status/3`."
-      @spec track_status(atom(), non_neg_integer() | nil) :: :ok
-      def track_status(status, organization_id),
-        do: Instrumentation.track_status(__MODULE__, status, organization_id)
+      @doc "See `Glific.Providers.Instrumentation.track_status/4`."
+      @spec track_status(atom(), non_neg_integer() | nil, keyword()) :: :ok
+      def track_status(status, organization_id, opts \\ []),
+        do: Instrumentation.track_status(__MODULE__, status, organization_id, opts)
 
       @doc "See `Glific.Providers.Instrumentation.track_action/4`."
       @spec track_action(String.t(), Instrumentation.action_status(), non_neg_integer() | nil) ::
@@ -154,12 +171,17 @@ defmodule Glific.Providers.Instrumentation do
   @doc """
   Record a delivery-status callback (`:enqueued`, `:sent`, `:delivered`,
   `:read`, `:error`).
+
+  `opts` is passed to the adapter's `classify_status/2` as context and lets a
+  provider refine the raw status — e.g. Gupshup reclassifies a failed callback
+  carrying a frequency-cap `error_code` as `:frequency_capped` rather than
+  `:error`, so async throttling doesn't trip status-failure alerts.
   """
-  @spec track_status(module(), atom(), non_neg_integer() | nil) :: :ok
-  def track_status(adapter, status, organization_id) do
+  @spec track_status(module(), atom(), non_neg_integer() | nil, keyword()) :: :ok
+  def track_status(adapter, status, organization_id, opts \\ []) do
     Appsignal.increment_counter("provider_status_count", 1, %{
       provider: adapter.provider(),
-      status: to_string(status),
+      status: to_string(adapter.classify_status(status, Map.new(opts))),
       organization_id: org_tag(organization_id)
     })
 

--- a/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
+++ b/lib/glific_web/providers/gupshup/controllers/message_event_controller.ex
@@ -59,7 +59,15 @@ defmodule GlificWeb.Providers.Gupshup.Controllers.MessageEventController do
   defp update_status(conn, params, status) do
     bsp_message_id = get_in(params, ["payload", "gsId"]) || get_in(params, ["payload", "id"])
     Communications.Message.update_bsp_status(bsp_message_id, status, params)
-    Instrumentation.track_status(status, conn.assigns[:organization_id])
+
+    # A failed callback carries the error code at payload.payload.code (same path
+    # Communications.Message reads). Passing it lets Gupshup's classify_status/2
+    # bucket an async frequency cap as `frequency_capped` instead of `error`.
+    # It is nil for non-failure callbacks, which classify_status ignores.
+    Instrumentation.track_status(status, conn.assigns[:organization_id],
+      error_code: get_in(params, ["payload", "payload", "code"])
+    )
+
     handler(conn, params, "Status updated")
   end
 end

--- a/test/glific/providers/gupshup/instrumentation_test.exs
+++ b/test/glific/providers/gupshup/instrumentation_test.exs
@@ -26,6 +26,24 @@ defmodule Glific.Providers.Gupshup.InstrumentationTest do
     end
   end
 
+  describe "classify_status/2" do
+    test "reclassifies a frequency-capped failed callback to :frequency_capped" do
+      assert Instrumentation.classify_status(:error, %{error_code: 472}) == :frequency_capped
+      assert Instrumentation.classify_status(:error, %{error_code: "472"}) == :frequency_capped
+    end
+
+    test "keeps other failed callbacks as :error" do
+      assert Instrumentation.classify_status(:error, %{error_code: 471}) == :error
+      assert Instrumentation.classify_status(:error, %{error_code: nil}) == :error
+      assert Instrumentation.classify_status(:error, %{}) == :error
+    end
+
+    test "passes non-error statuses through even if a cap code is present" do
+      assert Instrumentation.classify_status(:delivered, %{}) == :delivered
+      assert Instrumentation.classify_status(:read, %{error_code: 472}) == :read
+    end
+  end
+
   describe "frequency_capped?/1" do
     test "is true only for the configured cap code, as integer or string" do
       assert Instrumentation.frequency_capped?(472)
@@ -50,6 +68,7 @@ defmodule Glific.Providers.Gupshup.InstrumentationTest do
 
       assert :ok = Instrumentation.track_receive("text handler", organization_id)
       assert :ok = Instrumentation.track_status(:read, organization_id)
+      assert :ok = Instrumentation.track_status(:error, organization_id, error_code: 472)
       assert :ok = Instrumentation.track_action("hsm_sync", :success, organization_id)
     end
   end

--- a/test/glific/providers/instrumentation_test.exs
+++ b/test/glific/providers/instrumentation_test.exs
@@ -11,10 +11,12 @@ defmodule Glific.Providers.InstrumentationTest do
   alias Glific.Providers.InstrumentationTest.StubAdapter
 
   describe "adapter mixin defaults" do
-    test "supplies the provider tag and an identity classify_send/2" do
+    test "supplies the provider tag and identity classify_send/2 + classify_status/2" do
       assert StubAdapter.provider() == "stub"
       assert StubAdapter.classify_send(:error, %{error_code: 472}) == :error
       assert StubAdapter.classify_send(:success, %{}) == :success
+      assert StubAdapter.classify_status(:error, %{error_code: 472}) == :error
+      assert StubAdapter.classify_status(:delivered, %{}) == :delivered
     end
 
     test "injects track_* helpers that delegate to the core and return :ok",
@@ -26,6 +28,7 @@ defmodule Glific.Providers.InstrumentationTest do
       assert :ok = StubAdapter.track_send(:timeout)
       assert :ok = StubAdapter.track_receive("text handler", organization_id)
       assert :ok = StubAdapter.track_status(:delivered, organization_id)
+      assert :ok = StubAdapter.track_status(:error, organization_id, error_code: 472)
       assert :ok = StubAdapter.track_action("some_action", :success, organization_id)
       assert :ok = StubAdapter.track_action("some_action", :failure, organization_id)
     end


### PR DESCRIPTION
Refs #5422.

## Problem

Gupshup reports frequency capping as an **async failed-delivery callback**, not a synchronous send rejection. So the `classify_send` reclassification added in #5352 never fired for the real case, and those failures landed in the generic `provider_status_count{status=error}` bucket — tripping the very alerts `frequency_capped` was meant to keep clean.

## Change

Two commits:

1. **`feat(instrumentation)`** — add an overridable `classify_status/2` seam to the shared provider instrumentation, mirroring the existing `classify_status`/`classify_send/2` pattern. The macro injects an identity `classify_status/2` (overridable), and `track_status/4` now takes an opts context. Back-compatible: the opts arg defaults to `[]`.

2. **`fix(gupshup)`** — override `classify_status/2` on the Gupshup adapter (reusing `frequency_capped?/@frequency_cap_error_codes`) and thread the callback's `payload.payload.code` through the event controller's `track_status` call, so a frequency-capped failed callback is reclassified out of `error`. The synchronous `classify_send` check is kept as defensive cover for the rarer case; both seams share one code list.

## Testing

- Compile clean (warnings-as-errors)
- 14 tests pass (`instrumentation_test.exs` + `gupshup/instrumentation_test.exs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)