### PR TITLE
feat: add Template Library Meta's pre-approved WhatsApp templates via Gupshup

### DIFF
--- a/api.docs/bruno/glific_api/Saved Searches/Session Template/Get Template Library.bru
+++ b/api.docs/bruno/glific_api/Saved Searches/Session Template/Get Template Library.bru
@@ -1,0 +1,40 @@
+meta {
+  name: Get Template Library
+  type: graphql
+  seq: 8
+}
+
+post {
+  url: {{api_url}}
+  body: graphql
+  auth: none
+}
+
+headers {
+  authorization: {{auth_token}}
+  Content-Type: application/json
+}
+
+body:graphql {
+  query templateLibrary($filter: TemplateLibraryFilter) {
+    templateLibrary(filter: $filter) {
+      elementName
+      category
+      body
+      languageCode
+      industry
+      topic
+      usecase
+      containerMeta
+    }
+  }
+}
+
+body:graphql:vars {
+  {
+    "filter": {
+      "industry": "retail",
+      "languageCode": "en"
+    }
+  }
+}

--- a/api.docs/bruno/glific_api/Saved Searches/Session Template/Get Template Library.bru
+++ b/api.docs/bruno/glific_api/Saved Searches/Session Template/Get Template Library.bru
@@ -16,8 +16,8 @@ headers {
 }
 
 body:graphql {
-  query templateLibrary($filter: TemplateLibraryFilter) {
-    templateLibrary(filter: $filter) {
+  query templateLibrary {
+    templateLibrary {
       elementName
       category
       body
@@ -26,15 +26,6 @@ body:graphql {
       topic
       usecase
       containerMeta
-    }
-  }
-}
-
-body:graphql:vars {
-  {
-    "filter": {
-      "industry": "retail",
-      "languageCode": "en"
     }
   }
 }

--- a/assets/gql/session_templates/template_library.gql
+++ b/assets/gql/session_templates/template_library.gql
@@ -1,0 +1,12 @@
+query templateLibrary($filter: TemplateLibraryFilter) {
+  templateLibrary(filter: $filter) {
+    elementName
+    category
+    body
+    languageCode
+    industry
+    topic
+    usecase
+    containerMeta
+  }
+}

--- a/assets/gql/session_templates/template_library.gql
+++ b/assets/gql/session_templates/template_library.gql
@@ -1,5 +1,5 @@
-query templateLibrary($filter: TemplateLibraryFilter) {
-  templateLibrary(filter: $filter) {
+query templateLibrary {
+  templateLibrary {
     elementName
     category
     body

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -516,15 +516,12 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     end
   end
 
-  # `:query` threads Tesla-native query params (e.g. for the template library search).
   @spec get_request(String.t(), Keyword.t()) :: tuple()
   defp get_request(url, opts) do
     req_headers =
       headers(Keyword.get(opts, :token_type, :app_token), opts)
 
-    query = Keyword.get(opts, :query, [])
-
-    get(url, headers: req_headers, query: query)
+    get(url, headers: req_headers)
     |> case do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -359,15 +359,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   end
 
   @doc """
-  Fetches Meta's pre-approved WhatsApp template library, live from Gupshup's
-  Partner API (`GET <app_url>/template/metalibrary`), using the requesting org's
-  own partner app token. This is a read-only passthrough for browsing Meta's
-  curated template catalog — it does not persist anything.
-
-  Fetches the org's full eligible catalog with no query filters — the UI
-  searches/filters the cached result client-side instead of re-querying.
-  Category-narrowing happens client-side in
-  `Glific.Providers.Gupshup.Template.search_library_templates/1`.
+  Fetches Meta's pre-approved WhatsApp template library from Gupshup's
+  Partner API (`GET <app_url>/template/metalibrary`) — read-only, no query
+  filters; the UI searches/filters the cached result client-side instead.
   """
   @spec get_library_templates(non_neg_integer()) :: {:ok, map()} | {:error, String.t()}
   def get_library_templates(org_id) do

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -364,20 +364,15 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   own partner app token. This is a read-only passthrough for browsing Meta's
   curated template catalog — it does not persist anything.
 
-  Supported filters (all optional, unknown/blank values are dropped):
-  `:elementName`, `:languageCode`, `:usecase`. Gupshup's API does not support
-  filtering by `category` — that's filtered client-side in
-  `Glific.Providers.Gupshup.Template.search_library_templates/2`.
+  Fetches the org's full eligible catalog with no query filters — the UI
+  searches/filters the cached result client-side instead of re-querying.
+  Category-narrowing happens client-side in
+  `Glific.Providers.Gupshup.Template.search_library_templates/1`.
   """
-  @spec get_library_templates(non_neg_integer(), map()) :: {:ok, map()} | {:error, String.t()}
-  def get_library_templates(org_id, filters \\ %{}) do
-    query =
-      filters
-      |> Map.take([:elementName, :languageCode, :usecase])
-      |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
-
+  @spec get_library_templates(non_neg_integer()) :: {:ok, map()} | {:error, String.t()}
+  def get_library_templates(org_id) do
     (app_url!(org_id) <> "/template/metalibrary")
-    |> get_request(org_id: org_id, query: query, raw_error: true)
+    |> get_request(org_id: org_id, raw_error: true)
     |> case do
       {:ok, response} ->
         {:ok, response}

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -358,6 +358,45 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     end
   end
 
+  @doc """
+  Fetches Meta's pre-approved WhatsApp template library, live from Gupshup's
+  Partner API (`GET <app_url>/template/metalibrary`), using the requesting org's
+  own partner app token. This is a read-only passthrough for browsing Meta's
+  curated template catalog — it does not persist anything.
+
+  Supported filters (all optional, unknown/blank values are dropped):
+  `:elementName`, `:industry`, `:languageCode`, `:topic`, `:usecase`. Gupshup's
+  API does not support filtering by `category` — that's filtered client-side
+  in `Glific.Providers.Gupshup.Template.search_library_templates/2`.
+  """
+  @spec get_library_templates(non_neg_integer(), map()) :: {:ok, map()} | {:error, String.t()}
+  def get_library_templates(org_id, filters \\ %{}) do
+    query =
+      filters
+      |> Map.take([:elementName, :industry, :languageCode, :topic, :usecase])
+      |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
+
+    (app_url!(org_id) <> "/template/metalibrary")
+    |> get_request(org_id: org_id, query: query, raw_error: true)
+    |> case do
+      {:ok, response} ->
+        {:ok, response}
+
+      {:error, %Tesla.Env{status: status, body: body}} when status in 400..499 ->
+        case Jason.decode(body) do
+          {:ok, %{"message" => message}} -> {:error, message}
+          _ -> {:error, "Error while fetching the template library"}
+        end
+
+      unmatched_response ->
+        Logger.error(
+          "Error while fetching the template library. #{Glific.SafeLog.safe_inspect(unmatched_response)}"
+        )
+
+        {:error, "Error while fetching the template library"}
+    end
+  end
+
   @global_organization_id 0
   @spec get_partner_token :: {:ok, map()} | {:error, any}
   defp get_partner_token do
@@ -499,15 +538,28 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     end
   end
 
+  # `:query` threads Tesla-native query params (e.g. for the template library search).
+  # `:raw_error` opts a caller into getting back the raw `%Tesla.Env{}` on a non-2xx
+  # response (mirroring `post_request/3`'s error shape) instead of the default
+  # safe-inspected string, so it can decode Gupshup's JSON error body itself
+  # (see `get_library_templates/2`). Defaults to `false` to keep every existing
+  # caller's `{:error, String.t()}` contract unchanged.
   @spec get_request(String.t(), Keyword.t()) :: tuple()
   defp get_request(url, opts) do
     req_headers =
       headers(Keyword.get(opts, :token_type, :app_token), opts)
 
-    get(url, headers: req_headers)
+    query = Keyword.get(opts, :query, [])
+
+    get(url, headers: req_headers, query: query)
     |> case do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}
+
+      {:ok, resp} ->
+        if Keyword.get(opts, :raw_error, false),
+          do: {:error, resp},
+          else: {:error, "#{Glific.SafeLog.safe_inspect(resp)}"}
 
       err ->
         {:error, "#{Glific.SafeLog.safe_inspect(err)}"}

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -365,15 +365,15 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   curated template catalog — it does not persist anything.
 
   Supported filters (all optional, unknown/blank values are dropped):
-  `:elementName`, `:industry`, `:languageCode`, `:topic`, `:usecase`. Gupshup's
-  API does not support filtering by `category` — that's filtered client-side
-  in `Glific.Providers.Gupshup.Template.search_library_templates/2`.
+  `:elementName`, `:languageCode`, `:usecase`. Gupshup's API does not support
+  filtering by `category` — that's filtered client-side in
+  `Glific.Providers.Gupshup.Template.search_library_templates/2`.
   """
   @spec get_library_templates(non_neg_integer(), map()) :: {:ok, map()} | {:error, String.t()}
   def get_library_templates(org_id, filters \\ %{}) do
     query =
       filters
-      |> Map.take([:elementName, :industry, :languageCode, :topic, :usecase])
+      |> Map.take([:elementName, :languageCode, :usecase])
       |> Enum.reject(fn {_key, value} -> value in [nil, ""] end)
 
     (app_url!(org_id) <> "/template/metalibrary")

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -526,12 +526,6 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, %Tesla.Env{body: body} = resp} ->
-        case Jason.decode(body) do
-          {:ok, %{"message" => message}} -> {:error, message}
-          _ -> {:error, "#{Glific.SafeLog.safe_inspect(resp)}"}
-        end
-
       err ->
         {:error, "#{Glific.SafeLog.safe_inspect(err)}"}
     end

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -372,24 +372,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @spec get_library_templates(non_neg_integer()) :: {:ok, map()} | {:error, String.t()}
   def get_library_templates(org_id) do
     (app_url!(org_id) <> "/template/metalibrary")
-    |> get_request(org_id: org_id, raw_error: true)
-    |> case do
-      {:ok, response} ->
-        {:ok, response}
-
-      {:error, %Tesla.Env{status: status, body: body}} when status in 400..499 ->
-        case Jason.decode(body) do
-          {:ok, %{"message" => message}} -> {:error, message}
-          _ -> {:error, "Error while fetching the template library"}
-        end
-
-      unmatched_response ->
-        Logger.error(
-          "Error while fetching the template library. #{Glific.SafeLog.safe_inspect(unmatched_response)}"
-        )
-
-        {:error, "Error while fetching the template library"}
-    end
+    |> get_request(org_id: org_id)
   end
 
   @global_organization_id 0
@@ -534,11 +517,6 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   end
 
   # `:query` threads Tesla-native query params (e.g. for the template library search).
-  # `:raw_error` opts a caller into getting back the raw `%Tesla.Env{}` on a non-2xx
-  # response (mirroring `post_request/3`'s error shape) instead of the default
-  # safe-inspected string, so it can decode Gupshup's JSON error body itself
-  # (see `get_library_templates/2`). Defaults to `false` to keep every existing
-  # caller's `{:error, String.t()}` contract unchanged.
   @spec get_request(String.t(), Keyword.t()) :: tuple()
   defp get_request(url, opts) do
     req_headers =
@@ -551,10 +529,11 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}
 
-      {:ok, resp} ->
-        if Keyword.get(opts, :raw_error, false),
-          do: {:error, resp},
-          else: {:error, "#{Glific.SafeLog.safe_inspect(resp)}"}
+      {:ok, %Tesla.Env{body: body} = resp} ->
+        case Jason.decode(body) do
+          {:ok, %{"message" => message}} -> {:error, message}
+          _ -> {:error, "#{Glific.SafeLog.safe_inspect(resp)}"}
+        end
 
       err ->
         {:error, "#{Glific.SafeLog.safe_inspect(err)}"}

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -396,11 +396,11 @@ defmodule Glific.Providers.Gupshup.Template do
   the `PAYMENTS` and `ORDER_MANAGEMENT` topics, and are limited to languages
   the organization has active.
   """
-  @spec search_library_templates(non_neg_integer(), map()) ::
+  @spec search_library_templates(non_neg_integer()) ::
           {:ok, list(map())} | {:error, String.t()}
-  def search_library_templates(org_id, filters) do
+  def search_library_templates(org_id) do
     org_id
-    |> PartnerAPI.get_library_templates(to_gupshup_library_filters(filters))
+    |> PartnerAPI.get_library_templates()
     |> case do
       {:ok, %{"templates" => templates}} when is_list(templates) ->
         Instrumentation.track_action("template_library_search", :success, org_id)
@@ -414,15 +414,6 @@ defmodule Glific.Providers.Gupshup.Template do
         Instrumentation.track_action("template_library_search", :failure, org_id)
         {:error, reason}
     end
-  end
-
-  @spec to_gupshup_library_filters(map()) :: map()
-  defp to_gupshup_library_filters(filters) do
-    %{
-      elementName: Map.get(filters, :element_name),
-      languageCode: Map.get(filters, :language_code),
-      usecase: Map.get(filters, :usecase)
-    }
   end
 
   @spec filter_library_templates(list(map()), non_neg_integer()) :: list(map())

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -23,6 +23,9 @@ defmodule Glific.Providers.Gupshup.Template do
     "Sign Language"
   ]
 
+  @library_category "UTILITY"
+  @library_excluded_topics ["PAYMENTS", "ORDER_MANAGEMENT"]
+
   import Ecto.Query
 
   alias Glific.{
@@ -382,6 +385,91 @@ defmodule Glific.Providers.Gupshup.Template do
     do: template |> Map.merge(%{buttons: attrs.buttons})
 
   defp append_buttons(template, _attrs), do: template
+
+  @doc """
+  Searches Meta's pre-approved WhatsApp template library, fetched live from
+  Gupshup's Partner API. Read-only passthrough — used to let the frontend browse
+  Meta's curated template catalog and prefill the create template form. Does
+  **not** create any `SessionTemplate` rows.
+
+  Results are narrowed to `#{@library_category}` category templates, exclude
+  the `PAYMENTS` and `ORDER_MANAGEMENT` topics, and are limited to languages
+  the organization has active.
+  """
+  @spec search_library_templates(non_neg_integer(), map()) ::
+          {:ok, list(map())} | {:error, String.t()}
+  def search_library_templates(org_id, filters) do
+    org_id
+    |> PartnerAPI.get_library_templates(to_gupshup_library_filters(filters))
+    |> case do
+      {:ok, %{"templates" => templates}} when is_list(templates) ->
+        Instrumentation.track_action("template_library_search", :success, org_id)
+        {:ok, templates |> filter_library_templates(org_id) |> Enum.map(&to_library_entry/1)}
+
+      {:ok, _response} ->
+        Instrumentation.track_action("template_library_search", :success, org_id)
+        {:ok, []}
+
+      {:error, reason} ->
+        Instrumentation.track_action("template_library_search", :failure, org_id)
+        {:error, reason}
+    end
+  end
+
+  @spec to_gupshup_library_filters(map()) :: map()
+  defp to_gupshup_library_filters(filters) do
+    %{
+      elementName: Map.get(filters, :element_name),
+      industry: Map.get(filters, :industry),
+      languageCode: Map.get(filters, :language_code),
+      topic: Map.get(filters, :topic),
+      usecase: Map.get(filters, :usecase)
+    }
+  end
+
+  @spec filter_library_templates(list(map()), non_neg_integer()) :: list(map())
+  defp filter_library_templates(templates, org_id) do
+    active_locales =
+      org_id
+      |> Partners.organization()
+      |> Map.get(:languages, [])
+      |> MapSet.new(& &1.locale)
+
+    Enum.filter(templates, &keep_library_template?(&1, active_locales))
+  end
+
+  @spec keep_library_template?(map(), MapSet.t()) :: boolean()
+  defp keep_library_template?(template, active_locales) do
+    utility_category?(template["category"]) and
+      allowed_topic?(template["topic"]) and
+      MapSet.member?(active_locales, template["languageCode"])
+  end
+
+  @spec utility_category?(String.t() | nil) :: boolean()
+  defp utility_category?(category) when is_binary(category),
+    do: String.upcase(category) == @library_category
+
+  defp utility_category?(_category), do: false
+
+  @spec allowed_topic?(String.t() | nil) :: boolean()
+  defp allowed_topic?(topic) when is_binary(topic),
+    do: String.upcase(topic) not in @library_excluded_topics
+
+  defp allowed_topic?(_topic), do: true
+
+  @spec to_library_entry(map()) :: map()
+  defp to_library_entry(template) do
+    %{
+      element_name: template["elementName"],
+      category: template["category"],
+      body: template["data"],
+      language_code: template["languageCode"],
+      industry: template["industry"],
+      topic: template["topic"],
+      usecase: template["usecase"],
+      container_meta: template["containerMeta"]
+    }
+  end
 
   @doc """
   Updating HSM templates for an organization

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -456,9 +456,24 @@ defmodule Glific.Providers.Gupshup.Template do
       industry: template["industry"],
       topic: template["topic"],
       usecase: template["usecase"],
-      container_meta: template["containerMeta"]
+      container_meta: decode_container_meta(template["containerMeta"])
     }
   end
+
+  # Gupshup returns containerMeta as an already JSON-encoded string, not a
+  # decoded object. Passing that raw string straight through the `:json`
+  # scalar (which calls Poison.encode!/1 on whatever it's given) would encode
+  # it a second time, double-escaping the buttons/footer/etc it carries.
+  @spec decode_container_meta(String.t() | map() | nil) :: map()
+  defp decode_container_meta(container_meta) when is_binary(container_meta) do
+    case Jason.decode(container_meta) do
+      {:ok, decoded} when is_map(decoded) -> decoded
+      _ -> %{}
+    end
+  end
+
+  defp decode_container_meta(container_meta) when is_map(container_meta), do: container_meta
+  defp decode_container_meta(_container_meta), do: %{}
 
   @doc """
   Updating HSM templates for an organization

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -420,9 +420,7 @@ defmodule Glific.Providers.Gupshup.Template do
   defp to_gupshup_library_filters(filters) do
     %{
       elementName: Map.get(filters, :element_name),
-      industry: Map.get(filters, :industry),
       languageCode: Map.get(filters, :language_code),
-      topic: Map.get(filters, :topic),
       usecase: Map.get(filters, :usecase)
     }
   end

--- a/lib/glific/providers/gupshup/template.ex
+++ b/lib/glific/providers/gupshup/template.ex
@@ -406,10 +406,6 @@ defmodule Glific.Providers.Gupshup.Template do
         Instrumentation.track_action("template_library_search", :success, org_id)
         {:ok, templates |> filter_library_templates(org_id) |> Enum.map(&to_library_entry/1)}
 
-      {:ok, _response} ->
-        Instrumentation.track_action("template_library_search", :success, org_id)
-        {:ok, []}
-
       {:error, reason} ->
         Instrumentation.track_action("template_library_search", :failure, org_id)
         {:error, reason}
@@ -460,10 +456,6 @@ defmodule Glific.Providers.Gupshup.Template do
     }
   end
 
-  # Gupshup returns containerMeta as an already JSON-encoded string, not a
-  # decoded object. Passing that raw string straight through the `:json`
-  # scalar (which calls Poison.encode!/1 on whatever it's given) would encode
-  # it a second time, double-escaping the buttons/footer/etc it carries.
   @spec decode_container_meta(String.t() | map() | nil) :: map()
   defp decode_container_meta(container_meta) when is_binary(container_meta) do
     case Jason.decode(container_meta) do

--- a/lib/glific/providers/gupshup_enterprise/template.ex
+++ b/lib/glific/providers/gupshup_enterprise/template.ex
@@ -3,6 +3,7 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   Module for handling template operations specific to Gupshup
   """
 
+  @behaviour Glific.Providers.TemplateBehaviour
   alias Glific.{
     Partners,
     Repo,
@@ -47,6 +48,14 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   def bulk_apply_templates(_organization_id, _data) do
     {:ok, %{message: "Feature not available"}}
   end
+
+  @doc """
+  Searches Meta's pre-approved WhatsApp template library. Not available for
+  GupshupEnterprise, which has no equivalent partner API.
+  """
+  @spec search_library_templates(non_neg_integer()) ::
+          {:ok, list(map())} | {:error, String.t()}
+  def search_library_templates(_organization_id), do: {:error, "Feature not available"}
 
   @doc """
   Updating HSM templates for an organization

--- a/lib/glific/providers/gupshup_enterprise/template.ex
+++ b/lib/glific/providers/gupshup_enterprise/template.ex
@@ -3,7 +3,6 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   Module for handling template operations specific to Gupshup
   """
 
-  @behaviour Glific.Providers.TemplateBehaviour
   alias Glific.{
     Partners,
     Repo,
@@ -48,14 +47,6 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   def bulk_apply_templates(_organization_id, _data) do
     {:ok, %{message: "Feature not available"}}
   end
-
-  @doc """
-  Searches Meta's pre-approved WhatsApp template library. Not available for
-  GupshupEnterprise, which has no equivalent partner API.
-  """
-  @spec search_library_templates(non_neg_integer()) ::
-          {:ok, list(map())} | {:error, String.t()}
-  def search_library_templates(_organization_id), do: {:error, "Feature not available"}
 
   @doc """
   Updating HSM templates for an organization

--- a/lib/glific/providers/gupshup_enterprise/template.ex
+++ b/lib/glific/providers/gupshup_enterprise/template.ex
@@ -53,9 +53,9 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   Searches Meta's pre-approved WhatsApp template library. Not available for
   GupshupEnterprise, which has no equivalent partner API.
   """
-  @spec search_library_templates(non_neg_integer(), map()) ::
+  @spec search_library_templates(non_neg_integer()) ::
           {:ok, list(map())} | {:error, String.t()}
-  def search_library_templates(_organization_id, _filters), do: {:error, "Feature not available"}
+  def search_library_templates(_organization_id), do: {:error, "Feature not available"}
 
   @doc """
   Updating HSM templates for an organization

--- a/lib/glific/providers/gupshup_enterprise/template.ex
+++ b/lib/glific/providers/gupshup_enterprise/template.ex
@@ -50,6 +50,14 @@ defmodule Glific.Providers.GupshupEnterprise.Template do
   end
 
   @doc """
+  Searches Meta's pre-approved WhatsApp template library. Not available for
+  GupshupEnterprise, which has no equivalent partner API.
+  """
+  @spec search_library_templates(non_neg_integer(), map()) ::
+          {:ok, list(map())} | {:error, String.t()}
+  def search_library_templates(_organization_id, _filters), do: {:error, "Feature not available"}
+
+  @doc """
   Updating HSM templates for an organization
   """
   @spec update_hsm_templates(non_neg_integer()) :: :ok | {:error, String.t()}

--- a/lib/glific/providers/template_behaviour.ex
+++ b/lib/glific/providers/template_behaviour.ex
@@ -17,4 +17,7 @@ defmodule Glific.Providers.TemplateBehaviour do
 
   @callback bulk_apply_templates(org_id :: non_neg_integer(), data :: String.t()) ::
               :ok | {:ok, any}
+
+  @callback search_library_templates(org_id :: non_neg_integer(), filters :: map()) ::
+              {:ok, list(map())} | {:error, String.t()}
 end

--- a/lib/glific/providers/template_behaviour.ex
+++ b/lib/glific/providers/template_behaviour.ex
@@ -18,6 +18,6 @@ defmodule Glific.Providers.TemplateBehaviour do
   @callback bulk_apply_templates(org_id :: non_neg_integer(), data :: String.t()) ::
               :ok | {:ok, any}
 
-  @callback search_library_templates(org_id :: non_neg_integer(), filters :: map()) ::
+  @callback search_library_templates(org_id :: non_neg_integer()) ::
               {:ok, list(map())} | {:error, String.t()}
 end

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -339,31 +339,33 @@ defmodule Glific.Templates do
   browse Meta's curated template catalog and prefill the create template form —
   it does **not** create any `SessionTemplate` rows.
 
-  Results are cached per organization/filter-combo for a short window, since the
-  same filters are commonly re-queried while a user browses the catalog and the
-  partner API is otherwise hit on every keystroke.
+  There's no caller-facing filtering: the BSP module fetches the org's full
+  eligible catalog (already narrowed to Utility templates, excluded topics, and
+  the org's active languages) and the UI searches/filters that cached payload
+  client-side. Results are cached per organization for a short window, since
+  the same catalog is otherwise re-fetched on every catalog open.
   """
-  @spec search_library_templates(non_neg_integer(), map()) ::
+  @spec search_library_templates(non_neg_integer()) ::
           {:ok, list(map())} | {:error, String.t()}
-  def search_library_templates(organization_id, filters) do
+  def search_library_templates(organization_id) do
     # Active languages are part of the cache key (not just invalidated after the
     # fact) so a stale entry can never outlive an org's language settings change:
     # changing active_language_ids yields a new key instead of serving old results.
     active_language_ids = Partners.organization(organization_id).active_language_ids
-    cache_key = {:template_library, filters, active_language_ids}
+    cache_key = {:template_library, active_language_ids}
 
     case Caches.get(organization_id, cache_key, refresh_cache: false) do
-      {:ok, false} -> fetch_library_templates(organization_id, filters, cache_key)
+      {:ok, false} -> fetch_library_templates(organization_id, cache_key)
       {:ok, templates} -> {:ok, templates}
     end
   end
 
-  @spec fetch_library_templates(non_neg_integer(), map(), tuple()) ::
+  @spec fetch_library_templates(non_neg_integer(), tuple()) ::
           {:ok, list(map())} | {:error, String.t()}
-  defp fetch_library_templates(organization_id, filters, cache_key) do
+  defp fetch_library_templates(organization_id, cache_key) do
     bsp_module = Provider.bsp_module(organization_id, :template)
 
-    case bsp_module.search_library_templates(organization_id, filters) do
+    case bsp_module.search_library_templates(organization_id) do
       {:ok, templates} = result ->
         Caches.set(organization_id, cache_key, templates, ttl: :timer.minutes(20))
         result

--- a/lib/glific/templates.ex
+++ b/lib/glific/templates.ex
@@ -7,6 +7,7 @@ defmodule Glific.Templates do
   plug(Tesla.Middleware.FormUrlencoded)
 
   alias Glific.{
+    Caches,
     Communications.Mailer,
     Contacts.Contact,
     Flows.Translate.GoogleTranslate,
@@ -330,6 +331,46 @@ defmodule Glific.Templates do
   @spec bulk_apply_templates(non_neg_integer(), String.t()) :: {:ok, any} | {:error, any}
   def bulk_apply_templates(org_id, data) do
     Provider.bsp_module(org_id, :template).bulk_apply_templates(org_id, data)
+  end
+
+  @doc """
+  Searches Meta's pre-approved WhatsApp template library, fetched live from the
+  organization's BSP partner API. Read-only passthrough for the frontend to
+  browse Meta's curated template catalog and prefill the create template form —
+  it does **not** create any `SessionTemplate` rows.
+
+  Results are cached per organization/filter-combo for a short window, since the
+  same filters are commonly re-queried while a user browses the catalog and the
+  partner API is otherwise hit on every keystroke.
+  """
+  @spec search_library_templates(non_neg_integer(), map()) ::
+          {:ok, list(map())} | {:error, String.t()}
+  def search_library_templates(organization_id, filters) do
+    # Active languages are part of the cache key (not just invalidated after the
+    # fact) so a stale entry can never outlive an org's language settings change:
+    # changing active_language_ids yields a new key instead of serving old results.
+    active_language_ids = Partners.organization(organization_id).active_language_ids
+    cache_key = {:template_library, filters, active_language_ids}
+
+    case Caches.get(organization_id, cache_key, refresh_cache: false) do
+      {:ok, false} -> fetch_library_templates(organization_id, filters, cache_key)
+      {:ok, templates} -> {:ok, templates}
+    end
+  end
+
+  @spec fetch_library_templates(non_neg_integer(), map(), tuple()) ::
+          {:ok, list(map())} | {:error, String.t()}
+  defp fetch_library_templates(organization_id, filters, cache_key) do
+    bsp_module = Provider.bsp_module(organization_id, :template)
+
+    case bsp_module.search_library_templates(organization_id, filters) do
+      {:ok, templates} = result ->
+        Caches.set(organization_id, cache_key, templates, ttl: :timer.minutes(20))
+        result
+
+      error ->
+        error
+    end
   end
 
   @doc """

--- a/lib/glific_web/resolvers/templates.ex
+++ b/lib/glific_web/resolvers/templates.ex
@@ -51,7 +51,7 @@ defmodule GlificWeb.Resolvers.Templates do
   @spec template_library(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, list(map())} | {:error, any}
   def template_library(_, args, %{context: %{current_user: user}}) do
-    Templates.search_library_templates(user.organization_id, Map.get(args, :filter, %{}))
+    Templates.search_library_templates(user.organization_id, Map.get(args, :filter) || %{})
   end
 
   @doc false

--- a/lib/glific_web/resolvers/templates.ex
+++ b/lib/glific_web/resolvers/templates.ex
@@ -50,8 +50,8 @@ defmodule GlificWeb.Resolvers.Templates do
   """
   @spec template_library(Absinthe.Resolution.t(), map(), %{context: map()}) ::
           {:ok, list(map())} | {:error, any}
-  def template_library(_, args, %{context: %{current_user: user}}) do
-    Templates.search_library_templates(user.organization_id, Map.get(args, :filter) || %{})
+  def template_library(_, _args, %{context: %{current_user: user}}) do
+    Templates.search_library_templates(user.organization_id)
   end
 
   @doc false

--- a/lib/glific_web/resolvers/templates.ex
+++ b/lib/glific_web/resolvers/templates.ex
@@ -43,6 +43,17 @@ defmodule GlificWeb.Resolvers.Templates do
     {:ok, Templates.count_session_templates(args)}
   end
 
+  @doc """
+  Browse Meta's pre-approved WhatsApp template library, fetched live from the
+  organization's BSP partner API. Read-only passthrough — does not create any
+  session templates.
+  """
+  @spec template_library(Absinthe.Resolution.t(), map(), %{context: map()}) ::
+          {:ok, list(map())} | {:error, any}
+  def template_library(_, args, %{context: %{current_user: user}}) do
+    Templates.search_library_templates(user.organization_id, Map.get(args, :filter, %{}))
+  end
+
   @doc false
   @spec create_session_template(Absinthe.Resolution.t(), %{input: map()}, %{context: map()}) ::
           {:ok, any} | {:error, any}

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -182,18 +182,6 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :container_meta, :json
   end
 
-  @desc "Filtering options for the template library search. All fields are optional."
-  input_object :template_library_filter do
-    @desc "Match the template's element name"
-    field :element_name, :string
-
-    @desc "Match the template's language code"
-    field :language_code, :string
-
-    @desc "Match the template's usecase"
-    field :usecase, :string
-  end
-
   object :session_template_queries do
     field :whatsapp_hsm_categories, list_of(:string) do
       middleware(Authorize, :manager)
@@ -227,7 +215,6 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
 
     @desc "Browse Meta's pre-approved WhatsApp template library, fetched live from the BSP partner API"
     field :template_library, list_of(:template_library_entry) do
-      arg(:filter, :template_library_filter)
       middleware(Authorize, :staff)
       resolve(&Resolvers.Templates.template_library/3)
     end

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -170,6 +170,36 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     field :language_id, :id
   end
 
+  @desc "An entry from Meta's pre-approved WhatsApp template library (Gupshup partner API passthrough). Read-only — not a persisted SessionTemplate."
+  object :template_library_entry do
+    field :element_name, :string
+    field :category, :string
+    field :body, :string
+    field :language_code, :string
+    field :industry, :string
+    field :topic, :string
+    field :usecase, :string
+    field :container_meta, :json
+  end
+
+  @desc "Filtering options for the template library search. All fields are optional."
+  input_object :template_library_filter do
+    @desc "Match the template's element name"
+    field :element_name, :string
+
+    @desc "Match the template's industry"
+    field :industry, :string
+
+    @desc "Match the template's language code"
+    field :language_code, :string
+
+    @desc "Match the template's topic"
+    field :topic, :string
+
+    @desc "Match the template's usecase"
+    field :usecase, :string
+  end
+
   object :session_template_queries do
     field :whatsapp_hsm_categories, list_of(:string) do
       middleware(Authorize, :manager)
@@ -199,6 +229,13 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
       arg(:filter, :session_template_filter)
       middleware(Authorize, :manager)
       resolve(&Resolvers.Templates.count_session_templates/3)
+    end
+
+    @desc "Browse Meta's pre-approved WhatsApp template library, fetched live from the BSP partner API"
+    field :template_library, list_of(:template_library_entry) do
+      arg(:filter, :template_library_filter)
+      middleware(Authorize, :staff)
+      resolve(&Resolvers.Templates.template_library/3)
     end
   end
 

--- a/lib/glific_web/schema/session_template_type.ex
+++ b/lib/glific_web/schema/session_template_type.ex
@@ -187,14 +187,8 @@ defmodule GlificWeb.Schema.SessionTemplateTypes do
     @desc "Match the template's element name"
     field :element_name, :string
 
-    @desc "Match the template's industry"
-    field :industry, :string
-
     @desc "Match the template's language code"
     field :language_code, :string
-
-    @desc "Match the template's topic"
-    field :topic, :string
 
     @desc "Match the template's usecase"
     field :usecase, :string

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -1,0 +1,116 @@
+defmodule Glific.Providers.Gupshup.PartnerAPITest do
+  use Glific.DataCase
+
+  alias Glific.Providers.Gupshup.PartnerAPI
+
+  describe "get_library_templates/2" do
+    test "returns the template library on a successful response", attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{
+          method: :get,
+          url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+        } ->
+          %Tesla.Env{
+            status: 200,
+            body:
+              Jason.encode!(%{
+                "templates" => [
+                  %{
+                    "elementName" => "welcome_offer",
+                    "category" => "MARKETING",
+                    "data" => "Hello {{1}}, welcome to our store!",
+                    "industry" => "retail",
+                    "languageCode" => "en",
+                    "topic" => "welcome",
+                    "usecase" => "onboarding",
+                    "containerMeta" => %{"buttons" => []}
+                  }
+                ]
+              })
+          }
+      end)
+
+      assert {:ok, %{"templates" => [template]}} =
+               PartnerAPI.get_library_templates(attrs.organization_id, %{industry: "retail"})
+
+      assert template["elementName"] == "welcome_offer"
+      assert template["languageCode"] == "en"
+    end
+
+    test "drops nil/blank filters before calling the partner API", attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{method: :get, query: query} ->
+          # elementName/topic/usecase should have been dropped as nil/blank,
+          # only industry should remain in the query string.
+          assert Keyword.get(query, :industry) == "retail"
+          assert length(query) == 1
+
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"templates" => []})
+          }
+      end)
+
+      assert {:ok, %{"templates" => []}} =
+               PartnerAPI.get_library_templates(attrs.organization_id, %{
+                 industry: "retail",
+                 elementName: nil,
+                 topic: "",
+                 usecase: nil
+               })
+    end
+
+    test "returns Gupshup's decoded error message on a 4xx response", attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{
+          method: :get,
+          url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+        } ->
+          %Tesla.Env{
+            status: 400,
+            body: Jason.encode!(%{"message" => "Invalid industry filter"})
+          }
+      end)
+
+      assert {:error, "Invalid industry filter"} =
+               PartnerAPI.get_library_templates(attrs.organization_id, %{industry: "bogus"})
+    end
+
+    test "returns a generic error on an unexpected/malformed response", attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{
+          method: :get,
+          url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+        } ->
+          %Tesla.Env{status: 500, body: "internal server error"}
+      end)
+
+      assert {:error, "Error while fetching the template library"} =
+               PartnerAPI.get_library_templates(attrs.organization_id, %{})
+    end
+  end
+end

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -84,7 +84,8 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       assert {:error, "Invalid request"} = PartnerAPI.get_library_templates(attrs.organization_id)
     end
 
