### PR TITLE
feat(scripts): add a local demo for the BigQuery tied-timestamp bound (#5468)

### DIFF
--- a/lib/glific/scripts/bigquery_tie_demo.ex
+++ b/lib/glific/scripts/bigquery_tie_demo.ex
@@ -1,0 +1,216 @@
+defmodule Glific.Scripts.BigQueryTieDemo do
+  @moduledoc """
+  Local demonstration of the BigQuery update-sync row bound (issue #5468).
+
+  Creates contacts that all share one `updated_at` — the situation a bulk
+  `Repo.update_all/3` produces — then shows how many rows a single sync run pulls out of
+  Postgres under the old timestamp-only bookmark versus the current `(updated_at, id)` one.
+
+  Needs no BigQuery credentials: the fix is entirely about the size of the Postgres read,
+  so nothing is sent anywhere.
+
+  Must run under `MIX_ENV=test`. `BigQueryWorker` reaches its query internals through
+  `use Publicist`, which only rewrites `defp` when `Mix.env == :test` — in `:dev` those
+  functions are genuinely private and this module cannot call them.
+
+      MIX_ENV=test iex -S mix
+
+      alias Glific.Scripts.BigQueryTieDemo, as: Demo
+
+      # 1. create 1000 contacts all stamped with the same updated_at
+      since = Demo.seed(1, 1000)
+
+      # 2. old bookmark vs new bookmark on identical data
+      Demo.compare(1, since)
+
+      # 3. walk every sync run until the backlog is drained
+      Demo.drain(1, since)
+
+      # 4. remove the demo contacts
+      Demo.cleanup(1)
+
+  Every contact created here uses the phone prefix `5550` so `cleanup/1` can delete exactly
+  what was added and nothing else.
+  """
+
+  import Ecto.Query
+
+  require Logger
+
+  alias Glific.{
+    BigQuery.BigQueryWorker,
+    Contacts.Contact,
+    Repo,
+    RepoReplica
+  }
+
+  @phone_prefix "5550"
+
+  @doc """
+  Inserts `count` contacts sharing one `updated_at`. Returns the bookmark to sync from.
+  """
+  @spec seed(non_neg_integer, pos_integer) :: DateTime.t()
+  def seed(organization_id, count \\ 1000) do
+    put_org_context(organization_id)
+
+    tied_at = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+
+    # updated_at has to sit a few seconds past inserted_at: the sync filters on the seconds
+    # component of age(updated_at, inserted_at), so a sub-second gap is skipped entirely.
+    inserted_at = DateTime.add(tied_at, -10, :second)
+
+    rows =
+      Enum.map(1..count, fn n ->
+        %{
+          name: "Tie Demo #{n}",
+          phone: "#{@phone_prefix}#{String.pad_leading(to_string(n), 7, "0")}",
+          language_id: 1,
+          organization_id: organization_id,
+          inserted_at: inserted_at,
+          updated_at: tied_at
+        }
+      end)
+
+    {inserted, _} =
+      rows
+      |> Enum.chunk_every(500)
+      |> Enum.reduce({0, nil}, fn chunk, {total, _} ->
+        {n, _} = Repo.insert_all(Contact, chunk, on_conflict: :nothing)
+        {total + n, nil}
+      end)
+
+    IO.puts("""
+
+    Inserted #{inserted} contacts, all with updated_at = #{tied_at}
+    Sync bookmark for the demo: #{DateTime.add(tied_at, -1, :second)}
+    """)
+
+    DateTime.add(tied_at, -1, :second)
+  end
+
+  @doc """
+  Prints how many rows one sync run reads, under the old bookmark and the current one.
+  """
+  @spec compare(non_neg_integer, DateTime.t()) :: :ok
+  def compare(organization_id, since) do
+    put_org_context(organization_id)
+
+    limit = Application.get_env(:glific, :bigquery_per_min_limit, 500)
+
+    case BigQueryWorker.insert_last_updated("contacts", since, 0, organization_id) do
+      nil ->
+        IO.puts("\nNothing to sync since #{since}. Run seed/2 first.\n")
+
+      cursor ->
+        new_rows = length(fetch_new(organization_id, since, 0, cursor))
+        old_rows = count_old(organization_id, since, cursor.updated_at)
+
+        IO.puts("""
+
+        Rows in one sync run — limit is #{limit}
+
+          old bookmark  updated_at <= #{cursor.updated_at}
+                        #{old_rows} rows loaded into memory
+                        (every row tied on that timestamp, the limit is not expressible)
+
+          new bookmark  (updated_at, id) <= (#{cursor.updated_at}, #{cursor.id})
+                        #{new_rows} rows loaded into memory
+
+          reduction     #{old_rows} -> #{new_rows}#{over_limit_note(old_rows, limit)}
+        """)
+    end
+
+    :ok
+  end
+
+  @doc """
+  Walks sync runs from `since` until the backlog is drained, printing each run.
+  """
+  @spec drain(non_neg_integer, DateTime.t()) :: :ok
+  def drain(organization_id, since) do
+    put_org_context(organization_id)
+    limit = Application.get_env(:glific, :bigquery_per_min_limit, 500)
+
+    IO.puts("\nDraining from #{since} with a limit of #{limit} per run\n")
+    do_drain(organization_id, since, 0, 1, 0)
+  end
+
+  @doc """
+  Deletes every contact `seed/2` created, matched on the demo phone prefix.
+  """
+  @spec cleanup(non_neg_integer) :: :ok
+  def cleanup(organization_id) do
+    put_org_context(organization_id)
+
+    {deleted, _} =
+      Contact
+      |> where([c], like(c.phone, ^"#{@phone_prefix}%"))
+      |> where([c], c.organization_id == ^organization_id)
+      |> Repo.delete_all()
+
+    IO.puts("\nDeleted #{deleted} demo contacts\n")
+    :ok
+  end
+
+  @spec do_drain(non_neg_integer, DateTime.t(), non_neg_integer, pos_integer, non_neg_integer) ::
+          :ok
+  defp do_drain(_organization_id, _since, _since_id, run, total) when run > 50 do
+    IO.puts("Stopped after 50 runs (#{total} rows) — bookmark is not advancing.")
+  end
+
+  defp do_drain(organization_id, since, since_id, run, total) do
+    case BigQueryWorker.insert_last_updated("contacts", since, since_id, organization_id) do
+      nil ->
+        IO.puts("\nDrained: #{total} rows over #{run - 1} sync runs, nothing left.\n")
+
+      cursor ->
+        rows = fetch_new(organization_id, since, since_id, cursor)
+        ids = Enum.map(rows, & &1.id)
+
+        IO.puts(
+          "run #{String.pad_leading(to_string(run), 2)}  " <>
+            "#{String.pad_leading(to_string(length(rows)), 4)} rows  " <>
+            "ids #{List.first(ids)}..#{List.last(ids)}  " <>
+            "-> bookmark id #{cursor.id}"
+        )
+
+        do_drain(organization_id, cursor.updated_at, cursor.id, run + 1, total + length(rows))
+    end
+  end
+
+  @spec fetch_new(non_neg_integer, DateTime.t(), non_neg_integer, map()) :: list()
+  defp fetch_new(organization_id, since, since_id, cursor) do
+    BigQueryWorker.fetch_data("contacts", organization_id, %{
+      action: :update,
+      last_updated_at: cursor.updated_at,
+      last_updated_id: cursor.id,
+      table_last_updated_at: since,
+      table_last_updated_id: since_id
+    })
+  end
+
+  @spec count_old(non_neg_integer, DateTime.t(), DateTime.t()) :: non_neg_integer
+  defp count_old(organization_id, since, cursor_updated_at) do
+    Contact
+    |> where([c], c.organization_id == ^organization_id)
+    |> where([c], c.updated_at > ^since and c.updated_at <= ^cursor_updated_at)
+    |> where(
+      [c],
+      fragment("DATE_PART('seconds', age(?, ?))::integer", c.updated_at, c.inserted_at) > 0
+    )
+    |> RepoReplica.aggregate(:count, :id)
+  end
+
+  @spec over_limit_note(non_neg_integer, pos_integer) :: String.t()
+  defp over_limit_note(old_rows, limit) when old_rows > limit,
+    do: "  (old path was #{Float.round(old_rows / limit, 1)}x over the limit)"
+
+  defp over_limit_note(_old_rows, _limit), do: ""
+
+  @spec put_org_context(non_neg_integer) :: :ok
+  defp put_org_context(organization_id) do
+    Repo.put_process_state(organization_id)
+    RepoReplica.put_process_state(organization_id)
+    :ok
+  end
+end


### PR DESCRIPTION
Verification tool for #5469. Related to #5468.

## Why

#5469 changes how many rows one BigQuery sync run reads out of Postgres. That's hard to eyeball from the diff, and impossible to check end-to-end locally because a real sync needs BigQuery credentials. This makes the behaviour measurable in about thirty seconds without them — the bound is entirely on the Postgres read, so nothing is sent anywhere.

## Usage

```
MIX_ENV=test iex -S mix
```

```elixir
alias Glific.Scripts.BigQueryTieDemo, as: Demo

since = Demo.seed(1, 1200)   # 1200 contacts, all sharing one updated_at
Demo.compare(1, since)
Demo.drain(1, since)
Demo.cleanup(1)
```

`compare/2`:

```
Rows in one sync run — limit is 500

  old bookmark  updated_at <= 2026-07-30 06:54:51.464103Z
                1200 rows loaded into memory
                (every row tied on that timestamp, the limit is not expressible)

  new bookmark  (updated_at, id) <= (2026-07-30 06:54:51.464103Z, 89649)
                500 rows loaded into memory

  reduction     1200 -> 500  (old path was 2.4x over the limit)
```

`drain/2`:

```
run  1   500 rows  ids 89150..89649  -> bookmark id 89649
run  2   500 rows  ids 89650..90149  -> bookmark id 90149
run  3   200 rows  ids 90150..90349  -> bookmark id 90349
Drained: 1200 rows over 3 sync runs, nothing left.
```

Contiguous, non-overlapping, 500 + 500 + 200 = exactly the 1200 seeded — so the bound holds and nothing is skipped.

Turn the limit down to see it more starkly: `Application.put_env(:glific, :bigquery_per_min_limit, 100)` gives 12 runs of 100.

## How it measures the old behaviour

`compare/2` calls the real `insert_last_updated/4` and `fetch_data/3`, then separately counts what the *old* predicate (`updated_at > since AND updated_at <= cursor`, plus the same `age/2` filter) would have matched over the same rows. Both figures come from one dataset, so there's no reverting code or comparing across runs.

## Notes for review

- **`MIX_ENV=test` is required**, and the moduledoc says so. `BigQueryWorker` reaches its query internals through `use Publicist`, which only rewrites `defp` when `Mix.env == :test` — in `:dev` they are genuinely private and this module cannot call them. Direct calls are used rather than `apply/3` so the test-env build stays warning-free and Credo stays happy; the trade-off is two "undefined or private" warnings on a `:dev` compile, which is also a fair signal that the module isn't usable there.
- **Stacked on `fix/bigquery-unbounded-update-fetch-5468`**, because `insert_last_updated/4` and the `table_last_updated_id` bound don't exist on `master` yet. Retarget this to `master` once #5469 merges. I kept it out of #5469 itself so that diff stays exactly as reviewed.
- Seeded contacts use the phone prefix `5550`, and `cleanup/1` deletes on that prefix so it can't touch real local data.
- Uses `Repo.insert_all/3` in chunks of 500 with `on_conflict: :nothing`, so re-running `seed/2` is safe.

## What it does not prove

Row counts, not bytes — it measures the thing the fix controls, not memory consumption directly. And it says nothing about whether BigQuery accepts the payload, since no credentials are involved.

## Checks

- `MIX_ENV=test mix compile --warnings-as-errors` clean
- `MIX_ENV=test mix credo --strict` clean
- `MIX_ENV=test mix doctor` — 100% doc / moduledoc / spec
- `MIX_ENV=test mix dialyzer` passes
- `mix format --check-formatted` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
