### PR TITLE
autofix: handle get_cached_flow error in Periodic.init_common_flow (incident #4)

### DIFF
--- a/lib/glific/flows/periodic.ex
+++ b/lib/glific/flows/periodic.ex
@@ -17,7 +17,8 @@ defmodule Glific.Flows.Periodic do
     Flows,
     Flows.FlowContext,
     Messages.Message,
-    Partners
+    Partners,
+    SafeLog
   }
 
   @periodic_flows [
@@ -143,11 +144,18 @@ defmodule Glific.Flows.Periodic do
     do: common_flow(state, period, message, since)
 
   defp init_common_flow(state, flow_id, message) do
-    {:ok, flow} =
-      Flows.get_cached_flow(message.organization_id, {:flow_id, flow_id, @final_phrase})
+    case Flows.get_cached_flow(message.organization_id, {:flow_id, flow_id, @final_phrase}) do
+      {:ok, flow} ->
+        opts = Keyword.put(Keyword.new(), :flow_keyword, message.body)
+        FlowContext.init_context(flow, message.contact, @final_phrase, opts)
+        {state, true}
 
-    opts = Keyword.put(Keyword.new(), :flow_keyword, message.body)
-    FlowContext.init_context(flow, message.contact, @final_phrase, opts)
-    {state, true}
+      {:error, error} ->
+        Glific.log_error(
+          "Periodic flow: failed to load cached flow #{flow_id} for org #{message.organization_id}: #{SafeLog.safe_inspect(error)}"
+        )
+
+        {state, false}
+    end
   end
 end

--- a/test/glific/flows/periodic_test.exs
+++ b/test/glific/flows/periodic_test.exs
@@ -3,6 +3,7 @@ defmodule Glific.Flows.PeriodicTest do
 
   alias Glific.{
     Fixtures,
+    Flows,
     Flows.Periodic,
     Partners,
     Seeds.SeedsDev
@@ -141,5 +142,23 @@ defmodule Glific.Flows.PeriodicTest do
     {:ok, monday} = Timex.parse("2020-08-10T00:00:00+00:00", "{ISO:Extended}")
     assert {state, false} == Periodic.periodic_flow(state, "monday", nil, monday)
     assert {state, false} == Periodic.periodic_flow(state, "wednesday", nil, monday)
+  end
+
+  test "init_common_flow returns {state, false} instead of crashing when the cached flow lookup errors",
+       %{organization_id: organization_id} = attrs do
+    # there is no flow (and hence no published revision) with this id, so
+    # Flows.get_cached_flow/2 will fail to load a flow from the DB, Cachex will
+    # catch the raised error and get_cached_flow/2 returns {:error, _} instead of {:ok, flow}
+    non_existent_flow_id = 0
+
+    message = Fixtures.message_fixture(attrs) |> Repo.preload(:contact)
+
+    sentinel_state = %{sentinel_marker: :untouched}
+
+    assert {^sentinel_state, false} =
+             Periodic.init_common_flow(sentinel_state, non_existent_flow_id, message)
+
+    assert {:error, %Cachex.ExecutionError{}} =
+             Flows.get_cached_flow(organization_id, {:flow_id, non_existent_flow_id, "published"})
   end
 end


### PR DESCRIPTION
## AppSignal incident

[#4](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/4) — `MatchError`, 24,169 total occurrences, 50 in the last 7 days. Source: AppSignal.

## Root cause

`Glific.Flows.Periodic.init_common_flow/3` (`lib/glific/flows/periodic.ex`) used a bare match:

```elixir
{:ok, flow} =
  Flows.get_cached_flow(message.organization_id, {:flow_id, flow_id, @final_phrase})
```

`Flows.get_cached_flow/2` can return `{:error, %Cachex.ExecutionError{}}` — e.g. when the flow referenced in `flow_keywords_map` has no published revision. The bare match then raises `MatchError`, crashing the periodic-flow message processor for that contact/organization.

## Fix

Replaced the bare match with a `case`:
- `{:ok, flow}` — unchanged happy path.
- `{:error, error}` — logs via `Glific.log_error/2` (with `SafeLog.safe_inspect/1` on the error term, matching the same convention `Flows.get_cached_flow/2` itself already uses for this error shape) and returns `{state, false}` — the same "skip this periodic flow, don't crash" convention already used by the other clauses of `common_flow/4` in this module.

## Blast radius

Grepped for other bare matches on `Flows.get_cached_flow/2`. Found one sibling, `lib/glific/flows/flow.ex:306` (`Flow.get_flow/3`) — deliberately **not** touched here: it's a different function with different callers (`start_sub_flow/3`, `Flows.get_complete_flow/3`, flow-context resume), a different `Flow.t()`/raise contract, and no `{state, boolean}`-style skip semantics to mirror. Fixing it correctly needs its own investigation and its own PR/incident — flagging as a follow-up rather than bundling an under-considered fix into this one.

## Verification

⚠️ This sandbox has no Elixir/Erlang toolchain (no `mix`, no `erl`) — `mix format`, `mix compile --warnings-as-errors`, and `mix test` could not be run, and the `make-branch-ready-for-review` finalize step could not be invoked in this run. The fix and regression test were produced by a `backend-engineer` agent and a `test-automator` agent, then adversarially reviewed by a `code-reviewer` agent, which independently hand-traced the actual `Caches.fetch`/`Cachex`/`Ecto.NoResultsError` call chain (pulling Cachex 3.6.0's real source to confirm the exact error-wrapping behavior) and returned a **CLEAR** verdict with no blocking issues. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.** Opened as draft given the toolchain/finalize-step gap.

## Regression test

Added to `test/glific/flows/periodic_test.exs`: calls `init_common_flow/3` with a nonexistent `flow_id` (`0`), asserting the result is `{state, false}` rather than a crash, and separately asserts `Flows.get_cached_flow/2` really does return `{:error, %Cachex.ExecutionError{}}` for that input. Reviewer confirmed (by hand-tracing, not execution) that this fails with `MatchError` on `origin/master` and passes with the fix.

---
Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9qYzFz3kN2QAmUifgv9NQ)_