-    test "returns a generic error on an unexpected/malformed response", attrs do
+    test "falls back to a safe-inspected error when the response body isn't decodable JSON",
+         attrs do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
           %Tesla.Env{
@@ -99,8 +100,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
           %Tesla.Env{status: 500, body: "internal server error"}
       end)
 
-      assert {:error, "Error while fetching the template library"} =
-               PartnerAPI.get_library_templates(attrs.organization_id)
+      assert {:error, message} = PartnerAPI.get_library_templates(attrs.organization_id)
+      assert message =~ "500"
+      assert message =~ "internal server error"
     end
   end
 end

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -37,13 +37,16 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       end)
 
       assert {:ok, %{"templates" => [template]}} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{industry: "retail"})
+               PartnerAPI.get_library_templates(attrs.organization_id, %{
+                 element_name: "welcome_offer"
+               })
 
       assert template["elementName"] == "welcome_offer"
       assert template["languageCode"] == "en"
     end
 
-    test "drops nil/blank filters before calling the partner API", attrs do
+    test "drops nil/blank filters, and ignores industry/topic since they're no longer supported filters",
+         attrs do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
           %Tesla.Env{
@@ -52,9 +55,10 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
           }
 
         %{method: :get, query: query} ->
-          # elementName/topic/usecase should have been dropped as nil/blank,
-          # only industry should remain in the query string.
-          assert Keyword.get(query, :industry) == "retail"
+          # elementName/languageCode should have been dropped as nil/blank;
+          # industry/topic are dropped unconditionally (unsupported filters,
+          # even with real values); only usecase should remain in the query.
+          assert Keyword.get(query, :usecase) == "onboarding"
           assert length(query) == 1
 
           %Tesla.Env{
@@ -65,10 +69,11 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
 
       assert {:ok, %{"templates" => []}} =
                PartnerAPI.get_library_templates(attrs.organization_id, %{
-                 industry: "retail",
+                 usecase: "onboarding",
                  elementName: nil,
-                 topic: "",
-                 usecase: nil
+                 languageCode: "",
+                 industry: "retail",
+                 topic: "welcome"
                })
     end
 
@@ -86,12 +91,12 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
         } ->
           %Tesla.Env{
             status: 400,
-            body: Jason.encode!(%{"message" => "Invalid industry filter"})
+            body: Jason.encode!(%{"message" => "Invalid usecase filter"})
           }
       end)
 
