### PR TITLE
docs(web-channel): add Phase 0 design & T1 spike docs for review

### DIFF
--- a/plans/web-channel/web-channel-auth-research.md
+++ b/plans/web-channel/web-channel-auth-research.md
@@ -1,0 +1,225 @@
+# Embeddable Chat Auth — How Intercom / Zendesk / Crisp / Sunshine Do It
+
+Research input for the Glific web-channel tech design. Question: when an NGO embeds Glific's chat
+on **their own** site/app, how should the end-user be authenticated, and how should the widget be
+delivered? The mature SaaS support platforms have converged on a small number of patterns; this
+maps them onto Glific's locked decisions (separate frontend repo, `web.<shortcode>.glific.com`
+subdomain, 30-day session, phone+OTP for the hosted case).
+
+Sources are official developer docs (Intercom, Zendesk, Crisp) plus the Sunshine Conversations
+API. Where a doc didn't confirm a detail, it's marked **[unverified]** rather than asserted.
+
+---
+
+## The one finding that matters most
+
+**All four platforms authenticate an *identified* end-user the same way: the customer's backend
+signs a token with a shared secret that never touches the browser; the vendor verifies the
+signature and trusts the identity.** They differ only in token format and transport.
+
+| Platform | Token format | Signed with | Identifying claim | How it reaches the widget |
+|---|---|---|---|---|
+| **Intercom** (current) | **JWT, HS256** | Messenger API Secret | `user_id` (required) | `Intercom("boot", { intercom_user_jwt })` |
+| **Intercom** (legacy) | HMAC-SHA256 digest (`user_hash`) | API Secret | hash of `user_id`/`email` | `user_hash` in boot — **now deprecated**, still accepted |
+| **Zendesk Messaging** | **JWT** | Signing key (admin-created, ≤10) | `external_id` + `scope:"user"` | `messenger("loginUser", cb→JWT)` |
+| **Crisp** | Signed email (Identity Verification) + per-user **token** (session continuity) | secret key, backend-only | email | `$crisp` config at boot |
+| **Sunshine Conv.** | app-scoped **JWT** or API key (basic auth) | API key secret | server-to-server only | n/a — API layer, not a widget claim |
+
+**Takeaway for Glific:** this is exactly the "delegated auth" we flagged as a vague future item.
+It is not vague — it's a standardized pattern. When an NGO embeds Glific and their user is already
+logged into the NGO's site, the NGO's backend mints a signed token asserting "this is contact
++91XXXX", Glific verifies it against a per-org shared secret, and **no OTP is needed.** OTP is only
+for Glific's *own* hosted page where there is no NGO backend to vouch.
+
+Two design notes fall straight out:
+
+- **Intercom moved HMAC → JWT and is deprecating HMAC.** So don't build the older raw-HMAC
+  `user_hash` scheme even though it's simpler; **build JWT (HS256) from day one.** It's the same
+  secret and same crypto, but carries structured claims (id, expiry, custom attributes) and is
+  where the industry has settled. This directly answers the "should Glific adopt the HMAC pattern"
+  question: adopt the *idea* (backend-signed identity), in its *current* form (JWT).
+- **Email collisions are rejected.** Zendesk rejects a JWT whose email already maps to a different
+  external_id. Glific's analogue: a delegated token asserting a phone that belongs to a different
+  contact must fail closed. Phone is Glific's identity key, so this is naturally enforceable.
+
+---
+
+## Widget delivery: snippet-that-injects-an-iframe
+
+The universal shape is a **small JS snippet (script loader) that asynchronously injects an
+iframe.** Intercom's Messenger renders inside an iframe (`.intercom-messenger-frame > iframe`); the
+snippet exposes the `window.Intercom(...)` JS API on the host page. Crisp is the clearest because it
+offers **both** explicitly:
+
+- **JS snippet** → global `$crisp` object: programmatic control, richer host-page integration.
+- **Raw iframe** → `https://go.crisp.chat/chat/embed/?website_id=<id>`: drop-in, maximal isolation,
+  less control.
+
+**Trade-off, decided by these platforms in favour of iframe-under-a-snippet:**
+
+| | iframe | inline snippet (no iframe) | Web Component |
+|---|---|---|---|
+| CSS isolation | Total (separate document) | None — host styles leak both ways | Shadow DOM (good, not total) |
+| Security sandbox | `sandbox` attr, origin boundary | Runs in host's origin — risky | Same origin as host |
+| CSP friendliness | Host allowlists one frame-src | Host must allow your scripts inline | Same as snippet |
+| Host-page JS API | via `postMessage` only | Direct | Direct |
+
+The consensus — snippet loads, iframe renders, `postMessage` bridges them — is what Glific should
+copy. It maps cleanly onto the **separate frontend repo + subdomain** decision: the iframe's `src`
+is `web.<shortcode>.glific.com`, so the chat runs in Glific's own origin (its cookies, its CSP, its
+token storage) while embedded on the NGO's page. Origin isolation is *free* the moment it's an
+iframe pointed at the subdomain — the subdomain decision and the embeddability decision reinforce
+each other.
+
+---
+
+## Realtime transport
+
+- **Crisp RTM:** WebSocket over **Socket.IO**. After connect you have **~10 seconds to
+  authenticate** by emitting an `authentication` event with a token id + key and the event
+  namespaces you want. REST performs actions; RTM delivers events/acks. The RTM endpoint URL is
+  fetched from REST first (`Get Connect Endpoints`) — i.e. **connection discovery precedes the
+  socket**, useful for routing/sharding.
+- **Sunshine Conversations:** server-side **webhooks** are the realtime-out mechanism for building
+  custom clients — you receive message events and render them yourself.
+- **Intercom/Zendesk:** the widget's own transport is internal (not a documented public socket);
+  realtime-for-integrations is webhooks.
+
+**For Glific:** our Phoenix Channel already gives us what Crisp bolts onto Socket.IO — a joined
+topic with an auth step at connect (the token in connect params). Two patterns worth stealing:
+(1) **authenticate promptly after connect with a bounded window**, matching Crisp's 10s rule —
+reject unauthenticated sockets fast; (2) **endpoint discovery before connect** — a cheap REST call
+that hands back the socket URL, which is exactly where multi-node session routing would later live
+without changing the client contract.
+
+---
+
+## Public API surface (build-your-own-UI)
+
+**Sunshine Conversations is the reference for "headless chat as a product."** Its Core API is
+**app-scoped** (one app = one customer workspace): an app-scoped API key or app-scoped JWT grants
+access to that app's integrations, webhooks, users, and conversations — server-to-server only,
+never shipped to a browser. Customers build custom clients by calling the send API and consuming
+inbound **webhooks**. Two auth methods: **basic auth** (key id = username, secret = password) or
+**JWT signed with an API key**. There's also a broader **account scope** for cross-app operations.
+
+**For Glific:** this validates "the socket/REST contract *is* the public API." The scope split maps
+directly to multi-tenancy — an **org-scoped API credential** is the natural unit (Sunshine's "app"
+= Glific's "organization"). Server-to-server org credentials for the API; short-lived signed
+per-contact tokens for the browser. Never one in place of the other.
+
+---
+
+## Multi-tenancy & domain allowlisting
+
+- **Intercom Trusted Domains:** the Messenger only loads on an explicit allowlist of
+  domains/subdomains, **wildcards supported** (`*.intercom.com`). Off-list → Messenger refuses to
+  load ("This domain is not allowed for the Intercom Messenger").
+- **Workspace/website scoping:** Intercom `app_id`, Crisp `website_id`, Sunshine `app` — a public,
+  non-secret key in the snippet that scopes the widget to one workspace. **Non-secret by design**;
+  security comes from the signed identity token and the domain allowlist, *not* from hiding this id.
+
+**For Glific:**
+
+- The public scoping key is the **org shortcode / subdomain** — already the case.
+- Add a **per-org allowed-origins list** (the CORS/embedding allowlist), wildcards supported, so an
+  org self-hosting on `their-ngo.org` adds it explicitly. This is precisely the "whitelist their
+  domains" item from the requirements dump, and Intercom's model says implement it as a
+  first-class, wildcardable org setting — not hardcoded.
+- Don't rely on the shortcode being secret. It isn't, in any of these systems.
+
+---
+
+## Session longevity — the nuance that resolves the 30-day decision
+
+Here's the tension worth surfacing in the design doc. **Intercom recommends a *short* JWT expiry
+(as little as ~5 minutes)** — but that short token is the *identity proof*, not the *session*. The
+long-lived session is a **separate cookie**, whose lifetime Intercom controls via a
+`session_duration` claim. Crisp draws the same line even more sharply: a backend-generated
+**per-user token** provides **session continuity** — "recover the same conversation even when they
+change browser, switch device, or clear cookies" — decoupled from any single short-lived credential.
+
+So the mature pattern is **two layers**:
+
+1. a **short-lived, re-signable identity token** (minutes) that proves who you are, and
+2. a **long-lived session** (days) that keeps you in the same conversation.
+
+**Glific's 30-day decision should be read as layer 2, not layer 1.** A 30-day *bearer token that is
+itself the only credential* is the risky object I flagged — if it leaks, it's a 30-day master key
+with no revocation. The safer construction that still delivers "don't make her log in for 30 days":
+
+- Hosted case: OTP verifies once → mint a **30-day *session*** (server-side session record or a
+  rotating refresh token), from which short-lived access tokens are derived. Revocable server-side;
+  a leaked access token dies in minutes.
+- Embedded case: the **NGO's short-lived signed JWT** is layer 1; Glific issues its own session as
+  layer 2. The NGO controls identity; Glific controls session.
+
+This is strictly better than a raw 30-day JWT and costs only a session table you'll want anyway for
+the "logout / revoke device" story and for DPDP-style data-subject requests.
+
+---
+
+## Abuse protection on the public endpoint
+
+The docs are thin on published rate-limit numbers (expected — vendors don't advertise them), but
+the structural pattern is consistent and matches what we already decided:
+
+- The **anonymous/unauthenticated** surface (widget first load, and for Glific `request_otp`) is
+  the throttled one — per-IP and, for Glific, per-phone, because each OTP spends the NGO's WhatsApp
+  balance.
+- The **identified** surface is protected by the signed token, which makes bulk abuse expensive
+  (you'd need the NGO's secret or a valid OTP).
+
+Nothing here contradicts the "per-contact rate limit, no per-org circuit breaker" call — but it
+reinforces that the OTP-request endpoint is the one place per-contact limiting can't help (no
+contact yet), so per-IP + per-phone there is non-negotiable.
+
+---
+
+## Recommendations for Glific, ranked
+
+1. **Adopt backend-signed JWT (HS256) for delegated/embedded auth, per-org shared secret.** This is
+   the Intercom-current / Zendesk / Sunshine consensus. Skip raw HMAC `user_hash` — it's the
+   deprecated form of the same idea. Claim set: `phone` (identity), `org`, short `exp`. Reject a
+   token whose phone maps to a different contact (Zendesk's collision rule).
+2. **Two auth modes, one channel:** OTP for Glific-hosted; delegated JWT for NGO-embedded. Same
+   downstream contact + socket; only the front door differs.
+3. **Ship as snippet-injects-iframe, iframe `src` = `web.<shortcode>.glific.com`.** Origin
+   isolation for free; `postMessage` bridge for host-page control. The subdomain decision already
+   bought this.
+4. **Split session from identity.** 30-day *session* (revocable, server-side) issued from a
+   short-lived credential — not a 30-day bearer JWT. Needs a session/device table.
+5. **Per-org allowed-origins allowlist, wildcardable** (Intercom Trusted Domains). This *is* the
+   "whitelist their domains" requirement; make it a first-class org setting.
+6. **Org-scoped server-to-server API credential** (Sunshine app-scope model) for the headless/API
+   play, distinct from browser tokens. Inbound via signed webhooks.
+7. **Authenticate the socket promptly after connect with a bounded window** (Crisp's 10s) and
+   **discover the socket URL via a pre-connect REST call** (room to add multi-node routing later
+   without a client change).
+
+## Security pitfalls flagged by the sources
+
+- **Secret in the browser** — every platform screams this: signing secret / API secret is
+  backend-only. Glific's per-org JWT secret must never reach the widget bundle (which lives in a
+  *public* repo — extra care).
+- **Raw long-lived bearer tokens** — a 30-day JWT with no revocation is the anti-pattern; use a
+  session layer.
+- **Trusting the workspace id for security** — `app_id`/`website_id`/shortcode are public; security
+  is the signed token + domain allowlist, never the id.
+- **Email/identity collision** — must fail closed (Zendesk). For Glific, phone collision across
+  contacts.
+- **Deprecated-but-accepted auth** — Intercom still accepts `user_hash`; don't let "still works"
+  become "what we built on." Start on JWT.
+
+## Sources
+- Intercom — [Authenticating users in the Messenger with JWTs](https://www.intercom.com/help/en/articles/10589769-authenticating-users-in-the-messenger-with-json-web-tokens-jwts)
+- Intercom — [Identity Verification (deprecated HMAC user_hash)](https://www.intercom.com/help/en/articles/183-set-up-identity-verification-for-web-and-mobile-deprecated)
+- Intercom — [List trusted domains for your Messenger](https://www.intercom.com/help/en/articles/4418-list-trusted-domains-you-use-with-your-messenger)
+- Intercom — [Using Intercom with Content Security Policy](https://www.intercom.com/help/en/articles/3894-using-intercom-with-content-security-policy)
+- Zendesk — [Authenticating end users for messaging](https://support.zendesk.com/hc/en-us/articles/4411666638746-Authenticating-end-users-for-messaging)
+- Zendesk/Sunshine — [Sunshine Conversations API Reference](https://docs.smooch.io/rest/v1/)
+- Zendesk/Sunshine — [API Quickstart (current)](https://developer.zendesk.com/documentation/conversations/getting-started/api-quickstart/)
+- Crisp — [RTM API](https://docs.crisp.chat/guides/rtm-api/)
+- Crisp — [Web Chat SDK: Identity Verification](https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/identity-verification/)
+- Crisp — [Web Chat SDK: Session Continuity](https://docs.crisp.chat/guides/chatbox-sdks/web-sdk/session-continuity/)
+- Crisp — [Embed the chatbox in an iFrame](https://help.crisp.chat/en/article/how-to-embed-the-crisp-live-chat-chatbox-in-an-iframe-bkfh98/)

--- a/plans/web-channel/web-channel-backend-breakdown.md
+++ b/plans/web-channel/web-channel-backend-breakdown.md
@@ -1,0 +1,164 @@
+# Web Channel — Backend Change Breakdown
+
+A file-by-file map of what the backend touches, grounded in the **actual prototype diff** (20
+modified files, 272 insertions; 7 new source modules; 3 migrations) reconciled against the
+**design decisions locked this session**. It exists so the tech design can state precisely what is
+additive, what is a modification to shared code (blast-radius risk), and what still has to be
+built or reworked to match the agreed behaviour.
+
+**Legend**
+- **[A] Additive** — net-new file/field; existing code paths untouched. Low risk.
+- **[M] Modification** — edits shared code that WhatsApp also runs through. Needs regression care.
+- **[R] Rework** — the prototype does something the locked design has since superseded; must change.
+- **[N] Net-new (not yet built)** — required by the design, absent from the prototype.
+
+---
+
+## 1. Data model & migrations
+
+| File | Kind | Change |
+|---|---|---|
+| `priv/repo/migrations/20260715000000_add_channel_to_messages.exs` | [M] | `messages.channel :string default "whatsapp" null: false` + index `[:contact_id, :channel]`. |
+| `priv/repo/migrations/20260715085302_add_channel_to_flow_contexts.exs` | [M] | `flow_contexts.channel` — pins a context to its triggering channel. |
+| `priv/repo/migrations/20260715085249_add_web_message_flow_type.exs` | [M] | `ALTER TYPE flow_type_enum ADD VALUE 'web_message'` (non-transactional). |
+| `lib/glific/messages/message.ex` | [M] | `field :channel`, `@type`, optional-cast list, `validate_inclusion` against the enum. |
+| `lib/glific/flows/flow_context.ex` | [M] | `field :channel default "whatsapp"`, `@type`, `init_context` reads `:channel` opt. |
+| `lib/glific/enums/constants/enums.ex` | [M] | `@flow_type_const` gains `:web_message`; new `@message_channel_const` (7 channels). |
+| `lib/glific/enums/enums.ex` | [A] | `message_channel_const/0` macro + doctest. |
+
+**Two migration-safety findings the doc must call out:**
+
+1. **`add :channel, ... null: false` on `messages` rewrites the whole table.** `messages` is one of
+   the largest production tables; per `priv/repo/migrations/CLAUDE.md` a non-null-default add is a
+   full rewrite and lock. **Rework to:** add the column **nullable, no default**; backfill
+   `"whatsapp"` in a batched follow-up (or Oban job); then set the default. The application already
+   defaults `channel` to `"whatsapp"` at the schema layer, so reads are safe during the window.
+   This finding is the hinge of the BigQuery-compatibility question (see the schema/BigQuery doc).
+
+2. **`flow_type` is a real Postgres enum type**, not a string (the `ALTER TYPE` proves it). That
+   makes the `flow_type` → `supported_channels`-array question (below) a **non-trivial migration**,
+   not a field rename. Decide before building, because reversing an enum value is impossible
+   (`down` is a documented no-op).
+
+---
+
+## 2. Transport (net-new infra — all additive)
+
+| File | Kind | Change |
+|---|---|---|
+| `lib/glific_web/channels/web_channel_socket.ex` | [A] | `WebChannelSocket` — verifies contact token, sets org+root-user context, assigns `current_contact`. |
+| `lib/glific_web/channels/web_channel/room_channel.ex` | [A] | `RoomChannel` topic `web_channel:<contact_id>`: join→last 100, `load_more`, `new_message`, `update_name`, presence track. |
+| `lib/glific_web/channels/web_channel/presence.ex` | [A] | `WebChannel.Presence` (`use Phoenix.Presence`). |
+| `lib/glific_web/channels/web_channel/token.ex` | [A]→[R] | Contact token. **Rework:** see §4 (Phoenix.Token → JWT + refresh). |
+| `lib/glific_web/endpoint.ex` | [M] | Mounts `socket("/web_socket", …)` beside `/socket` and `/live`. One line; isolated. |
+| `lib/glific/application.ex` | [M] | Adds `WebChannel.Presence` to the supervision tree. |
+
+The transport is the cleanest part of the prototype — genuinely additive, no WhatsApp path
+touched. **Net-new still needed:** `room_channel.ex` must gain a **presence-driven resume** hook
+(§5) — on `:after_join`, wake any context that presence-parked while the contact was away.
+
+---
+
+## 3. Send path (channel-aware fork)
+
+| File | Kind | Change |
+|---|---|---|
+| `lib/glific/providers/web/message.ex` | [A]→[R] | `Providers.Web.Message` (`@behaviour MessageBehaviour`). Text/media = synchronous socket broadcast, no Oban/HTTP. `send_interactive`/`send_sticker` → `{:error, …}`. **Rework `deliver/2`:** see §5. |
+| `lib/glific/communications/web_message.ex` | [A] | `Communications.WebMessage` — mirrors `WAGroupMessage`. `send_message/2`, `receive_message/2`. Correctly **does not** call `set_session_status` (avoids the 24h-window landmine). Publishes `:sent_message`/`:received_message` to staff inbox. |
+| `lib/glific/messages.ex` | [M] | `list_conversation_messages/3` (per-contact per-channel history, [A]); `check_for_hsm_message(%{channel:"web"}, _)` clause routing outbound to `WebMessage`, bypassing HSM/interactive/session gates ([M], ordered before the generic clause). |
+| `lib/glific/providers/message_behaviour.ex` | [M] | Return-type union widened to `{:ok, Oban.Job.t()} | {:ok, Message.t()}` so synchronous channels satisfy the same behaviour. Every provider sees the wider spec (dialyzer-only impact). |
+| `lib/glific/communications/message.ex` | [M] | `process_message/1` made public so `WebMessage.receive_message` reuses the poolboy dispatch. Low risk (visibility only). |
+
+---
+
+## 4. Auth (prototype is a stub — largest [R]/[N] gap vs the locked design)
+
+| File | Kind | Change |
+|---|---|---|
+| `lib/glific_web/controllers/api/v1/web_channel_auth_controller.ex` | [A]→[R] | `request_otp`/`verify_otp`. Prototype: no SMS, accepts `"9999"` behind `:web_channel_otp_bypass`. |
+| `lib/glific_web/channels/web_channel/token.ex` | [R] | Prototype signs an opaque `Phoenix.Token` (`max_age 86_400`). |
+| `lib/glific_web/router.ex` | [M] | Two public routes in the non-authed pipeline. |
+| `config/dev.exs`, `config/test.exs` | [M] | `web_channel_otp_bypass: true` (must stay unset in prod/runtime). |
+
+**Rework/net-new to match the auth decisions (see `web-channel-auth-research.md`):**
+
+- **[R] JWT (HS256), per-org signing secret** replacing the opaque Phoenix.Token — so a future
+  NGO-minted delegated token verifies through the same path (embeddable-later hedge). Claims:
+  `contact_id`/`phone`, `org`, short `exp`.
+- **[N] Short access token + long refresh token.** The "30-day session" = refresh-token lifetime,
+  **not** a 30-day bearer. Needs a **new `web_channel_sessions` (or device) table** (migration +
+  schema + context) to make refresh revocable and support logout/DPDP erasure.
+- **[N] Real SMS OTP** (India provider — pending research) replacing the `9999` bypass, with the
+  bypass hard-failing under `MIX_ENV=prod`.
+- **[N] `request_otp` rate limiting per-phone AND per-IP.** Prototype defers to a generic
+  `RateLimitPlug`; the design requires phone+IP limits specifically, since this endpoint runs
+  before a contact exists (per-contact limiting can't protect it) and each call will cost an SMS.
+
+---
+
+## 5. Flow gating & the presence/switch-over reworks
+
+| File | Kind | Change |
+|---|---|---|
+| `lib/glific/flows/action.ex` | [M]→[R] | 3 guard clauses reject `send_interactive_msg`/`send_broadcast`/templated `send_msg` under `%{channel:"web"}` via `notification` + continue. |
+| `lib/glific/flows/flow.ex` | [M] | `web_channel_capability_errors/2` — publish-time validation walks nodes for unsupported types on a `:web_message` flow. Also surfaces `flow_type` in the cached flow map. |
+| `lib/glific/flows/contact_action.ex` | [M] | Propagates `context.channel` into outbound send attrs so replies route back over the origin channel. |
+| `lib/glific/processor/consumer_flow.ex` | [M]→[N] | Threads `message.channel` into `init_context` (both start paths). |
+
+**Three deltas from the locked design — the important part of this doc:**
+
+1. **[R] Presence: drop-and-continue → pause-and-resume.** Prototype `Providers.Web.Message.deliver/2`
+   sends anyway when the contact is absent and marks `bsp_status: :error`, and the **flow keeps
+   running**. The locked design (scenarios §4) is the opposite: if absent, **do not send — pause
+   the flow at that node**, and deliver + resume on reconnect. This requires:
+   - `deliver/2` to signal "not delivered / absent" rather than persist-as-error;
+   - the flow send path to **park the context** on that signal (reuse the `wakeup_at`/parking
+     machinery, but event-driven);
+   - `room_channel.ex` `:after_join` to **resume** parked contexts via `wakeup_one/2`.
+   Also drop the `bsp_status: :error` semantics — `bsp_status` is WhatsApp vocabulary and an absent
+   web contact is not a delivery failure (naming debt noted separately).
+
+2. **[N] Channel-scoped continuation (switch-over rule, scenarios §1).** Prototype only *propagates*
+   channel; it does **not** make continuation channel-aware. `active_context`/`continue_the_context?`
+   in `consumer_flow.ex`/`flow_context.ex` must only continue a context when the inbound message's
+   channel equals the context's pinned channel; a mismatch is treated as no active context (falls
+   through to fresh routing). This is the fix for the accidental cross-channel takeover and is
+   currently unbuilt.
+
+3. **[R] Capability gating is scattered, not a registry.** The rules live in 3 places (action.ex
+   guards, flow.ex validation, and the frontend `setConfig`). The extensibility decision is a
+   single `Glific.Channels.capabilities/1` source of truth all gates consume. Recommended refactor
+   **now**, while there are only two channels — the RCS research feeds its shape.
+
+---
+
+## 6. GraphQL / staff inbox (additive)
+
+| File | Kind | Change |
+|---|---|---|
+| `lib/glific_web/schema/message_types.ex` | [M] | `channel :string` on the message object **and** the send-message input (staff reply routing). |
+| `lib/glific_web/schema/flow_types.ex` | [M] | `flow_type` on `:flow_input` (create/edit picks channel). |
+| `assets/gql/messages/fields.frag.gql` | [M] | `channel` in the message fragment. |
+
+The unified staff inbox is mostly frontend; the backend contract is just the `channel` field
+(read) + accepting `channel` on the send input (write → routes via the §3 fork). **Net-new not in
+the prototype:** the daily **metrics rollup table** (`org_id, channel, date, active_contacts,
+messages_in/out, peak_connections`) that DAU-based pricing and scalability reporting need.
+
+---
+
+## 7. Summary — where the prototype stands vs the design
+
+- **Solid & additive (keep):** transport (socket/channel/presence), the `messages.channel`
+  discriminator + schema/enum, `WebMessage` context shape, the `MessageBehaviour` union widening,
+  the correct omission of `set_session_status`, GraphQL `channel` fields.
+- **Rework to match locked decisions:** presence drop→pause (§5.1); auth Phoenix.Token→JWT +
+  refresh/session table (§4); migration made table-rewrite-safe (§1.1); capability gating →
+  registry (§5.3).
+- **Net-new still to build:** channel-scoped continuation (§5.2); SMS OTP + phone/IP rate limits
+  (§4); presence-resume-on-join (§2/§5.1); metrics rollup (§6); `web_channel_sessions` table (§4).
+- **Open reconciliation:** `flow_type` enum (built) vs `supported_channels` array (extensibility
+  direction) — a real enum migration, decide before building further (§1.2).
+
+Cross-references: data/BigQuery compatibility → `web-channel-schema-and-bigquery.md`; channel
+framework + RCS worked example → `web-channel-framework-and-rcs.md`; behaviour → `web-channel-scenarios.md`.

--- a/plans/web-channel/web-channel-schema-and-bigquery.md
+++ b/plans/web-channel/web-channel-schema-and-bigquery.md
@@ -1,0 +1,164 @@
+# Web Channel — Schema Evolution & BigQuery Compatibility
+
+How adding `messages.channel` (and, later, `flow_type` / `supported_channels`) reaches
+organizations' BigQuery datasets, and how to roll it out so **no existing org's data warehouse or
+dashboards break.** Grounded in a code investigation of `lib/glific/third_party/bigquery/`
+(`bigquery.ex`, `bigquery_schema.ex`, `bigquery_worker.ex`, `bigquery_job.ex`).
+
+**Headline:** none of the BigQuery modules are touched on this branch — the prototype's `channel`
+work is Postgres-only. The BigQuery changes below are **net-new design work**, and there is a
+sharp, silent failure mode if they're sequenced wrong.
+
+---
+
+## 1. How the sync actually works
+
+- **Cron-triggered Oban worker, not DB triggers.** `MinuteWorker`'s `"bigquery"` branch
+  (`minute_worker.ex:84`) fans out `BigQueryWorker.perform_periodic/1` per BigQuery-enabled org.
+- **Legacy streaming inserts** (`tabledata.insertAll`), 100 rows/batch (`bigquery.ex:916`).
+- **Cursor-based incremental:** inserts pull `id > cursor`; updates pull `updated_at > cursor`
+  (`bigquery_worker.ex:211`/`:228`). Cursors live in the `bigquery_jobs` table.
+- **A dedup DELETE pass** runs periodically because streaming double-writes updated rows.
+- Reads come from a **replica**, org-scoped.
+
+Synced tables relevant to us: `messages`, `flows`, `flow_contexts`, `flow_results`, `contacts` —
+all synced. `messages` is MONTH-partitioned on `inserted_at`, clustered on
+`[contact_phone, flow_id]`.
+
+---
+
+## 2. The crux: the schema is hand-maintained in two places, and order matters
+
+The BigQuery schema is **not derived from Postgres.** It's a hardcoded Elixir field list
+(`bigquery_schema.ex`, 3200+ lines, one fn per table). Adding a column that reaches BigQuery
+requires editing **two independent places by hand**:
+
+1. the **schema-fn** — e.g. `message_schema` (`bigquery_schema.ex:254`) — declaring the column;
+2. the **row-builder** — e.g. `get_message_row/2` (`bigquery_worker.ex:1543`) — emitting the value.
+
+The row-builder is an **explicit named-key map**, not `Map.from_struct`. This is the key safety
+property:
+
+> **The Postgres migration is completely inert for BigQuery until the row-builder emits the field.**
+
+So the already-shipped `add_channel_to_messages` migration changes *nothing* about BigQuery today.
+That gives us a clean lever to sequence the rollout safely.
+
+---
+
+## 3. The silent failure mode (why ordering is not optional)
+
+There is an existing table-patch path — `alter_table/2` (`bigquery.ex:777`) issues a full-schema
+PUT that BigQuery accepts as an additive column add **iff the new field is `NULLABLE`.** But:
+
+- It runs **only** via `sync_schema_with_bigquery` → `do_refresh_the_schema`, whose triggers are:
+  (a) an org **re-saving its BigQuery credential** (`partners.ex:1071`), (b) the ops/iex bulk path
+  `Seeds.SeedsMigration.sync_schema_with_bigquery/1` (`seeds_migration.ex:425`), (c) a `NOT_FOUND`
+  (missing-table) insert error.
+- **The periodic data sync NEVER refreshes the schema.** So an existing org does **not** get a new
+  column automatically — someone must explicitly patch it.
+- `alter_tables` loops orgs in a **fire-and-forget `Task.async` whose result is never awaited or
+  logged** (`bigquery.ex:447`) — a failed patch fails **silently**.
+
+**The breaking case:** if the row-builder emits `channel` to an org whose BigQuery table doesn't
+yet have the column, `insertAll` returns HTTP 200 with an `insertErrors` array (`no such field:
+channel`). The insert body sets **no `ignoreUnknownValues`**, and the handler treats any
+`insertErrors` as fatal — `raise` (`bigquery.ex:934`). With `max_attempts: 1`, the job dies and
+**that org's message sync stalls.** It does **not** self-heal (the auto-refresh only fires on
+`NOT_FOUND`, a different code path). Emit-before-patch = broken warehouse, silently, per org.
+
+That NULLABLE-and-unemitted columns are safe is proven in-tree: `message_schema` already declares
+`group_message_id`/`flow_broadcast_id` that the row-builder never emits — they sit NULL, no errors.
+
+---
+
+## 4. Non-breaking rollout for `messages.channel`
+
+Existing Postgres rows are already `'whatsapp'` (migration default), so **no Postgres backfill is
+needed.** The BigQuery side is a strict 4-step order:
+
+1. **[done] Ship the Postgres migration.** Inert for BigQuery. *(But make it table-rewrite-safe
+   first — see §6; that's a Postgres-availability issue, separate from BigQuery.)*
+2. **Add `channel` as `NULLABLE STRING`** to `message_schema` (`bigquery_schema.ex:254`). Do **not**
+   touch the row-builder yet. `NULLABLE` is mandatory — BigQuery rejects adding a `REQUIRED` column
+   to an existing table, and `alter_tables` would swallow that failure silently.
+3. **Bulk-patch every existing BigQuery-enabled org** via
+   `Seeds.SeedsMigration.sync_schema_with_bigquery(org_ids)`. Because the patch is fire-and-forget,
+   **verify** each org's table schema afterward (spot-check `information_schema.columns`) rather
+   than trusting a return value.
+4. **Only after step 3 completes for all orgs**, add `channel: row.channel` to `get_message_row/2`
+   (`bigquery_worker.ex:~1547`) and deploy. Every table already has the column, so inserts succeed
+   everywhere.
+
+**Never collapse 2+4 ahead of 3.** That is precisely the emit-before-patch crash.
+
+**Optional defense-in-depth:** add `ignoreUnknownValues: true` to the `insertAll` body
+(`bigquery.ex:916`) so an un-patched org silently *drops* the field instead of crashing. It removes
+the hard ordering dependency but permanently masks genuine schema drift — gate it deliberately, and
+if adopted, treat it as a general hardening of the sync, not a web-channel special case.
+
+---
+
+## 5. `flow_type` / `supported_channels` — same recipe, one extra hazard
+
+`flow_type` is a real column on `flows` but is **not currently synced to BigQuery** (the BQ `flows`
+row-builder emits only id/name/uuid/keywords/status/revision/tag). Same 4-step order applies if we
+want it in the warehouse.
+
+**The extra wrinkle bears directly on the `flow_type`-enum-vs-`supported_channels`-array decision:**
+the BigQuery `flows` table is **insert-only** — `flows` is in `ignore_updates_for_table/0`
+(`bigquery.ex:175`), so a flow synced once is **never re-synced on update.**
+
+- `flow_type` set at creation and never changed → fine.
+- A **mutable `supported_channels`** array that an author edits later → the change would **never
+  propagate to BigQuery.** The warehouse would hold the value as of first sync, forever.
+
+This is a real strike against a mutable `supported_channels` unless we also remove `flows` from the
+insert-only set (a broader change with its own dedup implications). It doesn't settle the decision,
+but the tech design must weigh it: the "more flexible" array is *less* warehouse-friendly than the
+enum, given the current sync.
+
+`flow_contexts.channel` (also added in Postgres on this branch) is BQ-synced but, like the others,
+has zero BigQuery impact until both schema-fn and row-builder are edited.
+
+---
+
+## 6. Postgres-side safety (independent of BigQuery)
+
+Separate from the warehouse: the `add_channel_to_messages` migration adds `null: false, default:
+"whatsapp"` to `messages`, a very large table — a **full table rewrite + lock** per Glific's
+migration guide. Rework to the safe pattern: **nullable add → batched backfill → set default**
+(the schema already defaults `channel` in the changeset, so reads are safe during the window).
+Same consideration for `flow_contexts` if it's large.
+
+---
+
+## 7. Historical rows in BigQuery
+
+The incremental sync only re-pulls rows with a new `id` or bumped `updated_at`. The migration does
+**not** bump `updated_at`, so already-synced historical messages read `channel = NULL` in BigQuery.
+Two options:
+
+- **Recommended, cheapest:** document `COALESCE(channel, 'whatsapp')` for report authors. Existing
+  dashboards that don't reference `channel` are unaffected regardless.
+- **Full fidelity:** one-time per-dataset `UPDATE {dataset}.messages SET channel='whatsapp' WHERE
+  channel IS NULL;` after step 3. Bounded DML, run per org dataset.
+
+---
+
+## 8. Recommendations for the tech design
+
+1. **Adding channel columns to the warehouse is safe and additive — but only with the strict
+   patch-before-emit order.** Bake the 4-step sequence (and the per-org verify) into the rollout
+   runbook; it is the single most breakable operation in this whole feature.
+2. **Treat the BigQuery schema/row-builder edits as first-class deliverables**, not an afterthought
+   — the Postgres migration alone gives NULL columns and a false sense of "done."
+3. **Weigh the insert-only `flows` constraint against `supported_channels` mutability.** If channels
+   per flow must be editable post-creation *and* appear correctly in the warehouse, the enum is the
+   safer model, or `flows` must leave the insert-only set.
+4. **Default NULL → whatsapp semantics everywhere** (COALESCE), so no existing report breaks and no
+   historical backfill is strictly required.
+5. Consider `ignoreUnknownValues` as a broader sync-hardening, decided on its own merits.
+
+Cross-references: file-by-file backend map → `web-channel-backend-breakdown.md`; the migration
+rewrite-safety point also appears there (§1).

--- a/plans/web-channel/web-channel-t1-message-flow-map.md
+++ b/plans/web-channel/web-channel-t1-message-flow-map.md
@@ -1,0 +1,459 @@
+# T1 Spike — Message Send/Receive Flow Map (Gupshup & Maytapi)
+
+> **Epic:** Web Channel — Phase 0 · **Ticket:** T1 (Spike)
+> **Purpose:** map how messages are **sent** and **received** for the two existing WhatsApp providers —
+> **Gupshup** (WhatsApp) and **Maytapi** (WhatsApp groups) — down to the database tables they write, so the
+> web channel can plug into the same seam. This is a *read-only* code map; the **flow engine**
+> (`process_message`, `FlowContext`, `Flows.*`) is deliberately **out of scope** and traced separately.
+
+Every message type is covered: **text · media (image/audio/video/document/sticker) · HSM/template · interactive (list/quick-reply)**.
+
+---
+
+## How to read this document
+
+Because GitHub's mermaid renderer degrades on very large single graphs, the map is split into **one diagram per path**
+(reference · inbound · outbound · groups · overview) rather than one giant graph. They share the same visual language:
+
+| Element | Meaning |
+|---|---|
+| **Blue box** | Web layer — Plug / Phoenix controller (`lib/glific_web/…`) |
+| **Green box** | Business-logic function — `Module.function/arity` + `file:line` (`lib/glific/…`) |
+| **Grey dashed box** | External hop — HTTP call to the BSP (Gupshup/Maytapi API) |
+| **Orange cylinder** | Database table (key columns only — *not* the full schema) |
+| **Red dashed box** | Out of scope — the flow engine boundary |
+| **Solid arrow** | Call / data flow. Labels on arrows into a table = **fields written** on that hop |
+| **Dotted arrow** | Async hand-off or status transition |
+
+**Enum values used in the labels** (from `lib/glific/enums/constants/enums.ex`):
+- `flow` → `:inbound` \| `:outbound`
+- `status` / `bsp_status` (same `MessageStatus` enum) → `:enqueued :sent :delivered :read :received :error :contact_opt_out :reached :seen :played :deleted`
+- `type` → `:text :image :audio :video :document :sticker :location :contact :list :quick_reply :hsm :poll :location_request_message :whatsapp_form_response`
+
+---
+
+## 1. Database tables (the destinations)
+
+Three tables receive message writes. The **central design fact** of this spike: Gupshup writes the **shared `messages`**
+table; Maytapi forks into a **parallel `wa_messages`** table. `messages_media` and `contacts` are shared by both.
+
+```mermaid
+flowchart LR
+  MESSAGES[("<b>messages</b> — Gupshup (WhatsApp) + Web<br/>type · flow · body · status · bsp_status<br/>bsp_message_id · <b>channel</b> (default whatsapp)<br/>is_hsm · template_id<br/>interactive_content · interactive_template_id<br/>media_id · context_id<br/>sender_id · receiver_id · contact_id · organization_id")]:::db
+  WAMSG[("<b>wa_messages</b> — Maytapi (WhatsApp groups)<br/>type · flow · body · status · bsp_status<br/><b>bsp_id</b> · poll_content · poll_id<br/>media_id · context_id · is_dm<br/>contact_id · wa_group_id<br/>wa_managed_phone_id · organization_id")]:::db
+  MEDIA[("<b>messages_media</b> — shared<br/>url · source_url · caption<br/>content_type · gcs_url · flow")]:::db
+  CONTACTS[("<b>contacts</b> — shared<br/>phone · name · contact_type<br/>bsp_status · organization_id")]:::db
+
+  MESSAGES -->|media_id| MEDIA
+  WAMSG -->|media_id| MEDIA
+  MESSAGES -->|sender_id · receiver_id · contact_id| CONTACTS
+  WAMSG -->|contact_id| CONTACTS
+
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+```
+
+**Why it matters for the web channel:** Maytapi's `wa_messages` fork means a *whole* parallel persistence + inbox +
+BigQuery path. The web channel instead reuses `messages` with the existing **`channel`** discriminator (already present,
+defaulting to `"whatsapp"`) — so it inherits the staff inbox, search, and warehouse sync for free. Note `wa_messages`
+has **no** `is_hsm` / `template_id` / `interactive_content` columns → **HSM and interactive do not apply to groups**.
+
+---
+
+## 2. Gupshup — INBOUND (receive) + status callbacks
+
+Webhook `POST /gupshup` → a `Shunt` plug routes on `type` + `payload_type` → per-type controller → provider normalizer
+→ `Communications.Message.receive_message/2` → persist. The controller **always** replies `200 ""`; the flow engine is
+dispatched asynchronously afterwards (out of scope).
+
+```mermaid
+flowchart LR
+  IN(["Gupshup BSP<br/>POST /gupshup"]):::ext
+
+  subgraph WEB["GlificWeb — inbound HTTP (lib/glific_web/providers/gupshup)"]
+    SHUNT["Plugs.Shunt.call/2<br/>shunt.ex:28<br/>routes on type + payload_type"]:::ctrl
+    MC_T["MessageController.text/2<br/>message_controller.ex:30"]:::ctrl
+    MC_M["MessageController.media/3<br/>message_controller.ex:72"]:::ctrl
+    MC_I["MessageController.interactive/3<br/>message_controller.ex:96"]:::ctrl
+    MC_L["MessageController.location/2<br/>message_controller.ex:108"]:::ctrl
+    EVT["MessageEventController.update_status/3<br/>message_event_controller.ex:59"]:::ctrl
+  end
+
+  subgraph GMSG["Glific.Providers.Gupshup.Message (normalizers)"]
+    RT["receive_text/1 · message.ex:120"]:::mod
+    RM["receive_media/1 · message.ex:146"]:::mod
+    RI["receive_interactive/1 · message.ex:211"]:::mod
+    RL["receive_location/1 · message.ex:166"]:::mod
+  end
+
+  subgraph COMM["Glific.Communications.Message"]
+    RCV["receive_message/2 · :194"]:::mod
+    DO["do_receive_message/3 · :208<br/>merges flow=:inbound,<br/>bsp_status=:delivered, status=:received"]:::mod
+    CRT["receive_text/1 · :240"]:::mod
+    CRM["receive_media/1 · :251 (Repo.transaction)"]:::mod
+    CRL["receive_location/1 · :306"]:::mod
+    UBS["update_bsp_status/3 · :166 err / :182 ok"]:::mod
+  end
+
+  subgraph PERSIST["Glific.Messages / Glific.Contacts"]
+    MKC["maybe_create_contact/1 · contacts.ex:449"]:::mod
+    CM["create_message/1 · messages.ex:181"]:::mod
+    CMM["create_message_media/1 · messages.ex:862"]:::mod
+  end
+
+  CONTACTS[("contacts")]:::db
+  MESSAGES[("messages")]:::db
+  MEDIA[("messages_media")]:::db
+  LOC[("locations")]:::db
+  FLOW["process_message<br/>(flow engine — OUT OF SCOPE)"]:::oos
+
+  IN --> SHUNT
+  SHUNT -->|"text / quick_reply"| MC_T --> RT --> RCV
+  SHUNT -->|"image/file/audio/video/sticker"| MC_M --> RM --> RCV
+  SHUNT -->|"button_reply / list_reply"| MC_I --> RI --> RCV
+  SHUNT -->|"location"| MC_L --> RL --> RCV
+  SHUNT -->|"type = message-event"| EVT --> UBS
+
+  RCV --> DO
+  DO -->|"upsert phone, name, contact_type=WABA"| MKC --> CONTACTS
+  DO --> CRT
+  DO --> CRM
+  DO --> CRL
+
+  CRT -->|"WRITE body, type=:text/:list/:quick_reply,<br/>interactive_content (jsonb, if interactive),<br/>flow=:inbound, bsp_status=:delivered, status=:received,<br/>bsp_message_id, context_id, channel=whatsapp,<br/>sender_id=contact, receiver_id=org, contact_id=contact"| CM --> MESSAGES
+  CRM -->|"WRITE url, source_url, caption,<br/>content_type, flow=:inbound<br/>(dedup by url+caption+org)"| CMM --> MEDIA
+  CRM -->|"WRITE + media_id FK, type=:image/:audio/:video/:document/:sticker"| CM
+  CRL -->|"WRITE type=:location, flow=:inbound"| CM
+  CRL -->|"WRITE longitude, latitude, message_id, contact_id"| LOC
+
+  UBS -->|"UPDATE WHERE bsp_message_id:<br/>bsp_status :enqueued->:sent->:delivered->:read"| MESSAGES
+  EVT -.->|"failed: bsp_status=:error, errors=payload<br/>+ process_errors (1002 no-number / 471,1003 suspend org)"| MESSAGES
+
+  CM -.->|"async Task.start + poolboy"| FLOW
+
+  classDef ext fill:#f5f5f5,stroke:#888,stroke-dasharray:4,color:#333
+  classDef ctrl fill:#e7eefc,stroke:#1565c0,color:#0d47a1
+  classDef mod fill:#e8f0ea,stroke:#0b7a45,color:#073f24
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+  classDef oos fill:#fbe9e7,stroke:#c62828,stroke-dasharray:5,color:#8b0000
+```
+
+**Inbound notes**
+- Every received type sets the same trio: `flow=:inbound`, `bsp_status=:delivered`, `status=:received` (`communications/message.ex:216`).
+- **Divergences:** media inserts `messages_media` first and links `media_id` (inside a `Repo.transaction`, so a failed message insert rolls back the media — no orphans); location writes a `locations` row instead; interactive stores the reply **title in `body`** and the full reply in **`interactive_content`** (jsonb) and otherwise reuses the text insert path.
+- **Idempotency:** inbound dedup relies on `unique_constraint [:bsp_message_id, :organization_id]`; a duplicate Gupshup re-delivery is swallowed as `:ok` (logged + counter), never surfaced as an error.
+- **Status callbacks** are bulk `Repo.update_all` keyed on `bsp_message_id`; they mutate only `bsp_status` (+`errors` on failure) + `updated_at`. There are no `delivered_at`/`read_at` columns.
+- **Dropped:** `contact`/vCard and any unmapped payload type hit `DefaultController.unknown/2` → `200 ""` with **no** DB write.
+
+---
+
+## 3. Gupshup — OUTBOUND (send)
+
+The row is **persisted first** (`status=:enqueued`), then an **Oban job** does the HTTP call; the response
+handler updates the row (`status=:sent`, `bsp_status=:enqueued`) — or `:error`. Later provider webhooks (§2) push
+`bsp_status` on to `:sent/:delivered/:read`. HSM takes a separate HTTP endpoint (`PartnerAPI.send_template`).
+
+```mermaid
+flowchart LR
+  FLOWIN["called by flow engine / staff reply<br/>— OUT OF SCOPE"]:::oos
+
+  subgraph MSGS["Glific.Messages (create + persist)"]
+    CASM["create_and_send_message/1<br/>messages.ex:282"]:::mod
+    CFI["check_for_interactive/2<br/>messages.ex:304"]:::mod
+    CASH["create_and_send_hsm_message/1<br/>messages.ex:625"]:::mod
+    CFH["check_for_hsm_message/2<br/>messages.ex:351"]:::mod
+    DSM["do_send_message/2 · messages.ex:366<br/>sets sender_id=org contact, flow=:outbound"]:::mod
+    CM["create_message/1<br/>messages.ex:181"]:::mod
+  end
+
+  subgraph COMM["Glific.Communications.Message"]
+    SM["send_message/2 · :42<br/>provider_handler -> Gupshup;<br/>@type_to_token dispatch"]:::mod
+    HSR["handle_success_response/2 · :100"]:::mod
+    HER["handle_error_response/2 · :145"]:::mod
+  end
+
+  subgraph GMSG["Glific.Providers.Gupshup.Message (payload builders)"]
+    ST["send_text/2 :23"]:::mod
+    SIMG["send_image/2 :32"]:::mod
+    SAUD["send_audio/2 :48"]:::mod
+    SVID["send_video/2 :61"]:::mod
+    SDOC["send_document/2 :76"]:::mod
+    SSTK["send_sticker/2 :89"]:::mod
+    SINT["send_interactive/2 :101"]:::mod
+    SMSG["send_message/3 :277<br/>+ create_oban_job/3 :305"]:::mod
+  end
+
+  subgraph WORKER["Gupshup.Worker (Oban)"]
+    WCS["create_changeset/2 :26<br/>queue :gupshup / :gupshup_high_tps"]:::mod
+    WP["perform/1 :45 -> process_gupshup/4"]:::mod
+  end
+
+  API["ApiClient.send_message/2 :65<br/>POST api.gupshup.io/wa/api/v1/msg"]:::ext
+  PAPI["PartnerAPI.send_template/2 · partner_api.ex:194<br/>POST APP_URL/template/msg"]:::ext
+  RH["ResponseHandler.handle_response/2<br/>response_handler.ex:21"]:::mod
+
+  MESSAGES[("messages")]:::db
+  MEDIA[("messages_media")]:::db
+
+  FLOWIN --> CASM
+  FLOWIN --> CASH
+  CASM --> CFI --> CFH --> DSM
+  CASH --> CFH
+  DSM --> CM
+  CM -->|"WRITE type, body, flow=:outbound, status=:enqueued,<br/>bsp_status=nil, channel=whatsapp, uuid,<br/>sender_id=org, receiver_id=contact, contact_id=contact<br/>— hsm: is_hsm=true + template_id<br/>— interactive: interactive_content + interactive_template_id<br/>— media: media_id"| MESSAGES
+  CM -.->|"media only: UPDATE caption"| MEDIA
+  CM --> SM
+  SM --> ST & SIMG & SAUD & SVID & SDOC & SSTK & SINT
+  ST & SIMG & SAUD & SVID & SDOC & SSTK & SINT --> SMSG
+  SMSG --> WCS --> WP
+  WP -->|"text / media / interactive"| API --> RH
+  WP -->|"is_hsm=true"| PAPI --> RH
+  RH -->|"2xx"| HSR
+  RH -->|"4xx"| HER
+  HSR -->|"UPDATE bsp_message_id, bsp_status=:enqueued,<br/>status=:sent, sent_at"| MESSAGES
+  HER -->|"UPDATE bsp_status=:error, status=:sent, errors"| MESSAGES
+
+  classDef ext fill:#f5f5f5,stroke:#888,stroke-dasharray:4,color:#333
+  classDef mod fill:#e8f0ea,stroke:#0b7a45,color:#073f24
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+  classDef oos fill:#fbe9e7,stroke:#c62828,stroke-dasharray:5,color:#8b0000
+```
+
+**Outbound notes**
+- The dispatch key is `message.type` via `@type_to_token` (`communications/message.ex:26`): `:list`/`:quick_reply`/`:location_request_message` all map to `send_interactive`; media types map to their `send_*`.
+- **HSM** carries `is_hsm=true` + `template_id` on the row; `template_uuid`/`template_type`/`params` ride only in the Oban `attrs` (not columns) and select the `PartnerAPI.send_template` HTTP branch inside the worker.
+- **messages_media is never INSERTed on send** — the media row is created upstream (upload/template import); the send path only *updates* its parsed caption and sets `messages.media_id`.
+- `contacts` is **read-only** here: org sender via `Partners.organization_contact_id/1`, receiver via `Contacts.get_contact/1`.
+- Failure modes: a 4xx sets `bsp_status=:error` but returns `:ok` (no Oban retry); only transport timeouts return `{:error, …}` to trigger a retry; a provider-handler exception sets `status=:error` (`communications/message.ex:81`).
+
+---
+
+## 4. Maytapi — SEND & RECEIVE (WhatsApp groups)
+
+The **parallel stack**: its own communications context (`GroupMessage`), its own builders/worker/queue (`:wa_group`),
+and its own table (`wa_messages`, keyed by `bsp_id` not `bsp_message_id`). **HSM/template and interactive are NOT
+wired** here — `@type_to_token` (`wa_group_message.ex:31`) only has text/media/poll; anything else raises and is
+rescued into an error. Supported: **text, media (image/audio/video/document/sticker), poll**.
+
+### 4a. Maytapi — outbound (send)
+
+```mermaid
+flowchart LR
+  ENTRY["Maytapi.Message.create_and_send_wa_message/3 · message.ex:25<br/>(collection fan-out: send_message_to_wa_group_collection/2 :71)<br/>callers = flow / wa_group_action — OUT OF SCOPE"]:::oos
+
+  subgraph MMSG["Glific.Providers.Maytapi.Message"]
+    CWM["create_wa_message/3 :37"]:::mod
+    APD["add_poll_details/1 :53"]:::mod
+  end
+
+  subgraph WACTX["WAMessages / Communications.GroupMessage"]
+    WCM["WAMessages.create_message/1<br/>wa_messages.ex:27"]:::mod
+    GSM["GroupMessage.send_message/2 · wa_group_message.ex:46<br/>@type_to_token dispatch"]:::mod
+  end
+
+  subgraph MWA["Maytapi.WAMessages (payload builders)"]
+    WST["send_text/2 :14"]:::mod
+    WSI["send_image :23 · audio :38 · video :51<br/>document :66 · sticker :81"]:::mod
+    WSP["send_poll/2 :94"]:::mod
+    WOJ["create_oban_job/2 :154"]:::mod
+  end
+
+  MWP["WAWorker.perform/1 · wa_worker.ex:33<br/>Oban queue :wa_group -> process_maytapi/3 :72"]:::mod
+  MAPI["ApiClient.send_message/3 :90<br/>POST api.maytapi.com/api/PRODUCT/PHONE_ID/sendMessage"]:::ext
+  MRH["ResponseHandler.handle_response/2<br/>response_handler.ex:24"]:::mod
+
+  WAMSG[("wa_messages")]:::db
+  WAPOLL[("wa_polls")]:::db
+
+  ENTRY --> CWM
+  CWM -.->|poll: read poll_content| APD
+  APD -.-> WAPOLL
+  CWM --> WCM
+  WCM -->|"WRITE type=:text/media/:poll, body, flow=:outbound,<br/>status=:enqueued, bsp_status=:sent, uuid,<br/>contact_id, wa_group_id, wa_managed_phone_id,<br/>media_id (media), poll_content + poll_id (poll)"| WAMSG
+  WCM --> GSM
+  GSM --> WST & WSI & WSP
+  WST & WSI & WSP --> WOJ --> MWP
+  MWP --> MAPI --> MRH
+  MRH -->|"2xx: UPDATE bsp_id, bsp_status=:enqueued,<br/>status=:sent, sent_at"| WAMSG
+  MRH -->|"4xx/err: UPDATE bsp_status=:error, status=:sent,<br/>errors + create_notification"| WAMSG
+
+  classDef ext fill:#f5f5f5,stroke:#888,stroke-dasharray:4,color:#333
+  classDef mod fill:#e8f0ea,stroke:#0b7a45,color:#073f24
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+  classDef oos fill:#fbe9e7,stroke:#c62828,stroke-dasharray:5,color:#8b0000
+```
+
+### 4b. Maytapi — inbound (receive) + ack/error events
+
+Note the extra inbound gating unique to groups: **dedup by `bsp_id`**, a **non-primary-receiver drop** (so only the
+group's primary managed phone ingests), and **lazy group/membership creation** (`wa_groups` + `wa_groups_phones`).
+
+```mermaid
+flowchart LR
+  IN(["Maytapi BSP<br/>POST /maytapi"]):::ext
+
+  subgraph WEB["GlificWeb — inbound (lib/glific_web/providers/maytapi)"]
+    SHUNT["Plugs.Shunt.call/2 · shunt.ex:28<br/>routes on message.type"]:::ctrl
+    MCT["MessageController.text/2 :25<br/>media/3 :93 · poll/2 :68"]:::ctrl
+    EVT["MessageEventController.handler/2 :26<br/>(ack / error / poll-vote / reaction)"]:::ctrl
+  end
+
+  subgraph MMSG["Maytapi.Message (normalizers)"]
+    RT["receive_text/1 :158"]:::mod
+    RM["receive_media/1 :178"]:::mod
+    RP["receive_poll/1 :236"]:::mod
+  end
+
+  subgraph GRP["Glific.Communications.GroupMessage"]
+    RCV["receive_message/2 :92<br/>dedup by bsp_id · non_primary_receiver? -> drop"]:::mod
+    DO["do_receive_message/3 :217<br/>create_message_metadata -> resolve phone + group"]:::mod
+    GRT["receive_text :247 · receive_media :260 · receive_poll :295"]:::mod
+    UBS["update_bsp_status :192 · error :202 · poll_vote :429"]:::mod
+  end
+
+  subgraph PERSIST["contexts"]
+    MKC["Contacts.maybe_create_contact/1"]:::mod
+    MCG["WAGroups.maybe_create_group/1 · wa_groups.ex:635<br/>+ ensure_membership/4 :388"]:::mod
+    CMM["Messages.create_message_media/1<br/>messages.ex:862"]:::mod
+    WCM["WAMessages.create_message/1<br/>wa_messages.ex:27"]:::mod
+  end
+
+  CONTACTS[("contacts")]:::db
+  WAGRP[("wa_groups + wa_groups_phones")]:::db
+  WAPHONE[("wa_managed_phones")]:::db
+  MEDIA[("messages_media")]:::db
+  WAMSG[("wa_messages")]:::db
+  FLOW["publish :received_wa_group_message<br/>-> flow engine (OUT OF SCOPE)"]:::oos
+
+  IN --> SHUNT
+  SHUNT -->|"type=message (text/media/poll)"| MCT
+  SHUNT -->|"type=ack/error/vote/reaction"| EVT
+  MCT --> RT & RM & RP --> RCV
+  EVT --> UBS
+  UBS -->|"UPDATE bsp_status -> :delivered/:reached/:seen/:played,<br/>:error + errors, or poll_content"| WAMSG
+
+  RCV -->|"upsert phone, name, contact_type=WA"| MKC --> CONTACTS
+  RCV --> DO
+  DO -.->|"read receiver phone"| WAPHONE
+  DO -->|"WRITE label, bsp_id, wa_managed_phone_id<br/>+ membership is_primary/is_active"| MCG --> WAGRP
+  DO --> GRT
+  GRT -->|"media: WRITE url, source_url, caption, content_type,<br/>flow=:inbound (dedup url+caption+org)"| CMM --> MEDIA
+  GRT -->|"WRITE bsp_id, body, type, flow=:inbound,<br/>status=:received, bsp_status=:delivered,<br/>contact_id, wa_group_id, wa_managed_phone_id,<br/>is_dm, media_id (media), poll_content (poll)"| WCM --> WAMSG
+  WCM -.-> FLOW
+
+  classDef ext fill:#f5f5f5,stroke:#888,stroke-dasharray:4,color:#333
+  classDef ctrl fill:#e7eefc,stroke:#1565c0,color:#0d47a1
+  classDef mod fill:#e8f0ea,stroke:#0b7a45,color:#073f24
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+  classDef oos fill:#fbe9e7,stroke:#c62828,stroke-dasharray:5,color:#8b0000
+```
+
+**Maytapi notes**
+- Outbound insert sets `bsp_status=:sent` (from the "sent" string), *then* the 2xx handler flips it to `:enqueued` and sets `status=:sent` + `bsp_id` — the opposite starting point from Gupshup (which inserts `bsp_status=nil`).
+- Self-echo: when Maytapi replays the org's own sent message (`fromMe=true`), `receive_*` keeps `flow=:outbound`/`status=:sent`; genuine inbound is `flow=:inbound`/`status=:received`. `bsp_status` on receive is always `:delivered`.
+- `wa_managed_phones` is read (receiver resolution) and only written by the separate phone-health `StatusController`.
+- Reactions/poll-votes update side tables (`wa_reactions`, `wa_messages.poll_content`); they don't create message rows.
+
+---
+
+## 5. Synthesis — the two stacks & the extensibility seam
+
+Both existing channels are **async BSP**: persist → enqueue Oban → HTTP → response handler updates status → (later)
+provider webhook pushes delivery status. They differ only in *where they persist* — Gupshup into shared `messages`,
+Maytapi into parallel `wa_messages`. The **seam** that lets a new channel join is `MessageBehaviour`: its `send_*`
+callbacks already return a **union**, so a synchronous channel (web) can return `{:ok, Message.t()}` instead of an
+Oban job — no queue, no HTTP, no webhook.
+
+```mermaid
+flowchart TB
+  APP["Glific.Messages<br/>create_and_send_message / _hsm"]:::mod
+  D1["Glific.Communications.Message<br/>provider_handler -> BSP"]:::mod
+  D2["Glific.Communications.GroupMessage<br/>hardcoded Maytapi"]:::mod
+
+  subgraph GSTACK["Gupshup — WhatsApp (async BSP)"]
+    G1["Providers.Gupshup.Message"]:::mod
+    G2["Gupshup.Worker · Oban :gupshup"]:::mod
+    G3["ApiClient / PartnerAPI · HTTP"]:::ext
+  end
+  subgraph MSTACK["Maytapi — WhatsApp groups (async BSP)"]
+    M1["Maytapi.WAMessages"]:::mod
+    M2["Maytapi.WAWorker · Oban :wa_group"]:::mod
+    M3["ApiClient · HTTP"]:::ext
+  end
+
+  SEAM["MessageBehaviour — the send seam<br/>send_* returns a UNION:<br/>&#123;:ok, Oban.Job.t()&#125; = async BSP (Gupshup, Maytapi)<br/>&#123;:ok, Message.t()&#125; = synchronous (web channel)"]:::seam
+
+  MESSAGES[("messages<br/>+ channel discriminator")]:::db
+  WAMSG[("wa_messages<br/>PARALLEL table")]:::db
+  MEDIA[("messages_media · shared")]:::db
+
+  WEB["Providers.Web.Message (T2/T3)<br/>synchronous socket deliver -> {:ok, Message}"]:::oos
+
+  APP --> D1
+  D1 -->|":gupshup"| G1 --> G2 --> G3
+  D2 --> M1 --> M2 --> M3
+  APP --> MESSAGES
+  D2 --> WAMSG
+  MESSAGES --> MEDIA
+  WAMSG --> MEDIA
+
+  G1 -. implements .-> SEAM
+  M1 -. implements .-> SEAM
+  SEAM -. web adds sync member .-> WEB
+  WEB -. reuses .-> MESSAGES
+
+  classDef ext fill:#f5f5f5,stroke:#888,stroke-dasharray:4,color:#333
+  classDef mod fill:#e8f0ea,stroke:#0b7a45,color:#073f24
+  classDef db fill:#fff3e0,stroke:#e65100,stroke-width:2px,color:#5d2c00
+  classDef oos fill:#fbe9e7,stroke:#c62828,stroke-dasharray:5,color:#8b0000
+  classDef seam fill:#fff9c4,stroke:#f9a825,stroke-width:2px,color:#5d4200
+```
+
+---
+
+## 6. Key findings for the web channel (T2+)
+
+**1. The seam is one behaviour with a union return — web is the first synchronous member.**
+`MessageBehaviour.send_*` already returns `{:ok, Oban.Job.t()} | {:ok, Message.t()}`. Gupshup/Maytapi return the Oban
+job; `Providers.Web.Message` returns `{:ok, Message.t()}` after a live socket broadcast — **no Oban queue, no HTTP,
+no provider webhook**. Everything downstream of the send fork already tolerates this.
+
+**2. Reuse `messages`; do not fork a `web_messages` table.** Gupshup writes shared `messages`; Maytapi forked
+`wa_messages` and thereby duplicated its inbox query, status lifecycle, and (separately) its BigQuery sync. The web
+channel takes Gupshup's path — a `channel` discriminator on `messages` (already present) — so it inherits the staff
+inbox, search, and warehouse for free. `messages_media` and `contacts` are reused unchanged.
+
+**3. Persistence primitives are shared and channel-agnostic.** Both inbound (`create_message/1`, `messages.ex:181`)
+and outbound (`do_send_message/2` → `create_message/1`) already flow through the same insert. The web channel adds a
+`channel: "web"` attr and otherwise reuses them. Inbound media reuse (`create_message_media/1`, `messages.ex:862`,
+deduped by url+caption+org) also works as-is.
+
+**4. Where the web fork attaches (mirrors the WhatsApp forks precisely):**
+
+| Concern | WhatsApp (Gupshup) | Web channel (T2/T3) |
+|---|---|---|
+| Outbound routing | `send_message/2` → `provider_handler` (`communications/message.ex:42`) | add a `check_for_hsm_message(%{channel: "web"})` branch in `messages.ex` → `Communications.WebMessage.send_message`, **before** the WhatsApp session-window/HSM gate |
+| Outbound delivery | persist `:enqueued` → Oban → HTTP → `:sent` | persist → **presence check** → connected: socket broadcast + `:sent`/`:delivered` inline; absent: **pause** (T3) |
+| Inbound entry | `Shunt` → controller → `receive_message/2` | Phoenix Channel `handle_in` → `WebMessage.receive_message` → `create_message(channel:"web")` |
+| Inbound flow handoff | `publish_data(:received_message)` → `process_message` (async) | same — but **T2 stops before `process_message`**; T3 re-enables it |
+| Table | `messages` | `messages` (same, `channel="web"`) |
+
+**5. The status lifecycle is the one place web MUST diverge.** BSP flow is `:enqueued → :sent` (API 2xx) `→ :delivered/:read`
+(webhook). Web has **no webhook** — *presence is the delivery signal*: connected → set delivered inline; absent → the
+flow **pauses** (T3), it is not marked `:error` like an undeliverable BSP send. This is the core behavioural change and
+belongs in `WebMessage.send_message` + the flow-pause work, not in the shared `create_message`.
+
+**6. HSM & interactive scope.** HSM/template and interactive live **only** on the Gupshup→`messages` stack
+(`is_hsm`+`template_id`, `interactive_content`+`interactive_template_id`); Maytapi groups support only text/media/poll.
+For web (T4), the **interactive path is reusable** (`interactive_content` is channel-neutral jsonb — buttons render in
+the web UI); **HSM/templates are a WhatsApp session-window construct** and likely a no-op on web, though the columns
+exist and won't break. This confirms the T4 rule: all nodes run on web except the WhatsApp-group node.
+
+**7. A third communications context, not a third provider dispatch.** Maytapi is reached via a *hardcoded* context
+(`GroupMessage`) rather than through `provider_handler`. `WebMessage` follows the same shape — a dedicated context that
+calls `Providers.Web.Message` directly — so `provider_handler/1` (which resolves the org's BSP credential) stays
+untouched.
+
+---
+
+*Scope reminder: this map ends at persistence and the `process_message` boundary. The flow engine (how a stored
+inbound message drives a flow, and how flow-driven sends originate) is traced separately in T3.*

--- a/plans/web-channel/web-channel-user-scenarios.md
+++ b/plans/web-channel/web-channel-user-scenarios.md
@@ -1,0 +1,222 @@
+# Glific Web Channel — User Scenarios & Acceptance Criteria
+
+**Purpose:** align the team on **how the web channel behaves** before we write the technical design.
+Each scenario is written as Given / When / Then and grouped by area. These are the target
+behaviours; once we agree on them they become the acceptance criteria the tech design builds toward.
+
+**One-line context:** NGO beneficiaries open a Glific-hosted web page, log in with phone + OTP, and
+chat in a WhatsApp-style window. The conversation is driven by the **same Glific flow engine** and
+appears in the **same staff inbox** as WhatsApp. Contacts are **shared** across channels (one person,
+one contact); the channel is recorded on each message.
+
+---
+
+## 1. Onboarding & authentication
+
+**S1 — Existing WhatsApp contact logs into web**
+- **Given** a contact already exists with phone P (with WhatsApp history)
+- **When** she completes phone + OTP on the web channel with phone P
+- **Then** she is bound to the **same** contact — no duplicate is created — and staff see one unified
+  conversation containing both channels.
+
+**S2 — New contact, web-first**
+- **Given** no contact exists for phone P
+- **When** OTP verification succeeds
+- **Then** the contact is created **at verification** (never merely on OTP request), and the org's
+  new-contact flow triggers on the web channel.
+
+**S3 — OTP requested but never verified**
+- **Given** a phone P with no contact
+- **When** an OTP is requested but never verified
+- **Then** no contact is created, and the OTP request is rate-limited per-phone and per-IP.
+
+**S4 — Consent is per channel; blocking is global**
+- **Given** a contact who has opted out of WhatsApp
+- **When** she opens the web chat she deliberately navigated to
+- **Then** she **can** use the web channel (consent is per-channel). **But** a blocked contact
+  (moderation) **cannot** use web either — blocking applies across all channels.
+
+---
+
+## 2. First load & the chat window
+
+**S5 — Empty chat window on first login**
+- **Given** a contact logs in for the first time with no prior web messages
+- **When** the chat opens
+- **Then** she sees an empty chat window with the **bot's name and logo shown at the top**.
+
+**S6 — Last 50 messages on first load**
+- **Given** a contact with prior web messages
+- **When** the chat opens
+- **Then** the most recent **50** web messages are loaded, newest at the bottom.
+
+**S7 — Scroll up to load older messages, with an end-of-history cue**
+- **Given** the chat is open
+- **When** she scrolls up past the top of the loaded messages
+- **Then** the previous page of older web messages loads; and once the **oldest** message on the
+  channel has been fetched, a **visual cue** indicates there are no more messages (the view no longer
+  scrolls further back).
+
+**S8 — Copy a message**
+- **Given** a message in the chat
+- **When** she uses the copy action (long-press / menu, as in WhatsApp)
+- **Then** the message text is copied to the clipboard.
+
+**S9 — Rich content auto-unravels**
+- **Given** a message (incoming or outgoing) containing a link, a YouTube URL, or an image
+- **When** it renders in the chat
+- **Then** the chat automatically shows a preview/embed — link unfurl, YouTube player/thumbnail,
+  inline image.
+
+**S10 — WhatsApp-style buttons**
+- **Given** a flow sends an interactive message using the same button types available on WhatsApp
+- **When** it renders in the web chat
+- **Then** the buttons appear and the contact can tap one to respond.
+
+**S11 — Record & send a voice note**
+- **Given** the contact is in the chat
+- **When** she records audio with the voice-note control and sends it
+- **Then** the voice note is delivered as a message, appears in the conversation, and is visible in
+  the staff inbox.
+
+**S12 — Typing indicator with escalation (driven by the flow)**
+- **Given** the flow is processing and will send the next message
+- **When** the flow shows the typing indicator
+- **Then** the contact sees a typing indicator; after **25s** it changes to **"taking longer than
+  usual"**; after **45s** it changes to **"any minute now"**. These states are sent/controlled by the
+  flow.
+
+**S13 — Offline banner**
+- **Given** the contact is in the chat
+- **When** the web channel detects there is no connectivity
+- **Then** a banner appears at the top saying **messages might not be sent**; the banner **hides
+  automatically** when connectivity is restored.
+
+**S14 — Install as an app (PWA)**
+- **Given** the contact is using the web channel on iOS or Android
+- **When** she chooses "Add to Home Screen" / install
+- **Then** the web app is saved as an **icon on her device** and launches like an app.
+
+**S15 — Mobile browser coverage**
+- **Given** the range of mobile browsers in use
+- **Then** the web channel **works on 95% of all mobile browsers**, verified by testing.
+
+---
+
+## 3. Cross-channel switching
+
+*Invariant: at most one active flow per contact, regardless of channel.*
+
+**S16 — Web flow active, she replies on WhatsApp (no keyword)**
+- **Given** an active flow on the web channel, parked waiting for a response
+- **When** an inbound WhatsApp message arrives with no keyword match
+- **Then** the web flow does **not** advance (continuation is channel-scoped); the WhatsApp message is
+  recorded; the web flow stays parked and remains resumable on web. **No cross-channel takeover.**
+
+**S17 — Keyword sent on a different channel**
+- **Given** an active flow on the web channel
+- **When** she sends a matching keyword over WhatsApp
+- **Then** the web flow is completed and a new flow starts on WhatsApp.
+
+**S18 — Rapid/simultaneous inbound on both channels (last message wins)**
+- **When** messages arrive on both channels close together
+- **Then** messages are handled in processing order, and the **last-processed message wins** — its
+  channel becomes the contact's current/active channel.
+
+---
+
+## 4. Presence & delivery
+
+**S19 — Outbound while present**
+- **When** a flow (or staff) sends to a **connected** web contact
+- **Then** the message is pushed live over the socket and marked delivered.
+
+**S20 — Outbound while absent (pause)**
+- **When** a flow reaches a send step and the contact is **not** connected
+- **Then** the message is **not** sent and the flow **pauses** at that step. Nothing is queued ahead.
+
+**S21 — Contact returns**
+- **When** the contact reconnects
+- **Then** the paused flow **resumes** from where it stopped and the pending message is delivered.
+
+**S22 — Contact never returns**
+- **Then** the parked flow simply lives out the **standard flow lifetime** — there is no
+  web-specific expiry.
+
+**S23 — Long delays work**
+- **Given** a web flow with a wait/delay step of any duration (hours or days)
+- **Then** it works unchanged — there is no short web expiry that would cut it off.
+
+**S24 — Disconnect with nothing pending**
+- **When** the contact disconnects while the flow is simply waiting for her reply
+- **Then** nothing happens; the flow stays parked and resumes when she returns.
+
+---
+
+## 5. Node behaviour on web
+
+**S25 — All nodes supported except "Update WhatsApp Group"**
+- **Given** a web-channel flow
+- **Then** every flow node behaves as it does on WhatsApp — text, media, images, **voice**,
+  interactive **buttons**, templates — **except "Update WhatsApp Group"**.
+
+**S26 — Unsupported node stops the flow and notifies**
+- **Given** a flow contains an "Update WhatsApp Group" node
+- **When** a contact on the web channel reaches that node
+- **Then** the flow **stops** at that node and a **notification** is raised saying the flow stopped
+  because the node is not supported on web.
+
+**S27 — Contact name is shared, not set on web**
+- **Given** contacts are shared across channels
+- **Then** the web channel shows and uses the **same contact name as WhatsApp** — there is no
+  separate web name and no set-name-on-web behaviour.
+
+---
+
+## 6. Staff inbox
+
+**S28 — Unified timeline**
+- **Then** staff see **one conversation per contact** with all channels merged, and a channel marker
+  where the conversation moves between channels.
+
+**S29 — Reply channel selection**
+- **When** staff reply from the inbox
+- **Then** the composer defaults to the contact's **last channel**, **always shows** which channel it
+  will send on, and is **overridable** in one click.
+
+**S30 — Channel & session indicator by last-seen**
+- **Given** an admin viewing a contact's chat window
+- **When** the contact was **last seen on WhatsApp**
+- **Then** a **WhatsApp icon** shows next to the **session timer** (the 24-hour window)
+- **When** the contact was **last seen on web**
+- **Then** a **web icon** shows with **no timer** — the session window does not apply to web.
+
+---
+
+## 7. Metrics & abuse
+
+**S31 — Daily active user**
+- **Then** a "daily active user" is a contact who **sent** at least one web message that day
+  (received-only does not count).
+
+**S32 — Rate limiting**
+- **Then** per-contact limits apply to messages sent/received, and per-phone + per-IP limits apply to
+  the OTP request endpoint.
+
+---
+
+## 8. Organisation configuration (Settings)
+
+**S33 — Enable the web channel from a "Web" settings page**
+- **Given** an admin in Glific Settings, with a new **"Web"** page shown next to **Gupshup**
+- **When** they open it and click to enable the default web channel
+- **Then** the page shows the **potential (accessible) link** for the org's web channel; on
+  **confirmation** the web channel is activated; and the page then shows a **link to the active web
+  channel**.
+
+---
+
+*Open items to confirm during alignment: exact copy for the typing-indicator states and the offline
+banner; which button types count as "same as WhatsApp"; whether "Update WhatsApp Group" stopping the
+flow should also surface to the end-user or only to staff; and the precise list of browsers behind
+the 95% coverage target.*


### PR DESCRIPTION
Planning/design docs for the Web Channel (Phase 0), pushed for team review. No code changes — docs only.

- web-channel-t1-message-flow-map.md — T1 spike: Gupshup & Maytapi send/receive code map (modules, functions, DB writes) as GitHub-renderable mermaid diagrams
- web-channel-user-scenarios.md — behaviour / acceptance scenarios
- web-channel-backend-breakdown.md — modules & files touched
- web-channel-schema-and-bigquery.md — schema + BigQuery warehouse impact
- web-channel-auth-research.md — embeddable-widget auth research

Refs #5443, #5444 