### PR TITLE
  fix(deploy): robust verification + terser Discord alerts + admin-merge releases

### DIFF
--- a/bin/gigalixir-release.sh
+++ b/bin/gigalixir-release.sh
@@ -93,6 +93,7 @@ parse_args() {
       --title) need "$@"; RELEASE_TITLE="$2"; shift 2 ;;
       --base) need "$@"; BASE_BRANCH="$2"; shift 2 ;;
       --stable-window) need "$@"; STABLE_WINDOW="$2"; shift 2 ;;
+      --discord-webhook) need "$@"; export DISCORD_WEBHOOK_URL="$2"; shift 2 ;;
       --skip-release) SKIP_RELEASE=1; shift ;;
       --skip-verify) SKIP_VERIFY=1; shift ;;
       --dry-run) DRY_RUN=1; shift ;;
@@ -298,7 +299,9 @@ EOF
 
   confirm "Merge PR #${PR_NUMBER}?" || abort "declined at the merge step"
 
-  run gh pr merge "$PR_NUMBER" --squash --delete-branch || die "gh pr merge failed"
+  # Always --admin: a version-bump PR does not wait for CI/reviews. Requires admin or
+  run gh pr merge "$PR_NUMBER" --squash --delete-branch --admin \
+    || die "gh pr merge failed (need admin/bypass permission on ${BASE_BRANCH})"
 
   run git checkout "$BASE_BRANCH" || die "could not switch back to ${BASE_BRANCH}"
   run git pull --ff-only origin "$BASE_BRANCH" || die "git pull failed"

--- a/bin/gigalixir-release.sh
+++ b/bin/gigalixir-release.sh
@@ -423,10 +423,21 @@ main() {
   detect_project
   [ "$DRY_RUN" -eq 1 ] && printf '\n*** DRY RUN - nothing will be changed, pushed or deployed ***\n'
   preflight
-  choose_version
-  open_pr
-  merge_pr
-  create_release
+
+  # Only production is a versioned release (bump -> PR -> merge -> GitHub release).
+  # staging / frontend-staging just deploy the current master and verify - no ceremony.
+  if [ "$ENV_NAME" = "production" ]; then
+    choose_version
+    open_pr
+    merge_pr
+    create_release
+  else
+    DEPLOY_SHA=$(git rev-parse HEAD)
+    NEW_VERSION="$CURRENT_VERSION"
+    step "Version"
+    log "no bump for ${ENV_NAME} - deploying current ${BASE_BRANCH} (${DEPLOY_SHA:0:7}) as ${CURRENT_VERSION}"
+  fi
+
   deploy
   verify
 }

--- a/bin/gigalixir-release.sh
+++ b/bin/gigalixir-release.sh
@@ -37,6 +37,7 @@ STABLE_WINDOW=300
 
 CURRENT_VERSION="" VERSION_FILE="" PROJECT_KIND=""
 BRANCH="" PR_NUMBER="" DEPLOY_SHA=""
+DISCORD_WEBHOOK=""
 
 usage() { sed -n '2,19p' "$0" | sed 's/^#\{1,2\} \{0,1\}//'; }
 
@@ -93,7 +94,7 @@ parse_args() {
       --title) need "$@"; RELEASE_TITLE="$2"; shift 2 ;;
       --base) need "$@"; BASE_BRANCH="$2"; shift 2 ;;
       --stable-window) need "$@"; STABLE_WINDOW="$2"; shift 2 ;;
-      --discord-webhook) need "$@"; export DISCORD_WEBHOOK_URL="$2"; shift 2 ;;
+      --discord-webhook) need "$@"; DISCORD_WEBHOOK="$2"; shift 2 ;;
       --skip-release) SKIP_RELEASE=1; shift ;;
       --skip-verify) SKIP_VERIFY=1; shift ;;
       --dry-run) DRY_RUN=1; shift ;;
@@ -381,8 +382,15 @@ verify() {
     return 0
   fi
 
-  "$VERIFIER" --app "$APP" --sha "$DEPLOY_SHA" --app-version "$NEW_VERSION" \
-    --stable-window "$STABLE_WINDOW"
+  # Scope the webhook to just this subprocess via an inline assignment, so git/gh (and
+  # anything they spawn) never inherit it. With no --discord-webhook, fall through to
+  # whatever DISCORD_WEBHOOK_URL is already in the environment.
+  local vargs=(--app "$APP" --sha "$DEPLOY_SHA" --app-version "$NEW_VERSION" --stable-window "$STABLE_WINDOW")
+  if [ -n "$DISCORD_WEBHOOK" ]; then
+    DISCORD_WEBHOOK_URL="$DISCORD_WEBHOOK" "$VERIFIER" "${vargs[@]}"
+  else
+    "$VERIFIER" "${vargs[@]}"
+  fi
   local rc=$?
 
   if [ "$rc" -ne 0 ]; then

--- a/bin/gigalixir-verify-deploy.sh
+++ b/bin/gigalixir-verify-deploy.sh
@@ -166,10 +166,11 @@ preflight() {
 }
 
 # The gigalixir CLI prepends a "new version available" banner to stdout, which is not
-# JSON and makes jq choke. Drop everything before the first [ or { so only the payload
-# reaches jq.
+# JSON and makes jq choke. Print from the first line that *starts* with [ or { (the JSON
+# opening) onward. Anchoring to the line start avoids matching a banner like
+# "update [1.2.3] available", whose bracket sits mid-line.
 strip_banner() {
-  sed -n '/[[{]/,$p'
+  sed -n '/^[[:space:]]*[[{]/,$p'
 }
 
 # Both fetchers echo raw JSON on stdout and return non-zero if the CLI failed or the

--- a/bin/gigalixir-verify-deploy.sh
+++ b/bin/gigalixir-verify-deploy.sh
@@ -78,16 +78,16 @@ fail_annotation() {
   return 0
 }
 
-# Posts a Discord embed (the rich card with a coloured sidebar), falling back to
-# nothing if no webhook is set. $1=ok|fail (sidebar colour), $2=title, $3=description.
-# Reads APP / SHA / TARGET_VERSION / POD_NODE from the surrounding run.
+# Posts a Discord embed, falling back to nothing if no webhook is set. $1=ok|fail,
+# $2=reason (failures only). Success stays terse - a 🟢 title and the facts; failures
+# carry the reason. Reads APP / SHA / TARGET_VERSION / POD_NODE from the surrounding run.
 notify() {
   [ -n "${DISCORD_WEBHOOK_URL:-}" ] || return 0
-  local kind="$1" title="$2" desc="$3" color
+  local kind="$1" desc="${2:-}" color title
   case "$kind" in
-    ok) color=3066993 ;;    # green
-    fail) color=15158332 ;; # red
-    *) color=9807270 ;;     # grey
+    ok) color=3066993; title="🟢 ${APP} deployment healthy" ;;
+    fail) color=15158332; title="🔴 ${APP} deployment failed" ;;
+    *) color=9807270; title="${APP} deployment" ;;
   esac
 
   local payload