-      assert {:error, "Invalid industry filter"} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{industry: "bogus"})
+      assert {:error, "Invalid usecase filter"} =
+               PartnerAPI.get_library_templates(attrs.organization_id, %{usecase: "bogus"})
     end
 
     test "returns a generic error on an unexpected/malformed response", attrs do

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -63,7 +63,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       assert {:ok, %{"templates" => []}} = PartnerAPI.get_library_templates(attrs.organization_id)
     end
 
-    test "returns Gupshup's decoded error message on a 4xx response", attrs do
+    test "returns a safe-inspected error on a 4xx response", attrs do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
           %Tesla.Env{
@@ -81,7 +81,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
           }
       end)
 
-      assert {:error, "Invalid request"} = PartnerAPI.get_library_templates(attrs.organization_id)
+      assert {:error, message} = PartnerAPI.get_library_templates(attrs.organization_id)
+      assert message =~ "400"
+      assert message =~ "Invalid request"
     end
 
     test "falls back to a safe-inspected error when the response body isn't decodable JSON",

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -3,7 +3,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
 
   alias Glific.Providers.Gupshup.PartnerAPI
 
-  describe "get_library_templates/2" do
+  describe "get_library_templates/1" do
     test "returns the template library on a successful response", attrs do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
@@ -37,16 +37,13 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       end)
 
       assert {:ok, %{"templates" => [template]}} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{
-                 element_name: "welcome_offer"
-               })
+               PartnerAPI.get_library_templates(attrs.organization_id)
 
       assert template["elementName"] == "welcome_offer"
       assert template["languageCode"] == "en"
     end
 
