### PR TITLE
docs: weekly CLAUDE.md sync — flow expression safety, provider instrumentation, BigQuery sync

### DIFF
--- a/lib/glific/CLAUDE.md
+++ b/lib/glific/CLAUDE.md
@@ -169,6 +169,50 @@ Request headers are automatically scrubbed by `Glific.Flows.Webhook.HeaderRedact
 being persisted to `webhook_logs` — credentials (Authorization, X-Api-Key, etc.) are
 redacted. Do not special-case credential fields in individual webhook modules.
 
+## Flow expression safety (`Glific.execute_eex/1`)
+
+`Glific.execute_eex/1` is the sole runtime choke point for flow-authored `<%= ... %>`
+expressions (router operands, wait timeouts, templating, contact-field values). The per-org
+`:safe_expressions` flag picks the evaluator:
+
+- **Flag ON** — `Glific.Flows.Expression.eval/1`, a fail-closed AST interpreter with a fixed
+  `@mfa` allowlist. It never calls `EEx.eval_string/1` or `Code.eval_quoted/2`; a node type with
+  no matching clause falls to the catch-all and is rejected. This is the **only** security
+  boundary — nothing upstream (including publish-time validation) may be trusted to have
+  already filtered the expression.
+- **Flag OFF** — the legacy path: a `@not_allowed` substring denylist, then
+  `EEx.eval_string/1`. This denylist guards only the legacy path; it does not run when the
+  interpreter is active.
+
+`Flow.validate_flow/3` and `Glific.validate_flow_expression/2` run at publish/import time and
+are **advisory only** — errors are reported to the flow's author but must never block
+`do_publish_flow/2`. `Flows.publish_flow/2` always calls `do_publish_flow/2`; validation errors
+only affect what's returned to the caller, not whether the flow goes live. Do not reintroduce a
+`case validate_flow(...) do [] -> do_publish_flow(...) ...` guard — the interpreter above is the
+real security boundary, not the publish gate.
+
+`validate_flow_expression/2` skips non-string action values (`when not is_binary(...)`) — some
+action `value` fields hold structured data instead of an expression (e.g. `set_contact_profile`
+stores a map).
+
+## Provider instrumentation framework (`Providers.Instrumentation`)
+
+BSP send/receive/status/action telemetry is centralized in `Glific.Providers.Instrumentation`
+(distinct from the flow-webhooks `Instrumentation` above). A provider gets the counters
+(`provider_send_count`, `provider_receive_count`, `provider_status_count`,
+`provider_action_count`, all tagged `provider`) for free with a one-line adapter:
+
+```elixir
+defmodule Glific.Providers.MyBsp.Instrumentation do
+  use Glific.Providers.Instrumentation, provider: "my_bsp"
+end
+```
+
+Override `classify_send/2` only when a provider needs non-default classification (Gupshup
+reclassifies a frequency-capped 4xx as `frequency_capped`); Maytapi has no such case and uses
+the inherited identity implementation. See `Providers.Gupshup.Instrumentation` /
+`Providers.Maytapi.Instrumentation`.
+
 ## Large subsystems — read before touching
 
 These are old, dense, and pattern-divergent. Read the subtree and nearby tests **before**
@@ -179,7 +223,12 @@ editing or "cleaning up":
   `flows/webhooks/core/Dispatcher` — see the Webhook framework section above.
 - `providers/` (25 modules) — BSP integrations (Gupshup, Gupshup Enterprise, Maytapi). Outbound
   message sending, webhooks, workers. Tesla-based HTTP; mocked with `Tesla.Mock` in tests.
-- `third_party/` — BigQuery, Dialogflow, GCS, Gemini, Sheets, Kaapi, etc.
+- `third_party/` — BigQuery, Dialogflow, GCS, Gemini, Sheets, Kaapi, etc. BigQuery sync has two
+  modes, both in `bigquery_worker.ex`: most tables collapse to one row per id on re-sync
+  (`ignore_updates_for_table/0` + the `periodic_updates` dedup list). SaaS-only tables meant to
+  accumulate a change-log instead (e.g. `organizations`) are deliberately kept OUT of both —
+  don't "fix" that omission, it would silently collapse the accumulated history to one row per
+  org.
 - `partners.ex` / `partners/` — organizations, providers, credentials, billing. Central to
   multi-tenancy and caching.
 


### PR DESCRIPTION
## Summary

Automated weekly sync of `lib/glific/CLAUDE.md` against commits merged to `master` between 2026-07-20 and 2026-07-27. Each merged PR was reviewed for whether it introduces a new pattern, subsystem, or invariant that isn't already captured in the layered CLAUDE.md docs; routine version bumps and one-off bugfixes with no lasting convention were excluded.

Three gaps were found and documented, all in `lib/glific/CLAUDE.md`:

1. **Flow expression safety (`Glific.execute_eex/1`)** — new section documenting the safe AST interpreter (`Glific.Flows.Expression.eval/1`, gated by the per-org `:safe_expressions` flag) as the sole runtime security boundary for flow expressions, and clarifying that `Flow.validate_flow/3` / publish-time validation is advisory-only and must never block `do_publish_flow/2`. Sourced from #5424 and #5427.
2. **Provider instrumentation framework (`Providers.Instrumentation`)** — new section documenting the shared BSP telemetry adapter now used by both Gupshup and Maytapi, and how to opt a new provider in. Sourced from #5379/#5420 and #5432.
3. **BigQuery sync: accumulate vs. dedup** — expanded the existing `third_party/` bullet under "Large subsystems" to flag the deliberate accumulate-vs-dedup distinction in `bigquery_worker.ex`, so the `organizations` table's append-only sync isn't mistakenly "fixed" into the periodic dedup list. Sourced from #5390.

PRs reviewed but requiring no doc change: #5406 (routine migration cleanup, no new convention), #5398 (the `template_v2_enabled` flag it introduces is already documented in the Feature Flags section), and other smaller feature/bugfix PRs from the week (#5399, #5413, #5268, #5428, #5422/#5423) that didn't introduce a durable new convention.

## Checklist

- [x] Coding standard and conventions are followed.
- [ ] Ran `mix setup` in the repository root and test. — N/A, docs-only change
- [ ] If you've fixed a bug or added code that is tested and has test cases. — N/A, docs-only change
- [ ] In the case of adding a new API, you added a **postman** request for that. — N/A, no API change

## Notes

Please review the added text for accuracy against the referenced PRs/modules before merging. This PR was generated by a scheduled automation that reviews the past week's merged commits and proposes CLAUDE.md updates for engineer review.


---
_Generated by [Claude Code](https://claude.ai/code/session_016DTRGEqxH4NhVvG681Buq6)_