### PR TITLE
Refactor: Code quality cleanup — moduledocs + Ecto.Query imports

### DIFF
--- a/lib/glific/access_control.ex
+++ b/lib/glific/access_control.ex
@@ -3,8 +3,7 @@ defmodule Glific.AccessControl do
   The AccessControl context.
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Flags, Partners, Repo, Users.User}
 
   alias Glific.AccessControl.{

--- a/lib/glific/access_control/flow_role.ex
+++ b/lib/glific/access_control/flow_role.ex
@@ -4,8 +4,7 @@ defmodule Glific.AccessControl.FlowRole do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/access_control/group_role.ex
+++ b/lib/glific/access_control/group_role.ex
@@ -4,8 +4,7 @@ defmodule Glific.AccessControl.GroupRole do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/access_control/trigger_role.ex
+++ b/lib/glific/access_control/trigger_role.ex
@@ -4,8 +4,7 @@ defmodule Glific.AccessControl.TriggerRole do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/accounts.ex
+++ b/lib/glific/accounts.ex
@@ -2,8 +2,6 @@ defmodule Glific.Accounts do
   @moduledoc """
   The Accounts context.
   """
-
-  import Ecto.Query, warn: false
   alias Glific.Repo
 
   alias Glific.Users.User

--- a/lib/glific/ask_glific.ex
+++ b/lib/glific/ask_glific.ex
@@ -3,8 +3,7 @@ defmodule Glific.AskGlific do
   Glific AskGlific context module for business logic.
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.AskGlific.Conversation
   alias Glific.Dify.ApiClient
   alias Glific.Repo

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -854,8 +854,8 @@ defmodule Glific.Assistants do
       - callback_url: Optional. URL to call for transformation status updates
 
   ## Returns
-    - {:ok, %{file_id: string, filename: string}}
-    - {:error, reason}
+    - `{:ok, %{file_id: string, filename: string}}`
+    - `{:error, reason}`
   """
   @spec upload_file(map(), non_neg_integer()) ::
           {:ok, map()} | {:error, String.t()}

--- a/lib/glific/chatbot_diagnose.ex
+++ b/lib/glific/chatbot_diagnose.ex
@@ -5,7 +5,7 @@ defmodule Glific.ChatbotDiagnose do
   against the database with organization scoping, and returns results.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/clients/balajanaagraha.ex
+++ b/lib/glific/clients/balajanaagraha.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.Balajanaagraha do
   @moduledoc """
   Custom webhook implementation specific to balajanaagraha usecase
   """
-
-  import Ecto.Query, warn: false
-
   alias Glific.{
     Contacts,
     Flows.ContactField

--- a/lib/glific/clients/bandhu.ex
+++ b/lib/glific/clients/bandhu.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.Bandhu do
   @moduledoc """
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
-
-  import Ecto.Query, warn: false
-
   @housing_url "https://housing.bandhumember.work/api/housing/create_sql_glific_query"
 
   @doc """

--- a/lib/glific/clients/digital_green.ex
+++ b/lib/glific/clients/digital_green.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.DigitalGreen do
   @moduledoc """
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
-
-  import Ecto.Query, warn: false
-
   require Logger
 
   alias Glific.{

--- a/lib/glific/clients/kef.ex
+++ b/lib/glific/clients/kef.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.KEF do
   @moduledoc """
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
-
-  import Ecto.Query, warn: false
-
   require Logger
 
   alias Glific.{

--- a/lib/glific/clients/lahi.ex
+++ b/lib/glific/clients/lahi.ex
@@ -7,7 +7,7 @@ defmodule Glific.Clients.Lahi do
     Repo
   }
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   @doc """
   Tweak GCS Bucket name based Lahi usecase

--- a/lib/glific/clients/mukkamaar.ex
+++ b/lib/glific/clients/mukkamaar.ex
@@ -2,7 +2,7 @@ defmodule Glific.Clients.MukkaMaar do
   @moduledoc """
   Custom webhook implementation specific to MukkaMaar usecase
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
   alias GoogleApi.BigQuery.V2.Api.Jobs
 
   alias Glific.{

--- a/lib/glific/clients/reap_benefit.ex
+++ b/lib/glific/clients/reap_benefit.ex
@@ -3,7 +3,7 @@ defmodule Glific.Clients.ReapBenefit do
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Flows.Flow,

--- a/lib/glific/clients/sarc.ex
+++ b/lib/glific/clients/sarc.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.Sarc do
   @moduledoc """
   Tweak GCS Bucket name based on group that the contact is in (if any) for SArC
   """
-
-  import Ecto.Query, warn: false
-
   alias Glific.{
     Contacts,
     Repo

--- a/lib/glific/clients/sol.ex
+++ b/lib/glific/clients/sol.ex
@@ -2,9 +2,6 @@ defmodule Glific.Clients.Sol do
   @moduledoc """
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
-
-  import Ecto.Query, warn: false
-
   alias Glific.{
     Contacts,
     Partners,

--- a/lib/glific/clients/stir.ex
+++ b/lib/glific/clients/stir.ex
@@ -14,7 +14,7 @@ defmodule Glific.Clients.Stir do
     Repo
   }
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   @priorities_list [
     {

--- a/lib/glific/clients/tap.ex
+++ b/lib/glific/clients/tap.ex
@@ -3,7 +3,7 @@ defmodule Glific.Clients.Tap do
   Tweak GCS Bucket name based on group that the contact is in (if any)
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts.Contact,

--- a/lib/glific/clients/udhyam.ex
+++ b/lib/glific/clients/udhyam.ex
@@ -2,7 +2,7 @@ defmodule Glific.Clients.Udhyam do
   @moduledoc """
   Custom implementation for Udhyam
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Flows.Flow,

--- a/lib/glific/clients/weunlearn.ex
+++ b/lib/glific/clients/weunlearn.ex
@@ -1,7 +1,7 @@
 defmodule Glific.Clients.Weunlearn do
   @moduledoc false
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts.Contact,

--- a/lib/glific/contacts.ex
+++ b/lib/glific/contacts.ex
@@ -2,7 +2,7 @@ defmodule Glific.Contacts do
   @moduledoc """
   The Contacts context.
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
 
   use Tesla

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -2,8 +2,7 @@ defmodule Glific.Contacts.Import do
   @moduledoc """
   The Contact Importer Module
   """
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.Settings.Language
   alias GlificWeb.Schema.Middleware.Authorize
 

--- a/lib/glific/conversations.ex
+++ b/lib/glific/conversations.ex
@@ -9,8 +9,7 @@ defmodule Glific.Conversations do
   use Ecto.Schema
   require Logger
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Contacts.Contact, Messages, Messages.Message, Repo, Search.Full}
 
   @doc """

--- a/lib/glific/conversations_group.ex
+++ b/lib/glific/conversations_group.ex
@@ -8,7 +8,7 @@ defmodule Glific.ConversationsGroup do
 
   use Ecto.Schema
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Conversations,

--- a/lib/glific/extensions/extension.ex
+++ b/lib/glific/extensions/extension.ex
@@ -5,8 +5,6 @@ defmodule Glific.Extensions.Extension do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -3,7 +3,7 @@ defmodule Glific.Flows do
   The Flows context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
 
   require Logger

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -6,7 +6,7 @@ defmodule Glific.Flows.Action do
   alias __MODULE__
 
   use Ecto.Schema
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts,

--- a/lib/glific/flows/broadcast.ex
+++ b/lib/glific/flows/broadcast.ex
@@ -6,8 +6,7 @@ defmodule Glific.Flows.Broadcast do
 
   use Publicist
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/flows/broadcast/message_broadcast.ex
+++ b/lib/glific/flows/broadcast/message_broadcast.ex
@@ -8,7 +8,6 @@ defmodule Glific.Flows.MessageBroadcast do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
   require Logger
 
   alias Glific.{

--- a/lib/glific/flows/broadcast/message_broadcast_contact.ex
+++ b/lib/glific/flows/broadcast/message_broadcast_contact.ex
@@ -8,7 +8,6 @@ defmodule Glific.Flows.MessageBroadcastContact do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
   require Logger
 
   alias Glific.{

--- a/lib/glific/flows/contact_field.ex
+++ b/lib/glific/flows/contact_field.ex
@@ -3,7 +3,7 @@ defmodule Glific.Flows.ContactField do
   Since many of the functions set/update fields in contact and related tables, lets
   centralize all the code here for now
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
   import Ecto.Changeset
 
   alias Glific.{

--- a/lib/glific/flows/expression.ex
+++ b/lib/glific/flows/expression.ex
@@ -16,7 +16,8 @@ defmodule Glific.Flows.Expression do
   2. **Interpret, don't eval.** We never call `Code.eval_quoted/2`. A syntactic
      allowlist over the *pre-expansion* AST is unsound, because `alias` rebinds
      names during macro expansion: `alias System, as: Timex` makes a hostile
-     `Timex.cmd/2` node byte-identical to a legitimate `Timex.today/0` node.
+     call to `System.cmd/2` byte-identical, post-expansion, to a legitimate
+     call to `Timex.today/0`.
      Validating one representation and executing another is the bug. We walk and
      execute the same tree.
   3. **Fail closed.** `eval_node/2` implements only the allowed node types. `alias`,

--- a/lib/glific/flows/flow.ex
+++ b/lib/glific/flows/flow.ex
@@ -7,7 +7,7 @@ defmodule Glific.Flows.Flow do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     AccessControl.Role,

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -9,7 +9,7 @@ defmodule Glific.Flows.FlowContext do
   use Gettext, backend: GlificWeb.Gettext
 
   import Ecto.Changeset
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias __MODULE__

--- a/lib/glific/flows/flow_count.ex
+++ b/lib/glific/flows/flow_count.ex
@@ -5,7 +5,7 @@ defmodule Glific.Flows.FlowCount do
   use Ecto.Schema
   import Ecto.Changeset
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/flows/flow_label.ex
+++ b/lib/glific/flows/flow_label.ex
@@ -5,8 +5,7 @@ defmodule Glific.Flows.FlowLabel do
   use Ecto.Schema
   import Ecto.Changeset
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/flows/translate/translate_log.ex
+++ b/lib/glific/flows/translate/translate_log.ex
@@ -2,7 +2,6 @@ defmodule Glific.Flows.Translate.TranslateLog do
   @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/flows/webhook/header_redactor.ex
+++ b/lib/glific/flows/webhook/header_redactor.ex
@@ -11,7 +11,7 @@ defmodule Glific.Flows.Webhook.HeaderRedactor do
 
   We cannot allow-list header *names*, because a flow author can name a header
   anything. So redaction is driven by two independent signals, applied centrally
-  in `Glific.Flows.Webhook.create_log/4` so every webhook path is covered:
+  in `Glific.Flows.Webhooks.Request.create_log/4` so every webhook path is covered:
 
     1. **Key name** — the header name matches a well-known credential name
        (`authorization`, `x-api-key`, `*-token`, `secret`, `cookie`, …).

--- a/lib/glific/flows/webhook_log.ex
+++ b/lib/glific/flows/webhook_log.ex
@@ -5,8 +5,7 @@ defmodule Glific.Flows.WebhookLog do
   use Ecto.Schema
   import Ecto.Changeset
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.Groups.WAGroup
   alias __MODULE__
 

--- a/lib/glific/flows/webhooks/core/registry.ex
+++ b/lib/glific/flows/webhooks/core/registry.ex
@@ -3,10 +3,10 @@ defmodule Glific.Flows.Webhooks.Registry do
   Maps a webhook's name string (as it appears in flow JSON URLs) to the
   module that implements `Glific.Flows.Webhooks.Behaviour` for it.
 
-  Every flow-webhook node is registered here and routed to its `Glific.Flows.Webhooks`
-  implementation module by `Glific.Flows.Webhook.dispatch_function/3` → `Dispatcher.dispatch/3`.
-  Org-specific webhook functions (per-org client modules) fall through to
-  `Glific.Clients.webhook/2` instead.
+  Every flow-webhook node is registered here and routed, via `Glific.Flows.Webhook`'s
+  internal dispatch, to its `Glific.Flows.Webhooks` implementation module through
+  `Dispatcher.dispatch/3`. Org-specific webhook functions (per-org client modules)
+  fall through to `Glific.Clients.webhook/2` instead.
 
   ## Why Registry is separate from Dispatcher
 

--- a/lib/glific/groups.ex
+++ b/lib/glific/groups.ex
@@ -2,8 +2,7 @@ defmodule Glific.Groups do
   @moduledoc """
   The Groups context.
   """
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/groups/contact_groups.ex
+++ b/lib/glific/groups/contact_groups.ex
@@ -12,8 +12,7 @@ defmodule Glific.Groups.ContactGroups do
   }
 
   use Ecto.Schema
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   @primary_key false
 
   @type t() :: %__MODULE__{

--- a/lib/glific/groups/contact_wa_groups.ex
+++ b/lib/glific/groups/contact_wa_groups.ex
@@ -16,8 +16,7 @@ defmodule Glific.Groups.ContactWAGroups do
   }
 
   use Ecto.Schema
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   @primary_key false
 
   @type t() :: %__MODULE__{

--- a/lib/glific/groups/group_contacts.ex
+++ b/lib/glific/groups/group_contacts.ex
@@ -8,8 +8,6 @@ defmodule Glific.Groups.GroupContacts do
   alias Glific.{Groups, Groups.ContactGroup}
 
   use Ecto.Schema
-  import Ecto.Query, warn: false
-
   @primary_key false
 
   @type t() :: %__MODULE__{

--- a/lib/glific/groups/wa_groups.ex
+++ b/lib/glific/groups/wa_groups.ex
@@ -2,8 +2,7 @@ defmodule Glific.Groups.WAGroups do
   @moduledoc """
   Whatsapp groups context.
   """
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/groups/wa_groups_collections.ex
+++ b/lib/glific/groups/wa_groups_collections.ex
@@ -10,8 +10,7 @@ defmodule Glific.Groups.WaGroupsCollections do
   }
 
   use Ecto.Schema
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   @primary_key false
 
   @type t() :: %__MODULE__{

--- a/lib/glific/jobs.ex
+++ b/lib/glific/jobs.ex
@@ -2,7 +2,7 @@ defmodule Glific.Jobs do
   @moduledoc """
   The Jobs context.
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     BigQuery.BigQueryJob,

--- a/lib/glific/jobs/user_jobs.ex
+++ b/lib/glific/jobs/user_jobs.ex
@@ -2,7 +2,7 @@ defmodule Glific.Jobs.UserJob do
   @moduledoc false
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/mails/mail_log.ex
+++ b/lib/glific/mails/mail_log.ex
@@ -5,8 +5,7 @@ defmodule Glific.Mails.MailLog do
   use Ecto.Schema
   import Ecto.Changeset
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -2,7 +2,7 @@ defmodule Glific.Messages do
   @moduledoc """
   The Messages context.
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
 
   require Logger

--- a/lib/glific/messages/message.ex
+++ b/lib/glific/messages/message.ex
@@ -1,5 +1,9 @@
 defmodule Glific.Messages.Message do
-  @moduledoc false
+  @moduledoc """
+  The schema for a single inbound or outbound WhatsApp message: its content, media/location
+  attachments, delivery status, and links to the sender/receiver contacts, session template,
+  flow, and group it belongs to.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/glific/notifications.ex
+++ b/lib/glific/notifications.ex
@@ -3,7 +3,7 @@ defmodule Glific.Notifications do
   The notifications manager and API to interface with the notification sub-system
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias Glific.Mails.MailLog

--- a/lib/glific/notifications/notification.ex
+++ b/lib/glific/notifications/notification.ex
@@ -1,11 +1,12 @@
 defmodule Glific.Notifications.Notification do
-  @moduledoc false
+  @moduledoc """
+  The schema for an in-app notification surfaced to org admins — a category, severity,
+  free-form message, and the entity (as a map) the notification is about.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 
   alias __MODULE__
-  import Ecto.Query, warn: false
-
   alias Glific.{Partners.Organization}
 
   @type t() :: %__MODULE__{

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -15,7 +15,7 @@ defmodule Glific.Partners do
 
   use Publicist
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
   require Logger
 
@@ -1479,8 +1479,7 @@ defmodule Glific.Partners do
       "ticketing_enabled" => Flags.get_ticketing_enabled(organization),
       "whatsapp_group_enabled" => Flags.get_whatsapp_group_enabled(organization),
       "whatsapp_forms_enabled" => Flags.get_whatsapp_forms_enabled?(organization),
-      "auto_translation_enabled" =>
-        Flags.get_google_auto_translation_enabled(organization),
+      "auto_translation_enabled" => Flags.get_google_auto_translation_enabled(organization),
       "certificate_enabled" => Flags.get_certificate_enabled(organization),
       "interactive_re_response_enabled" =>
         Flags.get_interactive_re_response_enabled(organization),

--- a/lib/glific/partners/billing.ex
+++ b/lib/glific/partners/billing.ex
@@ -7,7 +7,7 @@ defmodule Glific.Partners.Billing do
   use Ecto.Schema
   use Publicist
   import Ecto.Changeset
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
 
   alias __MODULE__

--- a/lib/glific/partners/invoice.ex
+++ b/lib/glific/partners/invoice.ex
@@ -4,7 +4,7 @@ defmodule Glific.Partners.Invoice do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Gettext, backend: GlificWeb.Gettext
 
   alias Glific.{Partners.Billing, Partners.Organization, Repo}

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -4,8 +4,7 @@ defmodule Glific.Partners.Organization do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/partners/organization_data.ex
+++ b/lib/glific/partners/organization_data.ex
@@ -1,5 +1,8 @@
 defmodule Glific.Partners.OrganizationData do
-  @moduledoc false
+  @moduledoc """
+  A generic key/value store scoped to an organization, used to persist ad-hoc
+  data (JSON or text) against a `key` without needing a dedicated schema/migration.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/glific/partners/saas.ex
+++ b/lib/glific/partners/saas.ex
@@ -5,8 +5,7 @@ defmodule Glific.Partners.Saas do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{Partners.Organization, Repo}

--- a/lib/glific/password_migration.ex
+++ b/lib/glific/password_migration.ex
@@ -4,8 +4,7 @@ defmodule Glific.PasswordMigration do
   We will remove this migration soon or may be move this file to priv migration directory
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.Repo
   alias Glific.Users.User
   alias Pbkdf2.Base64

--- a/lib/glific/processor/consumer_flow.ex
+++ b/lib/glific/processor/consumer_flow.ex
@@ -4,8 +4,6 @@ defmodule Glific.Processor.ConsumerFlow do
   consumer_worker which is the main workhorse
   """
   @dialyzer {:nowarn_function, context_nil?: 1}
-  import Ecto.Query, warn: false
-
   alias Glific.{
     Contacts.Contact,
     Flows,

--- a/lib/glific/profiles.ex
+++ b/lib/glific/profiles.ex
@@ -3,7 +3,7 @@ defmodule Glific.Profiles do
   The Profiles context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -12,7 +12,6 @@ defmodule Glific.Providers.Gupshup.Message do
     Repo
   }
 
-  import Ecto.Query, warn: false
   require Logger
 
   @channel "whatsapp"

--- a/lib/glific/providers/instrumentation.ex
+++ b/lib/glific/providers/instrumentation.ex
@@ -42,8 +42,7 @@ defmodule Glific.Providers.Instrumentation do
   silence check.
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Messages.Message, Repo}
 
   # No inbound message across the whole platform within this window is treated as

--- a/lib/glific/providers/maytapi/message.ex
+++ b/lib/glific/providers/maytapi/message.ex
@@ -2,9 +2,6 @@ defmodule Glific.Providers.Maytapi.Message do
   @moduledoc """
   Message API layer between application and Maytapi
   """
-
-  import Ecto.Query, warn: false
-
   require Logger
 
   alias Glific.{

--- a/lib/glific/providers/maytapi/wa_worker.ex
+++ b/lib/glific/providers/maytapi/wa_worker.ex
@@ -2,8 +2,6 @@ defmodule Glific.Providers.Maytapi.WAWorker do
   @moduledoc """
   A worker to handle send message in whatsapp group processes
   """
-  import Ecto.Query, warn: false
-
   use Oban.Worker,
     queue: :wa_group,
     max_attempts: 2,

--- a/lib/glific/reports.ex
+++ b/lib/glific/reports.ex
@@ -3,7 +3,7 @@ defmodule Glific.Reports do
   The Reports context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     BigQuery.BigQueryJob,

--- a/lib/glific/saas/consulting_hour.ex
+++ b/lib/glific/saas/consulting_hour.ex
@@ -5,8 +5,7 @@ defmodule Glific.Saas.ConsultingHour do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias __MODULE__
 
   alias Glific.{

--- a/lib/glific/saas/onboard.ex
+++ b/lib/glific/saas/onboard.ex
@@ -7,7 +7,7 @@ defmodule Glific.Saas.Onboard do
 
   require Logger
   use Gettext, backend: GlificWeb.Gettext
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Communications.Mailer,

--- a/lib/glific/saas/queries.ex
+++ b/lib/glific/saas/queries.ex
@@ -3,8 +3,7 @@ defmodule Glific.Saas.Queries do
   Lets keep all the onboarding queries and validation here
   """
   use Gettext, backend: GlificWeb.Gettext
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/searches.ex
+++ b/lib/glific/searches.ex
@@ -3,7 +3,7 @@ defmodule Glific.Searches do
   The Searches context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias __MODULE__

--- a/lib/glific/searches/collection_count.ex
+++ b/lib/glific/searches/collection_count.ex
@@ -3,8 +3,7 @@ defmodule Glific.Searches.CollectionCount do
   Module for checking collection count
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   use Publicist
 
   alias Glific.{

--- a/lib/glific/seeds/seeds_flows.ex
+++ b/lib/glific/seeds/seeds_flows.ex
@@ -1,8 +1,7 @@
 defmodule Glific.Seeds.SeedsFlows do
   @moduledoc false
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/settings.ex
+++ b/lib/glific/settings.ex
@@ -2,7 +2,7 @@ defmodule Glific.Settings do
   @moduledoc """
   The Settings context. This includes language for now.
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Partners,

--- a/lib/glific/state/flow.ex
+++ b/lib/glific/state/flow.ex
@@ -4,7 +4,7 @@ defmodule Glific.State.Flow do
   a flow at a time
   """
   require Logger
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Flows.Flow,

--- a/lib/glific/state/simulator.ex
+++ b/lib/glific/state/simulator.ex
@@ -3,7 +3,7 @@ defmodule Glific.State.Simulator do
   Manage simulator state and allocation to ensure we can have multiple simulators
   run at the same time
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts,

--- a/lib/glific/state/state.ex
+++ b/lib/glific/state/state.ex
@@ -9,7 +9,6 @@ defmodule Glific.State do
   use GenServer
 
   require Logger
-  import Ecto.Query, warn: false
 
   alias Glific.{
     Communications,

--- a/lib/glific/stats.ex
+++ b/lib/glific/stats.ex
@@ -3,8 +3,7 @@ defmodule Glific.Stats do
   The stats manager and API to interface with the stat sub-system
   """
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   use Publicist
 
   alias Glific.{

--- a/lib/glific/stats/stat.ex
+++ b/lib/glific/stats/stat.ex
@@ -1,11 +1,12 @@
 defmodule Glific.Stats.Stat do
-  @moduledoc false
+  @moduledoc """
+  The schema for a single rolled-up usage snapshot (contacts, messages, flows, active
+  users, …) for an organization over a given `period` (hour/day/week/month).
+  """
   use Ecto.Schema
   import Ecto.Changeset
 
   alias __MODULE__
-  import Ecto.Query, warn: false
-
   alias Glific.{Partners.Organization}
 
   @type t() :: %__MODULE__{

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -2,8 +2,7 @@ defmodule Glific.Templates do
   @moduledoc """
   The Templates context.
   """
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   use Tesla
   plug(Tesla.Middleware.FormUrlencoded)
 

--- a/lib/glific/templates/interactive_template.ex
+++ b/lib/glific/templates/interactive_template.ex
@@ -1,5 +1,9 @@
 defmodule Glific.Templates.InteractiveTemplate do
-  @moduledoc false
+  @moduledoc """
+  The schema for an interactive message template (quick reply, list, or location
+  request) — its `type`, the provider-specific `interactive_content` payload, and
+  translations.
+  """
   use Ecto.Schema
   import Ecto.Changeset
   alias __MODULE__

--- a/lib/glific/templates/interactive_templates.ex
+++ b/lib/glific/templates/interactive_templates.ex
@@ -11,7 +11,7 @@ defmodule Glific.Templates.InteractiveTemplates do
     Templates.InteractiveTemplate
   }
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   @doc """
   Returns the list of interactive templates

--- a/lib/glific/templates/session_templates.ex
+++ b/lib/glific/templates/session_templates.ex
@@ -1,5 +1,8 @@
 defmodule Glific.Templates.SessionTemplate do
-  @moduledoc false
+  @moduledoc """
+  The schema for a reusable message template (including BSP-approved HSM templates) —
+  its body, parameters, buttons, approval status, and translations.
+  """
   use Ecto.Schema
   import Ecto.Changeset
   alias __MODULE__

--- a/lib/glific/third_party/dialogflow/intent.ex
+++ b/lib/glific/third_party/dialogflow/intent.ex
@@ -6,8 +6,7 @@ defmodule Glific.Dialogflow.Intent do
 
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Partners.Organization, Repo}
 
   @required_fields [:name, :organization_id]

--- a/lib/glific/third_party/sheets/sheets.ex
+++ b/lib/glific/third_party/sheets/sheets.ex
@@ -3,7 +3,7 @@ defmodule Glific.Sheets do
   The Sheets context
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias Ecto.Multi

--- a/lib/glific/tickets.ex
+++ b/lib/glific/tickets.ex
@@ -3,7 +3,7 @@ defmodule Glific.Tickets do
   The Tickets context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts.Contact,

--- a/lib/glific/trackers.ex
+++ b/lib/glific/trackers.ex
@@ -3,7 +3,7 @@ defmodule Glific.Trackers do
   The Trackers context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Partners.Saas,

--- a/lib/glific/trackers/tracker.ex
+++ b/lib/glific/trackers/tracker.ex
@@ -4,8 +4,6 @@ defmodule Glific.Trackers.Tracker do
   """
   use Ecto.Schema
   import Ecto.Changeset
-  import Ecto.Query, warn: false
-
   alias __MODULE__
 
   alias Glific.Partners.Organization

--- a/lib/glific/triggers.ex
+++ b/lib/glific/triggers.ex
@@ -4,7 +4,7 @@ defmodule Glific.Triggers do
   within Glific
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
   require Logger
 
   alias Glific.{

--- a/lib/glific/triggers/trigger.ex
+++ b/lib/glific/triggers/trigger.ex
@@ -1,10 +1,12 @@
 defmodule Glific.Triggers.Trigger do
-  @moduledoc false
+  @moduledoc """
+  The schema for a scheduled flow trigger — when a `Flow` should start (once or on a
+  repeating frequency/day/hour schedule) and which groups/contacts it targets.
+  """
   use Ecto.Schema
   import Ecto.Changeset
 
   alias __MODULE__
-  import Ecto.Query, warn: false
 
   alias Glific.{
     AccessControl.Role,

--- a/lib/glific/users.ex
+++ b/lib/glific/users.ex
@@ -7,7 +7,7 @@ defmodule Glific.Users do
     repo: Glific.Repo,
     user: Glific.Users.User
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     AccessControl.Role,

--- a/lib/glific/users/user.ex
+++ b/lib/glific/users/user.ex
@@ -1,5 +1,9 @@
 defmodule Glific.Users.User do
-  @moduledoc false
+  @moduledoc """
+  The schema for a Glific staff user (as opposed to a `Contact`, who is a message
+  recipient) — login credentials via Pow, roles, and the `Contact`/`Organization`
+  they're linked to.
+  """
   use Ecto.Schema
   use Pow.Ecto.Schema, user_id_field: :phone
 

--- a/lib/glific/wa_conversations.ex
+++ b/lib/glific/wa_conversations.ex
@@ -6,8 +6,7 @@ defmodule Glific.WAConversations do
 
   require Logger
 
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Groups.WAGroup, Repo, WAGroup.WAMessage, WAMessages}
 
   @doc """

--- a/lib/glific/wa_group/wa_message.ex
+++ b/lib/glific/wa_group/wa_message.ex
@@ -1,7 +1,10 @@
 defmodule Glific.WAGroup.WAMessage do
-  @moduledoc false
+  @moduledoc """
+  The schema for a message sent or received within a WhatsApp group (as opposed to
+  `Glific.Messages.Message`, which covers 1:1 conversations) — content, poll/reaction
+  data, delivery status, and links to the `WAGroup`, contact, and managed phone involved.
+  """
   use Ecto.Schema
-  import Ecto.Query, warn: false
   alias Glific.Contacts.Location
   alias __MODULE__
 

--- a/lib/glific/wa_group/wa_poll.ex
+++ b/lib/glific/wa_group/wa_poll.ex
@@ -1,5 +1,8 @@
 defmodule Glific.WAGroup.WaPoll do
-  @moduledoc false
+  @moduledoc """
+  The schema for a poll sent to a WhatsApp group — its label, poll options
+  (`poll_content`), and whether multiple answers are allowed.
+  """
   use Ecto.Schema
   import Ecto.Changeset
   alias __MODULE__

--- a/lib/glific/wa_group/wa_reaction.ex
+++ b/lib/glific/wa_group/wa_reaction.ex
@@ -1,7 +1,6 @@
 defmodule Glific.WAGroup.WaReaction do
   @moduledoc false
   use Ecto.Schema
-  import Ecto.Query, warn: false
   import Ecto.Changeset
 
   alias Glific.{

--- a/lib/glific/wa_managed_phones.ex
+++ b/lib/glific/wa_managed_phones.ex
@@ -3,7 +3,7 @@ defmodule Glific.WAManagedPhones do
   The WAGroup context.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts,

--- a/lib/glific/wa_poll.ex
+++ b/lib/glific/wa_poll.ex
@@ -3,7 +3,7 @@ defmodule Glific.WaPoll do
   The whatsapp poll Context, which encapsulates and manages whatsapp poll
   """
   alias Glific.{Repo, WAGroup.WaPoll}
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   @doc """
   Creates an wa_poll

--- a/lib/glific/whatsapp_forms.ex
+++ b/lib/glific/whatsapp_forms.ex
@@ -3,7 +3,7 @@ defmodule Glific.WhatsappForms do
   WhatsApp Forms context module. This module provides functions for managing WhatsApp forms.
   """
   require Logger
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Enums.WhatsappFormCategory,

--- a/lib/glific/whatsapp_forms/whatsapp_form.ex
+++ b/lib/glific/whatsapp_forms/whatsapp_form.ex
@@ -3,7 +3,6 @@ defmodule Glific.WhatsappForms.WhatsappForm do
   Whatsapp Form schema.
   """
   use Ecto.Schema
-  import Ecto.Query, warn: false
   import Ecto.Changeset
 
   alias __MODULE__

--- a/lib/glific/whatsapp_forms/whatsapp_form_response.ex
+++ b/lib/glific/whatsapp_forms/whatsapp_form_response.ex
@@ -3,7 +3,6 @@ defmodule Glific.WhatsappForms.WhatsappFormResponse do
   Whatsapp Form Response schema.
   """
   use Ecto.Schema
-  import Ecto.Query, warn: false
   import Ecto.Changeset
 
   alias __MODULE__

--- a/lib/glific/whatsapp_forms_responses.ex
+++ b/lib/glific/whatsapp_forms_responses.ex
@@ -2,7 +2,7 @@ defmodule Glific.WhatsappFormsResponses do
   @moduledoc """
   Module to handle WhatsApp Form Responses
   """
-  import Ecto.Query, warn: false
+  import Ecto.Query
   use Publicist
   require Logger
 

--- a/lib/glific/whatsapp_forms_revisions.ex
+++ b/lib/glific/whatsapp_forms_revisions.ex
@@ -3,7 +3,7 @@ defmodule Glific.WhatsappFormsRevisions do
    Context module for managing WhatsApp form revisions.
   """
 
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Repo,

--- a/lib/glific_web/schema/contact_types.ex
+++ b/lib/glific_web/schema/contact_types.ex
@@ -5,7 +5,7 @@ defmodule GlificWeb.Schema.ContactTypes do
 
   use Absinthe.Schema.Notation
   import Absinthe.Resolution.Helpers
-  import Ecto.Query, warn: false
+  import Ecto.Query
 
   alias Glific.{
     Contacts.Contact,

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -5,8 +5,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
 
   use Absinthe.Schema.Notation
   import Absinthe.Resolution.Helpers, only: [dataloader: 1]
-  import Ecto.Query, warn: false
-
+  import Ecto.Query
   alias Glific.{Enums.OrganizationStatus, Partners, Repo, Settings.Language}
   alias GlificWeb.{Resolvers, Schema, Schema.Middleware.Authorize}
 

--- a/lib/glific_web/schema/profile_types.ex
+++ b/lib/glific_web/schema/profile_types.ex
@@ -5,8 +5,6 @@ defmodule GlificWeb.Schema.ProfileTypes do
 
   use Absinthe.Schema.Notation
   import Absinthe.Resolution.Helpers
-  import Ecto.Query, warn: false
-
   alias Glific.Repo
 
   alias GlificWeb.{


### PR DESCRIPTION
## Summary
- Added proper @moduledoc to 10 Ecto schemas (Message, User, OrganizationData, SessionTemplate, WAMessage, Notification, Stat, InteractiveTemplate, Trigger, WaPoll) that previously had @moduledoc false — fixes ExDoc "module is hidden" warnings since their t() types are referenced in specs elsewhere.
- Removed warn: false from all import Ecto.Query statements (97 files); dropped the import entirely where it was actually unused (26 files).
- Fixed 3 broken/malformed doc references: an unescaped {...} return-value example in assistants.ex, a nonexistent Timex.cmd/2 example in expression.ex, and two stale module/function references (create_log/4, dispatch_function/3) in the webhook docs.