-    test "drops nil/blank filters, and ignores industry/topic since they're no longer supported filters",
-         attrs do
+    test "requests the catalog with no query filters", attrs do
       Tesla.Mock.mock(fn
         %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
           %Tesla.Env{
@@ -55,11 +52,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
           }
 
         %{method: :get, query: query} ->
-          # elementName/languageCode should have been dropped as nil/blank;
-          # industry/topic are dropped unconditionally (unsupported filters,
-          # even with real values); only usecase should remain in the query.
-          assert Keyword.get(query, :usecase) == "onboarding"
-          assert length(query) == 1
+          assert query == []
 
           %Tesla.Env{
             status: 200,
@@ -67,14 +60,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
           }
       end)
 
-      assert {:ok, %{"templates" => []}} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{
-                 usecase: "onboarding",
-                 elementName: nil,
-                 languageCode: "",
-                 industry: "retail",
-                 topic: "welcome"
-               })
+      assert {:ok, %{"templates" => []}} = PartnerAPI.get_library_templates(attrs.organization_id)
     end
 
     test "returns Gupshup's decoded error message on a 4xx response", attrs do
@@ -91,12 +77,11 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
         } ->
           %Tesla.Env{
             status: 400,
-            body: Jason.encode!(%{"message" => "Invalid usecase filter"})
+            body: Jason.encode!(%{"message" => "Invalid request"})
           }
       end)
 
