### PR TITLE
[Evals]: AI Evaluations 2.0

### DIFF
--- a/assets/gql/organizations/get_services.gql
+++ b/assets/gql/organizations/get_services.gql
@@ -14,6 +14,7 @@ query organizationServices {
     ask_glific_enabled
     whatsapp_forms_enabled
     ai_evaluations_enabled
+    ai_evaluation_enabled
     template_v2_enabled
     errors {
       key

--- a/assets/gql/organizations/get_services.gql
+++ b/assets/gql/organizations/get_services.gql
@@ -14,7 +14,7 @@ query organizationServices {
     ask_glific_enabled
     whatsapp_forms_enabled
     ai_evaluations_enabled
-    ai_evaluation_enabled
+    ai_evaluation_v2_enabled
     template_v2_enabled
     errors {
       key

--- a/lib/glific/ai_evaluations/golden_qa.ex
+++ b/lib/glific/ai_evaluations/golden_qa.ex
@@ -18,6 +18,7 @@ defmodule Glific.AIEvaluations.GoldenQA do
           dataset_id: non_neg_integer() | nil,
           duplication_factor: non_neg_integer() | nil,
           file_name: String.t() | nil,
+          total_items: integer(),
           organization_id: non_neg_integer() | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
           inserted_at: DateTime.t() | nil,
@@ -25,13 +26,14 @@ defmodule Glific.AIEvaluations.GoldenQA do
         }
 
   @required_fields [:name, :dataset_id, :organization_id]
-  @optional_fields [:duplication_factor, :file_name]
+  @optional_fields [:duplication_factor, :file_name, :total_items]
 
   schema "golden_qas" do
     field(:name, :string)
     field(:dataset_id, :integer)
     field(:duplication_factor, :integer, default: 1)
     field(:file_name, :string)
+    field(:total_items, :integer, default: 0)
     belongs_to(:organization, Organization)
 
     timestamps(type: :utc_datetime)

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -524,6 +524,7 @@ defmodule Glific.Flags do
       :is_copy_node_enabled,
       :high_trigger_tps_enabled,
       :ai_evaluations,
+      :is_ai_evaluation_enabled,
       :is_prompt_generator_enabled,
       :is_template_v2_enabled
     ]

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -1488,7 +1488,8 @@ defmodule Glific.Partners do
       "high_trigger_tps_enabled" =>
         Flags.get_flag_enabled(:high_trigger_tps_enabled, organization),
       "ai_evaluations_enabled" => Flags.get_flag_enabled(:ai_evaluations, organization),
-      "ai_evaluation_enabled" => Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization),
+      "ai_evaluation_v2_enabled" =>
+        Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization),
       "assistant_config_versions_enabled" =>
         Flags.get_assistant_config_versions_enabled(organization),
       "copy_node_enabled" => Flags.get_copy_node_enabled(organization),

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -1488,6 +1488,7 @@ defmodule Glific.Partners do
       "high_trigger_tps_enabled" =>
         Flags.get_flag_enabled(:high_trigger_tps_enabled, organization),
       "ai_evaluations_enabled" => Flags.get_flag_enabled(:ai_evaluations, organization),
