### PR TITLE
autofix: handle unmatched BigQuery insert-pipeline shapes (incident #291)

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -926,6 +926,28 @@ defmodule Glific.BigQuery do
     )
   end
 
+  ## fetch_bigquery_credentials/1 returns {:ok, "BigQuery is not active"} when the org has
+  ## no bigquery service configured, so the {:ok, _} tag alone doesn't guarantee credentials.
+  defp do_make_insert_query({:ok, reason}, organization_id, _data, opts) do
+    table = Keyword.get(opts, :table)
+
+    Glific.log_error(
+      "BigQuery Insert skipped, credentials not available for org_id: #{organization_id}, table: #{table}, reason: #{safe_inspect(reason)}"
+    )
+
+    {:error, reason}
+  end
+
+  defp do_make_insert_query({:error, reason}, organization_id, _data, opts) do
+    table = Keyword.get(opts, :table)
+
+    Glific.log_error(
+      "BigQuery Insert Error while fetching credentials for org_id: #{organization_id}, table: #{table}, reason: #{safe_inspect(reason)}"
+    )
+
+    {:error, reason}
+  end
+
   @spec handle_insert_query_response(tuple(), non_neg_integer, Keyword.t()) :: :ok
   defp handle_insert_query_response({:ok, res}, organization_id, opts) do
     table = Keyword.get(opts, :table)
@@ -983,8 +1005,10 @@ defmodule Glific.BigQuery do
         Logger.info("Timeout while inserting the data. #{safe_inspect(response)}")
 
       _ ->
-        raise("BigQuery Insert Error for table #{table} #{safe_inspect(response)}")
+        Glific.log_error("BigQuery Insert Error for table #{table} #{safe_inspect(response)}")
     end
+
+    :ok
   end
 
   @spec bigquery_error_status(any()) :: {String.t() | atom(), String.t()}

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -159,15 +159,15 @@ defmodule Glific.BigQueryTest do
     end
   end
 
-  test "handle_insert_query_response/3 should raise error", attrs do
-    assert_raise RuntimeError, fn ->
-      BigQuery.handle_insert_query_response(
-        {:error, %{body: "{\"error\":{\"code\":404,\"status\":\"UNKNOWN_ERROR\"}}"}},
-        attrs.organization_id,
-        table: "messages",
-        max_id: 10
-      )
-    end
+  test "handle_insert_query_response/3 logs and returns :ok for an unrecognized error status",
+       attrs do
+    assert :ok ==
+             BigQuery.handle_insert_query_response(
+               {:error, %{body: "{\"error\":{\"code\":404,\"status\":\"UNKNOWN_ERROR\"}}"}},
+               attrs.organization_id,
+               table: "messages",
+               max_id: 10
+             )
   end
 
   @delete_query """
@@ -256,6 +256,46 @@ defmodule Glific.BigQueryTest do
                table: "messages",
                max_id: nil
              )
+  end
+
+  test "make_insert_query/4 returns :ok without crashing when bigquery is not configured for the org" do
+    organization_without_bigquery = organization_fixture()
+
+    assert :ok ==
+             BigQuery.make_insert_query(
+               [%{"id" => 1}],
+               "contacts",
+               organization_without_bigquery.id,
+               max_id: 10,
+               last_updated_at: nil
+             )
+  end
+
+  test "make_insert_query/4 returns :ok without crashing when fetching credentials errors",
+       attrs do
+    with_mocks([
+      {
+        Goth.Token,
+        [:passthrough],
+        [
+          fetch: fn _url ->
+            {:error,
+             "Could not retrieve token, response: {\"error\":\"invalid_grant\",\"error_description\":\"Invalid grant: account not found\"}"}
+          end
+        ]
+      }
+    ]) do
+      Glific.Caches.remove(attrs.organization_id, [{:provider_token, "bigquery"}])
+
+      assert :ok ==
+               BigQuery.make_insert_query(
+                 [%{"id" => 1}],
+                 "messages",
+                 attrs.organization_id,
+                 max_id: 10,
+                 last_updated_at: nil
+               )
+    end
   end
 
   test "handle_sync_errors/2 return ok atom when status is not ALREADY_EXISTS", attrs do


### PR DESCRIPTION
## AppSignal incident

[#291](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/291) — `FunctionClauseError`, 15,816 occurrences in the last 7 days — the highest-volume open incident this week.

## Root cause

`Glific.BigQuery.do_make_insert_query/4` (`lib/glific/third_party/bigquery/bigquery.ex`) had only one clause, matching `{:ok, %{conn:, project_id:, dataset_id:}}` — the shape `fetch_bigquery_credentials/1` returns when an org's BigQuery credentials resolve successfully. That same function can also return:

- `{:ok, "BigQuery is not active"}` — no BigQuery service configured for the org.
- `{:error, reason}` — a credential/token failure (invalid service-account JSON, Goth token fetch failure).

Neither shape matched the single clause, so both crashed with `FunctionClauseError` inside `Glific.BigQuery.BigQueryWorker` (an Oban worker) on every retry attempt until `max_attempts`.

## Fix

- Added two `do_make_insert_query/4` clauses (for the `{:ok, non-map}` and `{:error, reason}` shapes) that log via `Glific.log_error/1` and return `{:error, reason}` instead of crashing.
- `handle_insert_query_response/3`'s pre-existing `{:error, response}` clause had its own unconditional `raise(...)` fallback for unrecognized BigQuery API error statuses — changed to log instead, with the function now explicitly returning `:ok` so `BigQueryWorker`'s job completes rather than crash-looping.

**Deliberately excluded**: a sibling `raise` in this same function (`insertErrors != nil`, AppSignal incident #274) is already fixed by open PR #5466 — left untouched here to avoid a duplicate fix on the same lines.

## Verification

⚠️ **This sandbox has no Elixir/Erlang toolchain** (no `mix`, no `erl`) — `mix format`, `mix compile --warnings-as-errors`, and `mix test` could **not** be run. The fix and its regression tests were produced by a `backend-engineer` agent, tested by `test-automator`, and adversarially reviewed by a `code-reviewer` agent across two rounds (the first round caught the overlap with PR #5466, which was then stripped out) via careful hand-tracing of the actual `fetch_bigquery_credentials`/`do_make_insert_query`/`handle_insert_query_response` call chain. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.**

## Blast radius checked

Traced every reachable return shape of `fetch_bigquery_credentials/1` through to `do_make_insert_query/4` and `handle_insert_query_response/3` — all shapes now have a matching clause, no remaining raise/crash path for this incident's trigger conditions.

## Note

Two other PRs from this and a prior monitoring run touch the same file (`#5466` incident #274, `#5469` a different BigQuery fix) — reviewed for overlap, confirmed no duplicate lines, but a future merge conflict on shared function bodies is possible and should be resolved by whoever merges last.

---
Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ByAekRBKb1ufYBiaoiSUbn)_