### PR TITLE
chore(monitoring): set instrument_oban back to false

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -87,7 +87,7 @@ config :appsignal, :config,
   push_api_key: env!("APPSIGNAL_PUSH_API_KEY", :string!),
   ecto_repos: [],
   ignore_namespaces: ["gupshup_webhooks", "gupshup_enterprise_webhooks", "flow_editor_controller"],
-  instrument_oban: true
+  instrument_oban: false
 
 config :glific, Glific.Vault,
   ciphers: [


### PR DESCRIPTION
## What

One line: `instrument_oban: true` → `false` in `config/runtime.exs`.

## Why

#5436 flipped this `false` → `true` on 27 Jul. AppSignal's built-in Oban integration **duplicates error reporting Glific already does itself**, and reports on *every* attempt rather than only the final one.

`application.ex:121` already attaches our own handlers:

```elixir
[:oban, :job, :exception]     → "oban-failure"
[:oban, :plugin, :exception]  → "oban-plugin-failure"
[:oban, :job, :stop]          → "oban-success"
```

and `Glific.Appsignal` adds the error with its stacktrace — but only once retries are exhausted:

```elixir
if meta.attempt >= meta.max_attempts do
  @span.add_error(span, meta.kind, error, meta.stacktrace)
end
```

AppSignal's integration has no such gate. So a worker with `max_attempts: 3` failing every attempt produced **1** error report before #5436 and **4** after — three intermediate attempts from AppSignal plus one final from our handler.

That accounts for a large part of the backend-issue spike since 27 Jul. Much of it is duplicates and intermediate retries rather than new distinct failures.

## What this keeps vs drops

**Keeps:**
- `oban_job_duration` / `oban_job_latency` — Glific's own `[:oban, :job, :stop]` handler (`appsignal.ex:25`), independent of this flag
- `job_run_count` — `Jobs.Instrumentation`
- **errors with full stacktraces on final failure** — Glific's own exception handler

**Drops:**
- per-job APM performance samples (the timing-breakdown traces)
- error reports for intermediate retry attempts

So this is not a loss of visibility — aggregate metrics and diagnosable final-failure traces both survive. The one real cost is per-job transaction traces.

## Also

Restores the assumption `Providers.Instrumentation`'s moduledoc already documents:

> `instrument_oban: false` in `config/runtime.exs` means none of this is captured automatically, so the counters are emitted explicitly from the provider send/receive/sync paths.

#5436 silently invalidated that. This makes the docs true again.

## Trade-off worth a second opinion

If anyone is actively using the per-job APM samples to profile slow Oban jobs, this removes that. The alternative is keeping the flag on and cutting noise selectively via `ignore_namespaces` (already used for the Gupshup webhook namespaces) or per-worker filtering. Happy to go that route instead — this is the blunter but simpler option.

## Checks

Config-only change; no code paths touched. Full suite was green on this content as part of #5492 before the split (2852 tests, 1 pre-existing `ExportTest` failure also present on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