+      "ai_evaluation_enabled" => Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization),
       "assistant_config_versions_enabled" =>
         Flags.get_assistant_config_versions_enabled(organization),
       "copy_node_enabled" => Flags.get_copy_node_enabled(organization),

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -807,7 +807,7 @@ defmodule Glific.ThirdParty.Kaapi do
   end
 
   @spec handle_evaluation_dataset_v2_response(
-          {:ok, map()} | {:error, map() | binary() | :timeout}
+          {:ok, map()} | {:error, map() | binary() | :timeout},
           non_neg_integer()
         ) :: {:ok, map()} | {:error, map() | binary()}
   defp handle_evaluation_dataset_v2_response(

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -783,6 +783,67 @@ defmodule Glific.ThirdParty.Kaapi do
     end
   end
 
+  @doc """
+  Upload an evaluation dataset to Kaapi via the v2 endpoint, send error to Appsignal if failed.
+  """
+  @spec upload_evaluation_dataset_v2(map(), non_neg_integer()) ::
+          {:ok, map()} | {:error, map() | binary()} | {:error, :timeout}
+  def upload_evaluation_dataset_v2(params, organization_id) do
+    case fetch_kaapi_creds(organization_id) do
+      {:ok, secrets} ->
+        params
+        |> ApiClient.upload_evaluation_dataset_v2(secrets["api_key"])
+        |> handle_evaluation_dataset_v2_response(organization_id)
+
+      {:error, reason} ->
+        send_kaapi_error(
+          "Failed to upload evaluation dataset v2 to Kaapi",
+          organization_id,
+          reason
+        )
+
+        {:error, reason}
+    end
+  end
+
+  @spec handle_evaluation_dataset_v2_response(
+          {:ok, map()} | {:error, map() | binary() | :timeout}
+          non_neg_integer()
+        ) :: {:ok, map()} | {:error, map() | binary()}
+  defp handle_evaluation_dataset_v2_response(
+         {:ok, %{data: %{dataset_id: dataset_id, total_items: total_items}}},
+         _organization_id
+       ) do
+    {:ok, %{dataset_id: dataset_id, total_items: total_items}}
+  end
+
+  defp handle_evaluation_dataset_v2_response({:error, reason}, organization_id) do
+    send_kaapi_error("Failed to upload evaluation dataset v2 to Kaapi", organization_id, reason)
+    {:error, reason}
+  end
+
+  defp handle_evaluation_dataset_v2_response({:ok, result}, organization_id) do
+    send_kaapi_error(
+      "Got unexpected response from Kaapi while uploading evaluation dataset v2",
+      organization_id,
+      result
+    )
+
+    {:error, "An unknown error occurred, please contact Glific support."}
+  end
+
+  @spec send_kaapi_error(String.t(), non_neg_integer(), term()) :: Appsignal.Span.t() | nil
+  defp send_kaapi_error(message, organization_id, reason) do
+    Appsignal.send_error(
+      %Error{
+        message: message,
+        organization_id: organization_id,
+        reason: safe_inspect(reason)
+      },
+      []
+    )
+  end
+
   @spec insert_kaapi_provider(non_neg_integer(), String.t()) ::
           {:ok, Credential.t()} | {:error, Ecto.Changeset.t()}
   defp insert_kaapi_provider(organization_id, api_key) do

--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -227,21 +227,24 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   """
   @spec upload_evaluation_dataset(map(), String.t()) :: {:ok, map()} | {:error, any()}
   def upload_evaluation_dataset(params, org_api_key) do
-    multipart =
-      Tesla.Multipart.new()
-      |> Tesla.Multipart.add_file(params.file.path,
-        name: "file",
-        filename: params.file.filename,
-        headers: [{"content-type", params.file.content_type}]
-      )
-      |> Tesla.Multipart.add_field("dataset_name", params.dataset_name)
-      |> Tesla.Multipart.add_field("duplication_factor", to_string(params.duplication_factor))
-
-    opts = [adapter: [recv_timeout: 60_000]]
-
     org_api_key
     |> client()
-    |> Tesla.post("/api/v1/evaluations/datasets", multipart, opts: opts)
+    |> Tesla.post("/api/v1/evaluations/datasets", evaluation_dataset_multipart(params),
+      opts: [adapter: [recv_timeout: 60_000]]
+    )
+    |> parse_kaapi_response()
+  end
+
+  @doc """
+  Upload an evaluation dataset to Kaapi (v2)
+  """
+  @spec upload_evaluation_dataset_v2(map(), String.t()) :: {:ok, map()} | {:error, any()}
+  def upload_evaluation_dataset_v2(params, org_api_key) do
+    org_api_key
+    |> client()
+    |> Tesla.post("/api/v2/evaluations/datasets", evaluation_dataset_multipart(params),
+      opts: [adapter: [recv_timeout: 60_000]]
+    )
     |> parse_kaapi_response()
   end
 
@@ -303,6 +306,18 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
       opts: [path_params: [dataset_id: dataset_id]]
     )
     |> parse_kaapi_response()
+  end
+
+  @spec evaluation_dataset_multipart(map()) :: Tesla.Multipart.t()
+  defp evaluation_dataset_multipart(params) do
+    Tesla.Multipart.new()
+    |> Tesla.Multipart.add_file(params.file.path,
+      name: "file",
+      filename: params.file.filename,
+      headers: [{"content-type", params.file.content_type}]
+    )
+    |> Tesla.Multipart.add_field("dataset_name", params.dataset_name)
+    |> Tesla.Multipart.add_field("duplication_factor", to_string(params.duplication_factor))
   end
 
   @spec add_optional_fields(Tesla.Multipart.t(), map()) :: Tesla.Multipart.t()

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -11,7 +11,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     AIEvaluations.AIEvaluation,
     AIEvaluations.GoldenQA,
     Assistants.AssistantConfigVersion,
+    Flags,
     Metrics,
+    Partners,
     Repo,
     ThirdParty.Kaapi
   }
@@ -108,7 +110,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
          :ok <- validate_golden_qa_file_size(file, user),
          {:ok, row_count} <- validate_csv_structure(file),
          :ok <- validate_golden_qa_question_limit(row_count, factor),
-         {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
+         {:ok, kaapi_dataset} <- upload_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
       {:error, :timeout} ->
@@ -139,6 +141,17 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
+  @spec upload_dataset(map(), non_neg_integer()) :: {:ok, map()} | {:error, any()}
+  defp upload_dataset(dataset, organization_id) do
+    organization = Partners.organization(organization_id)
+
+    if Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization) do
+      Kaapi.upload_evaluation_dataset_v2(dataset, organization.id)
+    else
+      Kaapi.upload_evaluation_dataset(dataset, organization.id)
+    end
+  end
+
   @spec create_golden_qa_record(map(), String.t(), Plug.Upload.t(), integer(), map()) ::
           {:ok, %{golden_qa: GoldenQA.t()}} | {:ok, %{errors: [%{message: String.t()}]}}
   defp create_golden_qa_record(kaapi_dataset, name, file, factor, user) do
@@ -147,7 +160,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            dataset_id: kaapi_dataset.dataset_id,
            duplication_factor: factor,
            file_name: file.filename,
-           organization_id: user.organization_id
+           organization_id: user.organization_id,
+           total_items: Map.get(kaapi_dataset, :total_items, 0)
          }) do
       {:ok, golden_qa} ->
         {:ok, %{golden_qa: golden_qa}}
@@ -234,11 +248,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   @spec validate_golden_qa_name(String.t()) :: :ok | {:error, String.t()}
   defp validate_golden_qa_name(name) do
-    if Regex.match?(~r/^[a-z0-9_]+$/, name) do
-      :ok
-    else
-      {:error, "Name can only contain lowercase alphanumeric characters and underscores"}
-    end
+    if Regex.match?(~r/^[a-z0-9_]+$/, name),
+      do: :ok,
+      else: {:error, "Name can only contain lowercase alphanumeric characters and underscores"}
   end
 
   @spec validate_duplication_factor(integer()) :: :ok | {:error, String.t()}
@@ -282,6 +294,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
           name: golden_qa.name,
           duplication_factor: golden_qa.duplication_factor,
           file_name: golden_qa.file_name,
+          total_items: golden_qa.total_items,
           inserted_at: golden_qa.inserted_at,
           updated_at: golden_qa.updated_at
         }

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -71,6 +71,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :dataset_id, :integer
     field :file_name, :string
     field :signed_url, :string
+    field :total_items, :integer
     field :inserted_at, :datetime
     field :updated_at, :datetime
   end

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -30,6 +30,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:errors, list_of(:input_error))
     field(:whatsapp_forms_enabled, :boolean)
     field(:ai_evaluations_enabled, :boolean)
+    field(:ai_evaluation_enabled, :boolean)
     field(:assistant_config_versions_enabled, :boolean)
     field(:copy_node_enabled, :boolean)
     field(:superset_enabled, :boolean)

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -30,7 +30,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:errors, list_of(:input_error))
     field(:whatsapp_forms_enabled, :boolean)
     field(:ai_evaluations_enabled, :boolean)
-    field(:ai_evaluation_enabled, :boolean)
+    field(:ai_evaluation_v2_enabled, :boolean)
     field(:assistant_config_versions_enabled, :boolean)
     field(:copy_node_enabled, :boolean)
     field(:superset_enabled, :boolean)

--- a/priv/repo/migrations/20260803000000_add_v2_fields_to_golden_qas.exs
+++ b/priv/repo/migrations/20260803000000_add_v2_fields_to_golden_qas.exs
@@ -1,0 +1,9 @@
+defmodule Glific.Repo.Migrations.AddV2FieldsToGoldenQas do
+  use Ecto.Migration
+
+  def change do
+    alter table(:golden_qas) do
+      add :total_items, :integer, default: 0, null: false, comment: "total items in the dataset"
+    end
+  end
+end

--- a/test/glific/third_party/kaapi/api_client_test.exs
+++ b/test/glific/third_party/kaapi/api_client_test.exs
@@ -1,7 +1,6 @@
 defmodule Glific.ThirdParty.Kaapi.ApiClientTest do
   use GlificWeb.ConnCase
   import Tesla.Mock
-  alias Glific.ThirdParty.Kaapi
   alias Glific.ThirdParty.Kaapi.ApiClient
 
   @params %{
@@ -466,22 +465,92 @@ defmodule Glific.ThirdParty.Kaapi.ApiClientTest do
     end
   end
 
-  describe "normalize_kaapi_body/1" do
-    test "treats a 200 body with success:false as a logical failure" do
-      assert %{
-               success: false,
-               http_status: 200,
-               error_type: "kaapi_logical_failure",
-               reason: "boom"
-             } = Kaapi.normalize_kaapi_body(%{success: false, message: "boom"})
+  describe "upload_evaluation_dataset/2" do
+    setup [:create_dataset_upload_params]
+
+    test "successfully uploads the dataset to the v1 endpoint", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v1/evaluations/datasets"
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{dataset_name: "valid_dataset", dataset_id: "88001"}}
+        }
+      end)
+
+      assert {:ok, %{data: %{dataset_id: "88001"}}} =
+               ApiClient.upload_evaluation_dataset(dataset_params, @org_kaapi_api_key)
     end
 
-    test "falls back to the error key, then to a default reason" do
-      assert %{reason: "bad"} =
-               Kaapi.normalize_kaapi_body(%{success: false, error: "bad"})
+    test "returns error when kaapi returns error status", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post} ->
+        %Tesla.Env{status: 422, body: %{error: "Invalid dataset format"}}
+      end)
 
-      assert %{reason: "Kaapi logical failure"} =
-               Kaapi.normalize_kaapi_body(%{success: false})
+      assert {:error, %{status: 422, body: %{error: "Invalid dataset format"}}} =
+               ApiClient.upload_evaluation_dataset(dataset_params, @org_kaapi_api_key)
     end
+
+    test "returns error on transport failure/timeout", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post} -> {:error, :timeout} end)
+
+      assert {:error, :timeout} =
+               ApiClient.upload_evaluation_dataset(dataset_params, @org_kaapi_api_key)
+    end
+  end
+
+  describe "upload_evaluation_dataset_v2/2" do
+    setup [:create_dataset_upload_params]
+
+    test "successfully uploads the dataset to the v2 endpoint", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v2/evaluations/datasets"
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{dataset_id: "99001", total_items: 42}}
+        }
+      end)
+
+      assert {:ok, %{data: %{dataset_id: "99001", total_items: 42}}} =
+               ApiClient.upload_evaluation_dataset_v2(dataset_params, @org_kaapi_api_key)
+    end
+
+    test "returns error when kaapi returns error status", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post} ->
+        %Tesla.Env{status: 500, body: %{error: "Internal server error"}}
+      end)
+
+      assert {:error, %{status: 500, body: %{error: "Internal server error"}}} =
+               ApiClient.upload_evaluation_dataset_v2(dataset_params, @org_kaapi_api_key)
+    end
+
+    test "returns error on transport failure/timeout", %{dataset_params: dataset_params} do
+      mock(fn %Tesla.Env{method: :post} -> {:error, :timeout} end)
+
+      assert {:error, :timeout} =
+               ApiClient.upload_evaluation_dataset_v2(dataset_params, @org_kaapi_api_key)
+    end
+  end
+
+  defp create_dataset_upload_params(_context) do
+    tmp_path =
+      Path.join(
+        System.tmp_dir!(),
+        "kaapi_dataset_test_#{System.unique_integer([:positive])}.csv"
+      )
+
+    File.write!(tmp_path, "question,answer\nWhat is Glific?,A communication platform\n")
+    on_exit(fn -> File.rm(tmp_path) end)
+
+    upload = %Plug.Upload{path: tmp_path, content_type: "text/csv", filename: "dataset.csv"}
+
+    %{
+      dataset_params: %{
+        file: upload,
+        dataset_name: "valid_dataset",
+        duplication_factor: 2
+      }
+    }
   end
 end

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -1,0 +1,130 @@
+defmodule Glific.ThirdParty.KaapiTest do
+  use GlificWeb.ConnCase
+  import Tesla.Mock
+  alias Glific.Partners
+  alias Glific.ThirdParty.Kaapi
+
+  describe "upload_evaluation_dataset/2" do
+    setup [:enable_kaapi_credential, :create_dataset_upload_params]
+
+    test "extracts name and dataset_id from a well-shaped v1 response", %{
+      organization_id: organization_id,
+      dataset_params: dataset_params
+    } do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v1/evaluations/datasets"
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{dataset_name: "valid_dataset", dataset_id: "88002"}}
+        }
+      end)
+
+      assert {:ok, %{name: "valid_dataset", dataset_id: "88002"}} =
+               Kaapi.upload_evaluation_dataset(dataset_params, organization_id)
+    end
+
+    test "returns a generic error and does not crash on an unexpected response shape", %{
+      organization_id: organization_id,
+      dataset_params: dataset_params
+    } do
+      mock(fn %Tesla.Env{method: :post} ->
+        %Tesla.Env{status: 200, body: %{data: %{unexpected: "shape"}}}
+      end)
+
+      assert {:error, "An unknown error occurred, please contact Glific support."} =
+               Kaapi.upload_evaluation_dataset(dataset_params, organization_id)
+    end
+
+    test "passes an upstream error through unchanged", %{
+      organization_id: organization_id,
+      dataset_params: dataset_params
+    } do
+      mock(fn %Tesla.Env{method: :post} -> {:error, :timeout} end)
+
+      assert {:error, :timeout} = Kaapi.upload_evaluation_dataset(dataset_params, organization_id)
+    end
+  end
+
+  describe "upload_evaluation_dataset_v2/2" do
+    setup [:enable_kaapi_credential, :create_dataset_upload_params]
+
+    test "extracts dataset_id and total_items from a well-shaped v2 response", %{
+      organization_id: organization_id,
+      dataset_params: dataset_params
+    } do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v2/evaluations/datasets"
+
+        %Tesla.Env{status: 200, body: %{data: %{dataset_id: "99002", total_items: 55}}}
+      end)
+
+      assert {:ok, %{dataset_id: "99002", total_items: 55}} =
+               Kaapi.upload_evaluation_dataset_v2(dataset_params, organization_id)
+    end
+
+    test "returns a generic error and does not crash when total_items is missing", %{
+      organization_id: organization_id,
+      dataset_params: dataset_params
+    } do
+      mock(fn %Tesla.Env{method: :post} ->
+        %Tesla.Env{status: 200, body: %{data: %{dataset_id: "99003"}}}
+      end)
+
+      assert {:error, "An unknown error occurred, please contact Glific support."} =
+               Kaapi.upload_evaluation_dataset_v2(dataset_params, organization_id)
+    end
+  end
+
+  describe "normalize_kaapi_body/1" do
+    test "treats a 200 body with success:false as a logical failure" do
+      assert %{
+               success: false,
+               http_status: 200,
+               error_type: "kaapi_logical_failure",
+               reason: "boom"
+             } = Kaapi.normalize_kaapi_body(%{success: false, message: "boom"})
+    end
+
+    test "falls back to the error key, then to a default reason" do
+      assert %{reason: "bad"} =
+               Kaapi.normalize_kaapi_body(%{success: false, error: "bad"})
+
+      assert %{reason: "Kaapi logical failure"} =
+               Kaapi.normalize_kaapi_body(%{success: false})
+    end
+  end
+
+  defp enable_kaapi_credential(%{organization_id: organization_id}) do
+    Partners.create_credential(%{
+      organization_id: organization_id,
+      shortcode: "kaapi",
+      keys: %{},
+      secrets: %{"api_key" => "sk_test_key"},
+      is_active: true
+    })
+
+    :ok
+  end
+
+  defp create_dataset_upload_params(_context) do
+    tmp_path =
+      Path.join(
+        System.tmp_dir!(),
+        "kaapi_dataset_test_#{System.unique_integer([:positive])}.csv"
+      )
+
+    File.write!(tmp_path, "question,answer\nWhat is Glific?,A communication platform\n")
+    on_exit(fn -> File.rm(tmp_path) end)
+
+    upload = %Plug.Upload{path: tmp_path, content_type: "text/csv", filename: "dataset.csv"}
+
+    %{
+      dataset_params: %{
+        file: upload,
+        dataset_name: "valid_dataset",
+        duplication_factor: 2
+      }
+    }
+  end
+end

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -818,6 +818,184 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       assert golden_qa.name == "dataset_2024_v1"
     end
+
+    test "v1 path: uploads to the v1 endpoint and leaves total_items at default when the flag is off",
+         %{staff: user, upload: upload} do
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          assert url =~ "/api/v1/evaluations/datasets"
+
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "v1_regression_dataset", dataset_id: "88003"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "v1_regression_dataset",
+          file: upload,
+          duplication_factor: 1
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "v1_regression_dataset"
+      assert golden_qa.dataset_id == 88_003
+      assert golden_qa.total_items == 0
+    end
+  end
+
+  describe "create_golden_qa/3 v2 (is_ai_evaluation_enabled)" do
+    setup [:enable_kaapi, :create_upload_file]
+
+    test "v2 path: returns golden_qa with total_items and hits the v2 endpoint when is_ai_evaluation_enabled is on",
+         %{staff: user, upload: upload} do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          assert url =~ "/api/v2/evaluations/datasets"
+
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_id: "88004", total_items: 120}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_dataset_v2",
+          file: upload,
+          duplication_factor: 3
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
+        assert {:ok, %{golden_qa: golden_qa}} =
+                 AIEvaluations.create_golden_qa(nil, args, resolution)
+
+        assert golden_qa.name == "valid_dataset_v2"
+        assert golden_qa.dataset_id == 88_004
+        assert golden_qa.total_items == 120
+
+        assert called(
+                 Glific.Metrics.increment(
+                   @create_golden_qa_success_metric,
+                   user.organization_id
+                 )
+               )
+      end
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "v2 path: returns a generic error when the Kaapi response is missing total_items", %{
+      staff: user,
+      upload: upload
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{status: 200, body: %{data: %{dataset_id: "88005"}}}
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_dataset_v2_bad_shape",
+          file: upload,
+          duplication_factor: 2
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
+        assert {:ok, %{errors: [%{message: msg}]}} =
+                 AIEvaluations.create_golden_qa(nil, args, resolution)
+
+        assert msg == "An unknown error occurred, please contact Glific support."
+
+        assert called(
+                 Glific.Metrics.increment(
+                   @create_golden_qa_failure_metric,
+                   user.organization_id
+                 )
+               )
+      end
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "v2 path: returns the Kaapi error message when dataset name already exists (409)", %{
+      staff: user,
+      upload: upload
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          assert url =~ "/api/v2/evaluations/datasets"
+
+          %Tesla.Env{
+            status: 409,
+            body: %{
+              success: false,
+              data: nil,
+              error:
+                "Dataset with name 'tester' already exists in this organization and project. Please choose a different name.",
+              errors: nil,
+              metadata: nil
+            }
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "tester",
+          file: upload,
+          duplication_factor: 3
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
+        assert {:ok, %{errors: [%{message: msg}]}} =
+                 AIEvaluations.create_golden_qa(nil, args, resolution)
+
+        assert msg ==
+                 "Dataset with name 'tester' already exists in this organization and project. Please choose a different name."
+
+        assert called(
+                 Glific.Metrics.increment(
+                   @create_golden_qa_failure_metric,
+                   user.organization_id
+                 )
+               )
+      end
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
   end
 
   describe "get_golden_qa/3" do
@@ -871,6 +1049,23 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert dataset.id == golden_qa.id
       assert dataset.name == golden_qa.name
       assert dataset.signed_url == "https://storage.example.com/signed-url-token-12345"
+    end
+
+    test "returns total_items when present on the underlying record", %{staff: user} do
+      {:ok, golden_qa_with_total_items} =
+        Glific.AIEvaluations.create_golden_qa(%{
+          name: "test_dataset_with_total_items",
+          dataset_id: 55_001,
+          duplication_factor: 2,
+          total_items: 240,
+          organization_id: user.organization_id
+        })
+
+      args = %{id: golden_qa_with_total_items.id, include_signed_url: false}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: dataset}} = AIEvaluations.get_golden_qa(nil, args, resolution)
+      assert dataset.total_items == 240
     end
 
     test "returns error when golden_qa does not exist", %{staff: user} do

--- a/test/glific_web/schema/organization_test.exs
+++ b/test/glific_web/schema/organization_test.exs
@@ -643,6 +643,7 @@ defmodule GlificWeb.Schema.OrganizationTest do
     assert services["whatsapp_forms_enabled"] == false
     assert services["certificate_enabled"] == false
     assert services["template_v2_enabled"] == false
+    assert services["ai_evaluation_enabled"] == false
   end
 
   test "update an organization with organization settings", %{user: user} do

--- a/test/glific_web/schema/organization_test.exs
+++ b/test/glific_web/schema/organization_test.exs
@@ -643,7 +643,7 @@ defmodule GlificWeb.Schema.OrganizationTest do
     assert services["whatsapp_forms_enabled"] == false
     assert services["certificate_enabled"] == false
     assert services["template_v2_enabled"] == false
-    assert services["ai_evaluation_enabled"] == false
+    assert services["ai_evaluation_v2_enabled"] == false
   end
 
   test "update an organization with organization settings", %{user: user} do


### PR DESCRIPTION
## Summary
 Target issue is #5483  
Adds a new organization-scoped feature flag, is_ai_evaluation_enabled, exposed via GraphQL as ai_evaluation_v2_enabled in organizationServices. This gates the upcoming Eval 2.0 feature independently from the existing ai_evaluations flag.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases. 
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing
