### PR TITLE
 fix(translate): friendlier, provider-agnostic translation error handling

### DIFF
--- a/lib/glific/flows/translate/google_translate.ex
+++ b/lib/glific/flows/translate/google_translate.ex
@@ -4,12 +4,17 @@ defmodule Glific.Flows.Translate.GoogleTranslate do
   """
   @behaviour Glific.Flows.Translate.Translate
 
+  require Logger
+
   alias Glific.{
     Flows.Translate.Translate,
     Flows.Translate.TranslateLog,
     GoogleTranslate,
     Settings
   }
+
+  # Google flags an unsupported target language with a 400 whose message is one of these.
+  @unsupported_language_errors ["Bad language pair", "Invalid Value"]
 
   @doc """
   Translate a list of strings from language 'src' to language 'dst'.
@@ -102,13 +107,21 @@ defmodule Glific.Flows.Translate.GoogleTranslate do
         }
         |> TranslateLog.create_translate_log()
 
-        Glific.log_error(
-          "Google Translate failed for org #{org_id} (#{languages["src"]} -> #{languages["dst"]}): #{error}",
-          true
-        )
+        translate_error(error, languages, org_id)
+    end
+  end
 
-        {:error,
-         "Translation has failed. Please reach out to the Glific team as soon as possible."}
+  @spec translate_error(String.t(), map(), non_neg_integer()) :: {:error, String.t()}
+  defp translate_error(error, languages, org_id) do
+    log =
+      "Translation failed for org #{org_id} (#{languages["src"]} -> #{languages["dst"]}): #{error}"
+
+    if Enum.any?(@unsupported_language_errors, &String.contains?(error, &1)) do
+      Logger.warning(log)
+      {:error, "Auto-translation is not supported for #{languages["dst"]}."}
+    else
+      Glific.log_error(log)
+      {:error, "Translation failed. Please try again or contact the Glific team."}
     end
   end
 end

--- a/test/glific/flows/translate/google_translate_test.exs
+++ b/test/glific/flows/translate/google_translate_test.exs
@@ -125,11 +125,11 @@ defmodule Glific.Flows.Translate.GoogleTranslateTest do
     dst = "hindi"
 
     assert {:error, reason} = GoogleTranslate.translate(string, src, dst, org_id: org_id)
-    assert reason =~ "Translation has failed"
-    assert reason =~ "reach out to the Glific team"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
   end
 
-  test "translate/3 returns the generic failure message, not the raw Google 403 API_KEY_SERVICE_BLOCKED detail" do
+  test "translate/3 returns a generic failure message on a hard API failure" do
     org_id = Fixtures.get_org_id()
 
     Tesla.Mock.mock_global(fn _env ->
@@ -154,8 +154,50 @@ defmodule Glific.Flows.Translate.GoogleTranslateTest do
                org_id: org_id
              )
 
-    assert reason =~ "Translation has failed"
-    assert reason =~ "reach out to the Glific team"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
+  end
+
+  test "translate/3 returns an unsupported-language message for a Bad language pair error" do
+    org_id = Fixtures.get_org_id()
+
+    Tesla.Mock.mock_global(fn _env ->
+      %Tesla.Env{
+        status: 400,
+        body: %{"error" => %{"message" => "Bad language pair: en|gon"}}
+      }
+    end)
+
+    on_exit(fn -> Tesla.Mock.mock_global(&default_mock/1) end)
+
+    assert {:error, reason} =
+             GoogleTranslate.translate(["Some text to translate"], "english", "gondi",
+               org_id: org_id
+             )
+
+    assert reason =~ "not supported"
+    refute reason =~ ~r/google/i
+  end
+
+  test "translate/3 returns an unsupported-language message for an Invalid Value error" do
+    org_id = Fixtures.get_org_id()
+
+    Tesla.Mock.mock_global(fn _env ->
+      %Tesla.Env{
+        status: 400,
+        body: %{"error" => %{"message" => "Invalid Value"}}
+      }
+    end)
+
+    on_exit(fn -> Tesla.Mock.mock_global(&default_mock/1) end)
+
+    assert {:error, reason} =
+             GoogleTranslate.translate(["Some text to translate"], "english", "Sign Language",
+               org_id: org_id
+             )
+
+    assert reason =~ "not supported"
+    refute reason =~ ~r/google/i
   end
 
   test "check_large_strings/1 handles mix of short and long strings" do