-      assert {:error, "Invalid usecase filter"} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{usecase: "bogus"})
+      assert {:error, "Invalid request"} = PartnerAPI.get_library_templates(attrs.organization_id)
     end
 
     test "returns a generic error on an unexpected/malformed response", attrs do
@@ -115,7 +100,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       end)
 
       assert {:error, "Error while fetching the template library"} =
-               PartnerAPI.get_library_templates(attrs.organization_id, %{})
+               PartnerAPI.get_library_templates(attrs.organization_id)
     end
   end
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2833,7 +2833,9 @@ defmodule Glific.TemplatesTest do
     end)
 
     assert {:ok, templates_before} =
-             Templates.search_library_templates(attrs.organization_id, %{industry: "retail"})
+             Templates.search_library_templates(attrs.organization_id, %{
+               industry: "manufacturing"
+             })
 
     assert templates_before |> Enum.map(& &1.element_name) |> Enum.sort() ==
              ["utility_english", "utility_hindi"]
@@ -2844,7 +2846,9 @@ defmodule Glific.TemplatesTest do
              Partners.update_organization(organization, %{active_language_ids: [1]})
 
     assert {:ok, templates_after} =
-             Templates.search_library_templates(attrs.organization_id, %{industry: "retail"})
+             Templates.search_library_templates(attrs.organization_id, %{
+               industry: "manufacturing"
+             })
 
     assert Enum.map(templates_after, & &1.element_name) == ["utility_english"]
   end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2786,4 +2786,66 @@ defmodule Glific.TemplatesTest do
                attrs.organization_id
              )
   end
