### PR TITLE
feat(maytapi): increase recv_timeout for getGroups API calls

### DIFF
--- a/lib/glific/providers/maytapi/api_client.ex
+++ b/lib/glific/providers/maytapi/api_client.ex
@@ -17,6 +17,11 @@ defmodule Glific.Providers.Maytapi.ApiClient do
       {"x-maytapi-key", token}
     ]
 
+  # getGroups on a phone in many/large groups routinely takes longer than the
+  # Hackney default 5s recv_timeout, so the GET would time out before Maytapi
+  # responded. Bump the read timeout to match the write path's intent.
+  @get_recv_timeout 30_000
+
   @doc """
   Making Tesla get call and adding api key in header
   """
@@ -25,7 +30,10 @@ defmodule Glific.Providers.Maytapi.ApiClient do
     do:
       :read
       |> client()
-      |> Tesla.get(url, headers: headers(token))
+      |> Tesla.get(url,
+        headers: headers(token),
+        opts: [adapter: [recv_timeout: @get_recv_timeout]]
+      )
       |> log_on_failure(url)
 
   # Group operations (createGroup, group/add, group/remove)


### PR DESCRIPTION
Fix Maytapi getGroups timeouts flooding AppSignal alerts

The GET path (`maytapi_get`) had no read timeout override, so it inherited Hackney's default 5s recv_timeout. `getGroups` on phones in many/large groups routinely exceeds 5s and times out. The hourly WA-groups sync then produced a burst of timeouts (amplified ~3x by the `:read` retry policy) that tripped the `tesla_request_error_count >= 3` AppSignal trigger every hour.

Added `@get_recv_timeout 30_000` and threaded it into `maytapi_get`, mirroring the existing `@post_recv_timeout` on the POST path. Also benefits the other idempotent GETs (`listPhones`, `screen`).

Tests: mix format, compile --warnings-as-errors, api_client + wa_worker suites pass.
