### PR TITLE
fix(bigquery): include organizations table in data fetch condition

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -2096,7 +2096,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
   defp fetch_data(table, organization_id, attrs) do
     query = get_query(table, organization_id, attrs)
 
-    if table in ["stats", "stats_all", "trackers", "trackers_all", "trial_users"] do
+    if table in ["stats", "stats_all", "trackers", "trackers_all", "trial_users", "organizations"] do
       RepoReplica.all(query, skip_organization_id: true)
     else
       RepoReplica.all(query)

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -15,6 +15,7 @@ defmodule Glific.BigQueryTest do
     Partners,
     Partners.Saas,
     Repo,
+    RepoReplica,
     Seeds.SeedsDev
   }
 
@@ -851,6 +852,21 @@ defmodule Glific.BigQueryTest do
       # orgs, and OUT of the dedup list so those re-syncs accumulate as a change log
       # rather than collapsing to one row per org.
       refute "organizations" in BigQuery.ignore_updates_for_table()
+    end
+
+    test "fetch_data/3 for organizations returns every org, not just the current process organization_id",
+         %{organization_id: organization_id} do
+      other_organization = organization_fixture()
+
+      Repo.put_process_state(organization_id)
+      RepoReplica.put_process_state(organization_id)
+
+      organization_ids =
+        BigQueryWorker.fetch_data("organizations", organization_id, %{})
+        |> Enum.map(& &1.id)
+
+      assert organization_id in organization_ids
+      assert other_organization.id in organization_ids
     end
   end
 end


### PR DESCRIPTION

## Summary

Why : 
bug: The query builder (get_query("organizations", ...)) correctly avoids adding its own where clause. But the function that executes it, fetch_data/3, only passes skip_organization_id: true for a hardcoded list of tables: ["stats", "stats_all", "trackers", "trackers_all", "trial_users"]. "organizations" was left out of that list. So even though the query itself has no explicit org filter, Glific's automatic repo-level scoping still kicks in behind the scenes and silently adds WHERE organization_id = <whatever org you're currently running as> — because nothing told it not to.

The visible effect: When you ran the sync as org 1, the "unscoped, sync-every-org" query got silently narrowed down to "just fetch the organization whose id is 1" — which is exactly the single row (Staging) you saw in BigQuery. It's not that only one org's data synced correctly; it's that the safety net meant to protect tenant isolation accidentally clobbered the one query that was supposed to ignore it.