+
+  test "search_library_templates/2 stops serving a stale cache when the org's active languages change",
+       attrs do
+    organization = Partners.get_organization!(attrs.organization_id)
+
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "templates" => [
+                %{
+                  "elementName" => "utility_english",
+                  "category" => "UTILITY",
+                  "data" => "Hello {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "utility_hindi",
+                  "category" => "UTILITY",
+                  "data" => "Namaste {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "hi",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                }
+              ]
+            })
+        }
+    end)
+
+    assert {:ok, templates_before} =
+             Templates.search_library_templates(attrs.organization_id, %{industry: "retail"})
+
+    assert templates_before |> Enum.map(& &1.element_name) |> Enum.sort() ==
+             ["utility_english", "utility_hindi"]
+
+    # Dropping Hindi from the org's active languages must be reflected
+    # immediately, not after the 20-minute cache TTL expires.
+    assert {:ok, _updated_organization} =
+             Partners.update_organization(organization, %{active_language_ids: [1]})
+
+    assert {:ok, templates_after} =
+             Templates.search_library_templates(attrs.organization_id, %{industry: "retail"})
+
+    assert Enum.map(templates_after, & &1.element_name) == ["utility_english"]
+  end
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -3,6 +3,7 @@ defmodule Glific.TemplatesTest do
   use Oban.Pro.Testing, repo: Glific.Repo
 
   alias Glific.{
+    Caches,
     Fixtures,
     Mails.MailLog,
     Messages,
@@ -25,6 +26,9 @@ defmodule Glific.TemplatesTest do
   setup do
     organization = SeedsDev.seed_organizations()
     SeedsDev.hsm_templates(organization)
+    active_language_ids = Partners.organization(organization.id).active_language_ids
+    Caches.remove(organization.id, [{:template_library, active_language_ids}])
+
     :ok
   end
 
@@ -2787,7 +2791,7 @@ defmodule Glific.TemplatesTest do
              )
   end
 
-  test "search_library_templates/2 stops serving a stale cache when the org's active languages change",
+  test "search_library_templates/1 stops serving a stale cache when the org's active languages change",
        attrs do
     organization = Partners.get_organization!(attrs.organization_id)
 
@@ -2832,10 +2836,7 @@ defmodule Glific.TemplatesTest do
         }
     end)
 
-    assert {:ok, templates_before} =
-             Templates.search_library_templates(attrs.organization_id, %{
-               usecase: "onboarding_manufacturing"
-             })
+    assert {:ok, templates_before} = Templates.search_library_templates(attrs.organization_id)
 
     assert templates_before |> Enum.map(& &1.element_name) |> Enum.sort() ==
              ["utility_english", "utility_hindi"]
@@ -2845,15 +2846,12 @@ defmodule Glific.TemplatesTest do
     assert {:ok, _updated_organization} =
              Partners.update_organization(organization, %{active_language_ids: [1]})
 
-    assert {:ok, templates_after} =
-             Templates.search_library_templates(attrs.organization_id, %{
-               usecase: "onboarding_manufacturing"
-             })
+    assert {:ok, templates_after} = Templates.search_library_templates(attrs.organization_id)
 
     assert Enum.map(templates_after, & &1.element_name) == ["utility_english"]
   end
 
-  test "search_library_templates/2 serves an identical second call from cache instead of refetching",
+  test "search_library_templates/1 serves an identical second call from cache instead of refetching",
        attrs do
     {:ok, counter} = Agent.start_link(fn -> 0 end)
 
@@ -2890,15 +2888,9 @@ defmodule Glific.TemplatesTest do
         }
     end)
 
-    assert {:ok, first_call} =
-             Templates.search_library_templates(attrs.organization_id, %{
-               usecase: "onboarding_warehousing"
-             })
+    assert {:ok, first_call} = Templates.search_library_templates(attrs.organization_id)
 
-    assert {:ok, second_call} =
-             Templates.search_library_templates(attrs.organization_id, %{
-               usecase: "onboarding_warehousing"
-             })
+    assert {:ok, second_call} = Templates.search_library_templates(attrs.organization_id)
 
     assert Enum.map(first_call, & &1.element_name) == ["utility_cache_hit"]
     assert first_call == second_call

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2852,4 +2852,55 @@ defmodule Glific.TemplatesTest do
 
     assert Enum.map(templates_after, & &1.element_name) == ["utility_english"]
   end