--- a/test/glific/flows/translate_test.exs
+++ b/test/glific/flows/translate_test.exs
@@ -89,7 +89,6 @@ defmodule Glific.Flows.TranslateTest do
 
   test "export_localization/2 with add_translation false leaves the newly added translations blank",
        attrs do
-
     flow = Flows.get_complete_flow(attrs.organization_id, @help_flow_id)
     Flows.update_cached_flow(flow, "draft")
     flow = Flows.get_complete_flow(attrs.organization_id, @help_flow_id)
@@ -135,7 +134,8 @@ defmodule Glific.Flows.TranslateTest do
     flow = Flows.get_complete_flow(attrs.organization_id, @help_flow_id)
 
     assert {:error, reason} = Export.translate(flow)
-    assert reason =~ "Translation has failed"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
 
     flow_after = Flows.get_complete_flow(attrs.organization_id, @help_flow_id)
     assert map_size(flow_after.definition["localization"]["hi"]) == 1

--- a/test/glific/interactive_templates_test.exs
+++ b/test/glific/interactive_templates_test.exs
@@ -610,8 +610,8 @@ defmodule Glific.InteractiveTemplatesTest do
     on_exit(fn -> Tesla.Mock.mock_global(&default_translate_mock/1) end)
 
     assert {:error, reason} = InteractiveTemplates.translate_interactive_template(interactive)
-    assert reason =~ "Translation has failed"
-    assert reason =~ "reach out to the Glific team"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
 
     reloaded = InteractiveTemplates.get_interactive_template!(interactive.id)
     assert reloaded.translations == interactive.translations
@@ -628,7 +628,8 @@ defmodule Glific.InteractiveTemplatesTest do
     on_exit(fn -> Tesla.Mock.mock_global(&default_translate_mock/1) end)
 
     assert {:error, reason} = InteractiveTemplates.translate_interactive_template(interactive)
-    assert reason =~ "Translation has failed"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
 
     reloaded = InteractiveTemplates.get_interactive_template!(interactive.id)
     assert reloaded.translations == interactive.translations
@@ -645,7 +646,8 @@ defmodule Glific.InteractiveTemplatesTest do
     on_exit(fn -> Tesla.Mock.mock_global(&default_translate_mock/1) end)
 
     assert {:error, reason} = InteractiveTemplates.translate_interactive_template(interactive)
-    assert reason =~ "Translation has failed"
+    assert reason =~ "Translation failed"
+    refute reason =~ ~r/google/i
 
     reloaded = InteractiveTemplates.get_interactive_template!(interactive.id)
     assert reloaded.translations == interactive.translations


### PR DESCRIPTION
## Summary

### Why

When auto-translation failed, the UI always showed the same generic "Translation has failed. Please reach out to the Glific team…" — regardless of cause. Two problems:
1. Unsupported languages (e.g. Gondi, Sign Language) aren't a fault — Google simply can't translate them — yet they were logged as errors and paged AppSignal, creating noise for something no one can fix.
2. Error messages risked exposing the underlying provider and raw API detail to end users.

### What changed

Refactored the error path in Glific.Flows.Translate.GoogleTranslate into a translate_error/3 helper that classifies the failure:

- Unsupported target language — Google returns a 400 with Bad language pair or Invalid Value (captured in @unsupported_language_errors):
  - UI message → "Auto-translation is not supported for <language>."
  - Logged at Logger.warning (no AppSignal page — it's an inherent limitation, not a fault).
- All other failures (auth/config issues, 5xx, timeouts, etc.):
  - UI message → "Translation failed. Please try again or contact the Glific team."
  - Logged via Glific.log_error/1 (still reports to AppSignal).
- No provider name or raw API detail is ever surfaced to end usror is still recorded internally (logs + TranslateLog).

This applies everywhere translation runs through this module —  and template/interactive-template translation.

