### PR TITLE
 fix(gupshup): add receive timeout for library template requests and handle timeout errors

### DIFF
--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -41,6 +41,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   # Final URL: <app_url><app_id><@flow_media_path><media_id>
   # Returns the raw media bytes directly (one-step, no decryption).
   @flow_media_path "/media/"
+  @library_templates_recv_timeout 30_000
 
   @modes [
     "ENQUEUED",
@@ -366,7 +367,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @spec get_library_templates(non_neg_integer()) :: {:ok, map()} | {:error, String.t()}
   def get_library_templates(org_id) do
     (app_url!(org_id) <> "/template/metalibrary")
-    |> get_request(org_id: org_id)
+    |> get_request(org_id: org_id, recv_timeout: @library_templates_recv_timeout)
   end
 
   @global_organization_id 0
@@ -512,13 +513,21 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
 
   @spec get_request(String.t(), Keyword.t()) :: tuple()
   defp get_request(url, opts) do
-    req_headers =
-      headers(Keyword.get(opts, :token_type, :app_token), opts)
+    req_headers = headers(Keyword.get(opts, :token_type, :app_token), opts)
 
-    get(url, headers: req_headers)
+    request_opts =
+      case Keyword.get(opts, :recv_timeout) do
+        nil -> [headers: req_headers]
+        recv_timeout -> [headers: req_headers, opts: [adapter: [recv_timeout: recv_timeout]]]
+      end
+
+    get(url, request_opts)
     |> case do
       {:ok, %Tesla.Env{status: status, body: body}} when status in 200..299 ->
         {:ok, Jason.decode!(body)}
+
+      {:error, :timeout} ->
+        {:error, "Gupshup partner API request timed out, please try again"}
 
       err ->
         {:error, "#{Glific.SafeLog.safe_inspect(err)}"}

--- a/lib/glific/providers/gupshup/partner/partner_api.ex
+++ b/lib/glific/providers/gupshup/partner/partner_api.ex
@@ -367,7 +367,7 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
   @spec get_library_templates(non_neg_integer()) :: {:ok, map()} | {:error, String.t()}
   def get_library_templates(org_id) do
     (app_url!(org_id) <> "/template/metalibrary")
-    |> get_request(org_id: org_id, recv_timeout: @library_templates_recv_timeout)
+    |> get_request(org_id: org_id, adapter: [recv_timeout: @library_templates_recv_timeout])
   end
 
   @global_organization_id 0
@@ -516,9 +516,9 @@ defmodule Glific.Providers.Gupshup.PartnerAPI do
     req_headers = headers(Keyword.get(opts, :token_type, :app_token), opts)
 
     request_opts =
-      case Keyword.get(opts, :recv_timeout) do
-        nil -> [headers: req_headers]
-        recv_timeout -> [headers: req_headers, opts: [adapter: [recv_timeout: recv_timeout]]]
+      case Keyword.get(opts, :adapter, []) do
+        [] -> [headers: req_headers]
+        adapter_opts -> [headers: req_headers, opts: [adapter: adapter_opts]]
       end
 
     get(url, request_opts)

--- a/test/glific/providers/gupshup/partner_api_test.exs
+++ b/test/glific/providers/gupshup/partner_api_test.exs
@@ -106,5 +106,47 @@ defmodule Glific.Providers.Gupshup.PartnerAPITest do
       assert message =~ "500"
       assert message =~ "internal server error"
     end
+
+    test "returns a friendly error instead of the raw tuple when the request times out",
+         attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{
+          method: :get,
+          url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary"
+        } ->
+          {:error, :timeout}
+      end)
+
+      assert {:error, message} = PartnerAPI.get_library_templates(attrs.organization_id)
+      assert message == "Gupshup partner API request timed out, please try again"
+    end
+
+    test "sets a 30s receive timeout on the metalibrary request instead of Hackney's 5s default",
+         attrs do
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "https://partner.gupshup.io/partner/app/Glific42/token"} ->
+          %Tesla.Env{
+            status: 200,
+            body: Jason.encode!(%{"token" => %{"token" => "xyz456"}})
+          }
+
+        %{
+          method: :get,
+          url: "https://partner.gupshup.io/partner/app/Glific42/template/metalibrary",
+          opts: opts
+        } ->
+          assert opts[:adapter] == [recv_timeout: 30_000]
+
+          %Tesla.Env{status: 200, body: Jason.encode!(%{"templates" => []})}
+      end)
+
+      assert {:ok, %{"templates" => []}} = PartnerAPI.get_library_templates(attrs.organization_id)
+    end
   end
 end


### PR DESCRIPTION
## Problem
`templateLibrary` (GraphQL query, backed by `PartnerAPI.get_library_templates/1`) was timing out for organizations with large Meta template catalogs. The underlying GET to Gupshup's Partner API (`/template/metalibrary`) had no timeout override, so it inherited Hackney's bare 5-second default `recv_timeout` — too short for a call that returns the full
pre-approved template list. Every other slow BSP/third-party call in the codebase (Maytapi, Gemini, WhatsApp Forms) already extends this timeout; this one was the outlier.

On timeout, the raw `{:error, :timeout}` tuple was also being `inspect`-ed and passed straight through to the GraphQL client as the error message.

## Fix
- `get_library_templates/1` now passes a 30s `recv_timeout` (mirroring the pattern in
  `Maytapi.ApiClient`) instead of relying on the 5s Hackney default.
- `get_request/2` accepts an optional `:recv_timeout` opt, applied via
  `opts: [adapter: [recv_timeout: ...]]`, and only affects thisuest`
  callers are unchanged.
- Added a dedicated `{:error, :timeout}` match that returns a c
  ("Gupshup partner API request timed out, please try again") instead of leaking the raw
  Elixir tuple to the client.