+
+  test "search_library_templates/2 serves an identical second call from cache instead of refetching",
+       attrs do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        Agent.update(counter, &(&1 + 1))
+
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "templates" => [
+                %{
+                  "elementName" => "utility_cache_hit",
+                  "category" => "UTILITY",
+                  "data" => "Hi {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                }
+              ]
+            })
+        }
+    end)
+
+    assert {:ok, first_call} =
+             Templates.search_library_templates(attrs.organization_id, %{industry: "warehousing"})
+
+    assert {:ok, second_call} =
+             Templates.search_library_templates(attrs.organization_id, %{industry: "warehousing"})
+
+    assert Enum.map(first_call, & &1.element_name) == ["utility_cache_hit"]
+    assert first_call == second_call
+
+    # the metalibrary endpoint must only be hit once - the second identical
+    # call is served from the {:ok, templates} -> {:ok, templates} cache branch
+    assert Agent.get(counter, & &1) == 1
+  end
 end

--- a/test/glific/templates_test.exs
+++ b/test/glific/templates_test.exs
@@ -2834,7 +2834,7 @@ defmodule Glific.TemplatesTest do
 
     assert {:ok, templates_before} =
              Templates.search_library_templates(attrs.organization_id, %{
-               industry: "manufacturing"
+               usecase: "onboarding_manufacturing"
              })
 
     assert templates_before |> Enum.map(& &1.element_name) |> Enum.sort() ==
@@ -2847,7 +2847,7 @@ defmodule Glific.TemplatesTest do
 
     assert {:ok, templates_after} =
              Templates.search_library_templates(attrs.organization_id, %{
-               industry: "manufacturing"
+               usecase: "onboarding_manufacturing"
              })
 
     assert Enum.map(templates_after, & &1.element_name) == ["utility_english"]
@@ -2891,10 +2891,14 @@ defmodule Glific.TemplatesTest do
     end)
 
     assert {:ok, first_call} =
-             Templates.search_library_templates(attrs.organization_id, %{industry: "warehousing"})
+             Templates.search_library_templates(attrs.organization_id, %{
+               usecase: "onboarding_warehousing"
+             })
 
     assert {:ok, second_call} =
-             Templates.search_library_templates(attrs.organization_id, %{industry: "warehousing"})
+             Templates.search_library_templates(attrs.organization_id, %{
+               usecase: "onboarding_warehousing"
+             })
 
     assert Enum.map(first_call, & &1.element_name) == ["utility_cache_hit"]
     assert first_call == second_call

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -38,6 +38,12 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     "assets/gql/session_templates/create_from_message.gql"
   )
 
+  load_gql(
+    :template_library,
+    GlificWeb.Schema,
+    "assets/gql/session_templates/template_library.gql"
+  )
+
   test "session templates field returns list of session_templates", %{manager: user} do
     result = auth_query_gql_by(:list, user)
     assert {:ok, query_data} = result
@@ -445,5 +451,184 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     assert {:ok, query_data} = result
     label = get_in(query_data, [:data, "createSessionTemplate", "sessionTemplate", "label"])
     assert label == "WA Form Template"
+  end
+
+  test "template_library returns Meta's template library entries and does not persist anything",
+       %{staff: user} do
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "templates" => [
+                %{
+                  "elementName" => "welcome_offer",
+                  "category" => "UTILITY",
+                  "data" => "Hello {{1}}, welcome to our store!",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                }
+              ]
+            })
+        }
+    end)
+
+    session_template_count_before = Templates.count_session_templates(%{})
+
+    result =
+      auth_query_gql_by(:template_library, user,
+        variables: %{"filter" => %{"industry" => "retail"}}
+      )
+
+    assert {:ok, query_data} = result
+    [entry] = get_in(query_data, [:data, "templateLibrary"])
+
+    assert entry["elementName"] == "welcome_offer"
+    assert entry["category"] == "UTILITY"
+    assert entry["body"] == "Hello {{1}}, welcome to our store!"
+    assert entry["languageCode"] == "en"
+    assert entry["industry"] == "retail"
+    assert entry["topic"] == "welcome"
+    assert entry["usecase"] == "onboarding"
+
+    # read-only passthrough: no SessionTemplate row is created
+    assert Templates.count_session_templates(%{}) == session_template_count_before
+  end
+
+  test "template_library excludes non-Utility categories, excluded topics, and inactive-language entries",
+       %{staff: user} do
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "templates" => [
+                %{
+                  "elementName" => "utility_welcome",
+                  "category" => "UTILITY",
+                  "data" => "Hello {{1}}, your order is confirmed!",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "marketing_promo",
+                  "category" => "MARKETING",
+                  "data" => "Big sale this weekend!",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "utility_payment_reminder",
+                  "category" => "UTILITY",
+                  "data" => "Your payment is due",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "PAYMENTS",
+                  "usecase" => "billing",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "utility_order_update",
+                  "category" => "UTILITY",
+                  "data" => "Your order has shipped",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "ORDER_MANAGEMENT",
+                  "usecase" => "shipping",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "utility_french",
+                  "category" => "UTILITY",
+                  "data" => "Bonjour {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "fr",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "utility_hindi",
+                  "category" => "UTILITY",
+                  "data" => "Namaste {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "hi",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                }
+              ]
+            })
+        }
+    end)
+
+    result =
+      auth_query_gql_by(:template_library, user,
+        variables: %{"filter" => %{"industry" => "retail"}}
+      )
+
+    assert {:ok, query_data} = result
+    entries = get_in(query_data, [:data, "templateLibrary"])
+
+    element_names = Enum.map(entries, & &1["elementName"])
+
+    assert element_names == ["utility_welcome", "utility_hindi"]
+  end
+
+  test "template_library returns an error when the BSP call fails", %{staff: user} do
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        %Tesla.Env{
+          status: 400,
+          body: Jason.encode!(%{"message" => "Invalid industry filter"})
+        }
+    end)
+
+    result =
+      auth_query_gql_by(:template_library, user,
+        variables: %{"filter" => %{"industry" => "bogus"}}
+      )
+
+    assert {:ok, query_data} = result
+    assert [%{message: message}] = query_data.errors
+    assert message == "Invalid industry filter"
   end
 end

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -509,9 +509,10 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     assert entry["industry"] == "retail"
     assert entry["topic"] == "welcome"
     assert entry["usecase"] == "onboarding"
-    assert entry["containerMeta"]["footer"] == "Team support"
+    decoded_container_meta = Jason.decode!(entry["containerMeta"])
+    assert decoded_container_meta["footer"] == "Team support"
 
-    assert entry["containerMeta"]["buttons"] == [
+    assert decoded_container_meta["buttons"] == [
              %{"type" => "QUICK_REPLY", "text" => "Report Outage"}
            ]
 
@@ -652,6 +653,9 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     assert {:ok, query_data} = result
     assert [%{message: message}] = query_data.errors
-    assert message == "Invalid request"
+    # get_request/2 no longer decodes the error body - a non-2xx response
+    # falls back to a safe-inspected dump of the raw Tesla response/env.
+    assert message =~ "400"
+    assert message =~ "Invalid request"
   end
 end

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -593,7 +593,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     result =
       auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"industry" => "retail"}}
+        variables: %{"filter" => %{"industry" => "logistics"}}
       )
 
     assert {:ok, query_data} = result

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -490,7 +490,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     result =
       auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"industry" => "retail"}}
+        variables: %{"filter" => %{"usecase" => "onboarding"}}
       )
 
     assert {:ok, query_data} = result
@@ -611,7 +611,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     result =
       auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"industry" => "logistics"}}
+        variables: %{"filter" => %{"usecase" => "onboarding_logistics"}}
       )
 
     assert {:ok, query_data} = result
@@ -636,18 +636,18 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
       } ->
         %Tesla.Env{
           status: 400,
-          body: Jason.encode!(%{"message" => "Invalid industry filter"})
+          body: Jason.encode!(%{"message" => "Invalid usecase filter"})
         }
     end)
 
     result =
       auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"industry" => "bogus"}}
