### PR TITLE
fix:Require OTP verification for email update

### DIFF
--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -57,10 +57,11 @@ defmodule GlificWeb.Resolvers.Users do
 
   @spec update_password_params(User.t(), map()) :: {:ok, map()} | {:error, any}
   defp update_password_params(user, params) do
-    with false <- is_nil(params[:password]) || is_nil(params[:otp]),
-         :ok <- PasswordlessAuth.verify_code(user.phone, params.otp) do
+    with false <-
+           is_nil(params[:email]) && (is_nil(params[:password]) || is_nil(params[:otp])),
+         :ok <- PasswordlessAuth.verify_code(user.phone, params[:otp]) do
       PasswordlessAuth.remove_code(user.phone)
-      params = Map.merge(params, %{password_confirmation: params.password})
+      params = Map.merge(params, %{password_confirmation: params[:password]})
       {:ok, params}
     else
       true ->

--- a/test/glific_web/schema/user_test.exs
+++ b/test/glific_web/schema/user_test.exs
@@ -195,10 +195,11 @@ defmodule GlificWeb.Schema.UserTest do
   test "update current user cannot change email without a verified otp", %{manager: user} do
     Fixtures.otp_hsm_fixture()
     original_email = Repo.get!(User, user.id).email
+    new_email = "email-update-#{System.unique_integer([:positive])}@example.com"
 
     result =
       auth_query_gql_by(:update_current, user,
-        variables: %{"input" => %{"otp" => "000000", "email" => "demo@domain.com"}}
+        variables: %{"input" => %{"otp" => "000000", "email" => new_email}}
       )
 
     assert {:ok, query_data} = result

--- a/test/glific_web/schema/user_test.exs
+++ b/test/glific_web/schema/user_test.exs
@@ -192,6 +192,23 @@ defmodule GlificWeb.Schema.UserTest do
     assert key == "OTP"
   end
 
+  test "update current user cannot change email without a verified otp", %{manager: user} do
+    Fixtures.otp_hsm_fixture()
+    original_email = Repo.get!(User, user.id).email
+
+    result =
+      auth_query_gql_by(:update_current, user,
+        variables: %{"input" => %{"otp" => "000000", "email" => "demo@domain.com"}}
+      )
+
+    assert {:ok, query_data} = result
+
+    assert get_in(query_data, [:data, "updateCurrentUser", "errors", Access.at(0), "key"]) ==
+             "OTP"
+
+    assert Repo.get!(User, user.id).email == original_email
+  end
+
   test "delete a user", %{manager: user_auth} do
     user = Fixtures.user_fixture()
 


### PR DESCRIPTION

## Summary
Linked issue https://github.com/glific/glific-frontend/issues/3435
This fix ensures email updates also require verified OTP