@@ -95,24 +95,19 @@ notify() {
     --arg title "$title" \
     --arg desc "$desc" \
     --argjson color "$color" \
-    --arg app "${APP:-unknown}" \
     --arg sha "${SHA:0:7}" \
     --arg rel "${TARGET_VERSION:-unknown}" \
     --arg node "${POD_NODE:-unknown}" \
     --arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
-    '{embeds:[{
-        title: $title,
-        description: $desc,
-        color: $color,
-        timestamp: $ts,
-        fields: [
-          {name: "🏷️ App",     value: $app,  inline: true},
-          {name: "🔀 SHA",     value: $sha,  inline: true},
-          {name: "📦 Release", value: $rel,  inline: true},
-          {name: "💻 Node",    value: $node, inline: false}
-        ],
-        footer: {text: "Gigalixir rolling deployment"}
-      }]}')
+    '{embeds:[
+       ({ title: $title, color: $color, timestamp: $ts,
+          fields: [
+            {name: "Release", value: $rel,  inline: true},
+            {name: "SHA",     value: $sha,  inline: true},
+            {name: "Node",    value: $node, inline: false}
+          ]
+        } + (if $desc == "" then {} else {description: $desc} end))
+     ]}')
 
   curl -fsS -m 10 -X POST "$DISCORD_WEBHOOK_URL" \
     -H 'Content-Type: application/json' \
@@ -170,18 +165,25 @@ preflight() {
   [ "$POLL" -ge 1 ] || die "--poll must be at least 1"
 }
 
+# The gigalixir CLI prepends a "new version available" banner to stdout, which is not
+# JSON and makes jq choke. Drop everything before the first [ or { so only the payload
+# reaches jq.
+strip_banner() {
+  sed -n '/[[{]/,$p'
+}
+
 # Both fetchers echo raw JSON on stdout and return non-zero if the CLI failed or the
 # payload was not JSON, so a transient API blip is a skipped poll rather than a crash.
 fetch_releases() {
   local out
-  out=$(gigalixir releases -a "$APP" 2>/dev/null) || return 1
+  out=$(gigalixir releases -a "$APP" 2>/dev/null | strip_banner) || return 1
   printf '%s' "$out" | jq -e . >/dev/null 2>&1 || return 1
   printf '%s' "$out"
 }
 
 fetch_ps() {
   local out
-  out=$(gigalixir ps -a "$APP" 2>/dev/null) || return 1
+  out=$(gigalixir ps -a "$APP" 2>/dev/null | strip_banner) || return 1
   printf '%s' "$out" | jq -e . >/dev/null 2>&1 || return 1
   printf '%s' "$out"
 }
@@ -413,8 +415,7 @@ main() {
 
   if [ "$rc" -eq "$E_OK" ]; then
     log "VERIFIED: ${APP} is live on release v${TARGET_VERSION} and stable"
-    notify ok "🚀 Deployment Healthy" \
-      "A new revision has passed health checks and is now serving traffic (stable for ${STABLE_WINDOW}s)."
+    notify ok
   else
     local reason
     case "$rc" in
@@ -428,7 +429,7 @@ main() {
     log "DEPLOY VERIFICATION FAILED (${reason})"
     log "investigate: gigalixir logs -a ${APP} ; gigalixir ps -a ${APP} ; gigalixir releases -a ${APP}"
     fail_annotation "${APP}: ${reason}"
-    notify fail "🚨 Deployment Failed" "$reason"
+    notify fail "$reason"
   fi
   exit "$rc"
 }


### PR DESCRIPTION

## Summary
### Changes

**Verifier (`bin/gigalixir-verify-deploy.sh`)**
- Strip the gigalixir CLI's "new version available" banner before JSON parsing. Without  this, every `releases`/`ps` lookup failed and verification falsely reported "release never registered." (Root cause of the prod verify hang.)
- Terser Discord embed: app name in the title, 🟢/🔴 for status (no other emojis),
  detail only on failure (success stays silent per unix philosophy), fewer lines.

**Release driver (`bin/gigalixir-release.sh`)**
- Merge the bump PR with `--admin` to bypass branch protection — a version-only change
  doesn't need to wait for CI/reviews (requires admin/bypass permission).
- Add `--discord-webhook <url>` so local runs can post to Discord (exported to the  verifier subprocess); GitHub 
secrets aren't readable from a local machine.

```bash
bin/gigalixir-release.sh --env staging --discord-webhook "https://discord.com/api/webhooks/..."
```