+        variables: %{"filter" => %{"usecase" => "bogus"}}
       )
 
     assert {:ok, query_data} = result
     assert [%{message: message}] = query_data.errors
-    assert message == "Invalid industry filter"
+    assert message == "Invalid usecase filter"
   end
 
   test "template_library treats an explicit null filter the same as an absent one", %{

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -4,8 +4,10 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
   use Wormwood.GQLCase
 
   alias Glific.{
+    Caches,
     Fixtures,
     Messages,
+    Partners,
     Repo,
     Seeds.SeedsDev,
     Templates,
@@ -21,6 +23,9 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     SeedsDev.seed_messages()
     SeedsDev.hsm_templates(organization)
     Fixtures.session_template_fixture()
+    active_language_ids = Partners.organization(organization.id).active_language_ids
+    Caches.remove(organization.id, [{:template_library, active_language_ids}])
+
     :ok
   end
 
@@ -488,10 +493,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     session_template_count_before = Templates.count_session_templates(%{})
 
-    result =
-      auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"usecase" => "onboarding"}}
-      )
+    result = auth_query_gql_by(:template_library, user)
 
     assert {:ok, query_data} = result
     [entry] = get_in(query_data, [:data, "templateLibrary"])
@@ -609,10 +611,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
         }
     end)
 
-    result =
-      auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"usecase" => "onboarding_logistics"}}
-      )
+    result = auth_query_gql_by(:template_library, user)
 
     assert {:ok, query_data} = result
     entries = get_in(query_data, [:data, "templateLibrary"])
@@ -636,59 +635,14 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
       } ->
         %Tesla.Env{
           status: 400,
-          body: Jason.encode!(%{"message" => "Invalid usecase filter"})
+          body: Jason.encode!(%{"message" => "Invalid request"})
         }
     end)
 
-    result =
-      auth_query_gql_by(:template_library, user,
-        variables: %{"filter" => %{"usecase" => "bogus"}}
-      )
+    result = auth_query_gql_by(:template_library, user)
 
     assert {:ok, query_data} = result
     assert [%{message: message}] = query_data.errors
-    assert message == "Invalid usecase filter"
-  end
-
-  test "template_library treats an explicit null filter the same as an absent one", %{
-    staff: user
-  } do
-    Tesla.Mock.mock(fn
-      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
-        %Tesla.Env{
-          status: 200,
-          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
-        }
-
-      %{
-        method: :get,
-        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
-      } ->
-        %Tesla.Env{
-          status: 200,
-          body:
-            Jason.encode!(%{
-              "templates" => [
-                %{
-                  "elementName" => "utility_null_filter",
-                  "category" => "UTILITY",
-                  "data" => "Hi {{1}}",
-                  "industry" => "retail",
-                  "languageCode" => "en",
-                  "topic" => "welcome",
-                  "usecase" => "onboarding",
-                  "containerMeta" => %{"buttons" => []}
-                }
-              ]
-            })
-        }
-    end)
-
-    result = auth_query_gql_by(:template_library, user, variables: %{"filter" => nil})
-
-    assert {:ok, query_data} = result
-    entries = get_in(query_data, [:data, "templateLibrary"])
-
-    assert Enum.map(entries, & &1["elementName"]) == ["utility_null_filter"]
+    assert message == "Invalid request"
   end
 end

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -585,6 +585,24 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
                   "topic" => "welcome",
                   "usecase" => "onboarding",
                   "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "entry_without_category",
+                  "data" => "No category field at all",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                },
+                %{
+                  "elementName" => "entry_without_topic",
+                  "category" => "UTILITY",
+                  "data" => "No topic field at all",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
                 }
               ]
             })
@@ -601,7 +619,7 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
 
     element_names = Enum.map(entries, & &1["elementName"])
 
-    assert element_names == ["utility_welcome", "utility_hindi"]
+    assert element_names == ["utility_welcome", "utility_hindi", "entry_without_topic"]
   end
 
   test "template_library returns an error when the BSP call fails", %{staff: user} do
@@ -630,5 +648,47 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     assert {:ok, query_data} = result
     assert [%{message: message}] = query_data.errors
     assert message == "Invalid industry filter"
+  end
+
+  test "template_library treats an explicit null filter the same as an absent one", %{
+    staff: user
+  } do
+    Tesla.Mock.mock(fn
+      %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+        %Tesla.Env{
+          status: 200,
+          body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+        }
+
+      %{
+        method: :get,
+        url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+      } ->
+        %Tesla.Env{
+          status: 200,
+          body:
+            Jason.encode!(%{
+              "templates" => [
+                %{
+                  "elementName" => "utility_null_filter",
+                  "category" => "UTILITY",
+                  "data" => "Hi {{1}}",
+                  "industry" => "retail",
+                  "languageCode" => "en",
+                  "topic" => "welcome",
+                  "usecase" => "onboarding",
+                  "containerMeta" => %{"buttons" => []}
+                }
+              ]
+            })
+        }
+    end)
+
+    result = auth_query_gql_by(:template_library, user, variables: %{"filter" => nil})
+
+    assert {:ok, query_data} = result
+    entries = get_in(query_data, [:data, "templateLibrary"])
+
+    assert Enum.map(entries, & &1["elementName"]) == ["utility_null_filter"]
   end
 end

--- a/test/glific_web/schema/session_template_test.exs
+++ b/test/glific_web/schema/session_template_test.exs
@@ -484,7 +484,11 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
                   "languageCode" => "en",
                   "topic" => "welcome",
                   "usecase" => "onboarding",
-                  "containerMeta" => %{"buttons" => []}
+                  "containerMeta" =>
+                    Jason.encode!(%{
+                      "footer" => "Team support",
+                      "buttons" => [%{"type" => "QUICK_REPLY", "text" => "Report Outage"}]
+                    })
                 }
               ]
             })
@@ -505,6 +509,11 @@ defmodule GlificWeb.Schema.SessionTemplateTest do
     assert entry["industry"] == "retail"
     assert entry["topic"] == "welcome"
     assert entry["usecase"] == "onboarding"
+    assert entry["containerMeta"]["footer"] == "Team support"
+
+    assert entry["containerMeta"]["buttons"] == [
+             %{"type" => "QUICK_REPLY", "text" => "Report Outage"}
+           ]
 
     # read-only passthrough: no SessionTemplate row is created
     assert Templates.count_session_templates(%{}) == session_template_count_before


### PR DESCRIPTION
## Summary
official site - https://partner-docs.gupshup.io/reference/gettemplatesfromlibrary
Adds a `templateLibrary` GraphQL query that lets the frontend browse Meta's pre-approved WhatsApp template catalog (fetched live from Gupshup's Partner API) and prefill the "Create Template" form from it. Read-only passthrough —never persists a `SessionTemplate`.

- Fetches the org's full eligible catalog in one call (no caller-facing  filter arguments — the UI searches/filters the cached result client-side, so there's nothing to filter server-side per request).
- Server-side business rules, applied before caching: only `UTILITY` category  templates, excludes the `PAYMENTS`/`ORDER_MANAGEMENT` topics, and limits  results to the org's currently active languages.
- Results are cached per `{organization_id, active_language_ids}` for 20 minutes — the active-language set is part of the cache key (not just invalidated after the fact), so a language-settings change is reflected immediately instead of waiting out the TTL.
- Fixes a double-JSON-encoding bug in `containerMeta`: Gupshup returns it as  an already-encoded JSON string, and passing that straight thr `:json` GraphQL scalar (which itself calls `Jason`/`Poison.encode!/1`) encoded it a second time — silently dropping every template's footer on the client. Now decoded into a real map before it reaches the scalar.
- `PartnerAPI.get_request/2`'s error branch now decodes Gupshup's JSON error body and surfaces its `"message"` field directly when present a safe-inspected `%Tesla.Env{}` dump — applies to all 8 callers, not just this endpoint.