### PR TITLE
autofix: retry GCS download timeout on non-final attempts, discard on last (incident #292)

### DIFF
--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -204,20 +204,25 @@ defmodule Glific.GCS.GcsWorker do
   Standard perform method to use Oban worker
   """
   @impl Oban.Worker
-  @spec perform(Oban.Job.t()) :: :ok | {:discard, String.t()}
-  def perform(%Oban.Job{args: %{"media" => media}}) do
+  @spec perform(Oban.Job.t()) :: :ok | {:error, String.t()} | {:discard, String.t()}
+  def perform(%Oban.Job{
+        args: %{"media" => media},
+        attempt: attempt,
+        max_attempts: max_attempts
+      }) do
     Logger.info("GCSWORKER: Performing gcs media for media id: #{media["id"]}")
 
     Repo.put_process_state(media["organization_id"])
     RepoReplica.put_process_state(media["organization_id"])
 
     Jobs.Instrumentation.track("gcs_upload", media["organization_id"], fn ->
-      do_perform(media)
+      do_perform(media, attempt, max_attempts)
     end)
   end
 
-  @spec do_perform(map()) :: :ok | {:discard, String.t()}
-  defp do_perform(media) do
+  @spec do_perform(map(), pos_integer(), pos_integer()) ::
+          :ok | {:error, String.t()} | {:discard, String.t()}
+  defp do_perform(media, attempt, max_attempts) do
     # We will download the file from internet and then upload it to gsc and then remove it.
     extension = get_media_extension(media["type"])
 
@@ -255,16 +260,24 @@ defmodule Glific.GCS.GcsWorker do
         {:discard, error}
 
       {:error, :timeout} ->
-        # A network timeout could self-correct on an immediate retry, but discarding
-        # here (rather than letting Oban raise and retry) is what stops this from
-        # flooding AppSignal on every attempt. gcs_url stays nil and no invalid-media
-        # marker is set, so the periodic sweep still re-attempts this media later.
+        # A network timeout is transient and most likely to succeed on a quick retry,
+        # so let Oban retry it normally on non-final attempts -- Glific.Appsignal only
+        # reports to AppSignal once attempt >= max_attempts, so retrying here doesn't
+        # flood it. Only on the final attempt do we give up: discard (not error) so
+        # Oban doesn't raise, recording the failure for visibility. gcs_url stays nil
+        # and no invalid-media marker is set, so the periodic sweep still re-attempts
+        # this media later if the quick retries were exhausted.
         error =
           "GCSWORKER: GCS Download timeout for org_id: #{media["organization_id"]}, media_id: #{media["id"]}"
 
         Logger.info(error)
-        add_message_media_error(media, error)
-        {:discard, error}
+
+        if attempt < max_attempts do
+          {:error, error}
+        else
+          add_message_media_error(media, error)
+          {:discard, error}
+        end
 
       {:error, error} ->
         error =

--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -255,6 +255,10 @@ defmodule Glific.GCS.GcsWorker do
         {:discard, error}
 
       {:error, :timeout} ->
+        # A network timeout could self-correct on an immediate retry, but discarding
+        # here (rather than letting Oban raise and retry) is what stops this from
+        # flooding AppSignal on every attempt. gcs_url stays nil and no invalid-media
+        # marker is set, so the periodic sweep still re-attempts this media later.
         error =
           "GCSWORKER: GCS Download timeout for org_id: #{media["organization_id"]}, media_id: #{media["id"]}"
 

--- a/lib/glific/third_party/gcs/gcs_worker.ex
+++ b/lib/glific/third_party/gcs/gcs_worker.ex
@@ -204,7 +204,7 @@ defmodule Glific.GCS.GcsWorker do
   Standard perform method to use Oban worker
   """
   @impl Oban.Worker
-  @spec perform(Oban.Job.t()) :: :ok | {:error, String.t()} | {:discard, String.t()}
+  @spec perform(Oban.Job.t()) :: :ok | {:discard, String.t()}
   def perform(%Oban.Job{args: %{"media" => media}}) do
     Logger.info("GCSWORKER: Performing gcs media for media id: #{media["id"]}")
 
@@ -216,7 +216,7 @@ defmodule Glific.GCS.GcsWorker do
     end)
   end
 
-  @spec do_perform(map()) :: :ok | {:error, String.t()} | {:discard, String.t()}
+  @spec do_perform(map()) :: :ok | {:discard, String.t()}
   defp do_perform(media) do
     # We will download the file from internet and then upload it to gsc and then remove it.
     extension = get_media_extension(media["type"])
@@ -260,7 +260,7 @@ defmodule Glific.GCS.GcsWorker do
 
         Logger.info(error)
         add_message_media_error(media, error)
-        {:error, error}
+        {:discard, error}
 
       {:error, error} ->
         error =

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -139,6 +139,55 @@ defmodule Glific.GcsWorkerTest do
     end
   end
 
+  test "perform/1 discards (does not fail/retry) when the GCS download times out",
+       attrs do
+    # Simulates the AppSignal incident #292 flood: the download step times out on
+    # every attempt. Mocking Tesla to return {:error, :timeout} drives the worker
+    # through the exact same `download_file_to_temp/3` -> `do_perform/1` case clause
+    # that raised Oban.PerformError on every retry before the fix.
+    Tesla.Mock.mock(fn %{method: :get} -> {:error, :timeout} end)
+
+    with_mock(
+      Goth.Token,
+      [],
+      fetch: fn _url ->
+        {:ok, %{token: "mock_access_token", expires: System.system_time(:second) + 120}}
+      end
+    ) do
+      GCS.insert_gcs_jobs(attrs.organization_id)
+
+      media =
+        Fixtures.message_media_fixture(%{
+          organization_id: attrs.organization_id
+        })
+        |> Ecto.Changeset.change(%{
+          inserted_at: DateTime.add(DateTime.utc_now(), -2, :day) |> DateTime.truncate(:second),
+          updated_at: DateTime.add(DateTime.utc_now(), -2, :day) |> DateTime.truncate(:second)
+        })
+        |> Repo.update!()
+
+      assert :ok = GcsWorker.perform_periodic(attrs.organization_id, %{phase: "incremental"})
+      assert_enqueued(worker: GcsWorker, prefix: "global")
+
+      # Oban.drain_queue actually runs the enqueued job through `perform/1`, so this
+      # exercises the real Oban execution path (not a direct call to the private
+      # `do_perform/1`). A `{:discard, _}` return lands in `discard`, with `failure`
+      # at 0 and no retry left enqueued. Before the fix, `do_perform/1` returned
+      # `{:error, error}` here, which Oban treats as a job failure — this same
+      # assertion would instead see `failure: 1, discard: 0` and Oban would schedule
+      # a retry that re-raises Oban.PerformError on the next attempt too.
+      assert %{success: 0, failure: 0, snoozed: 0, discard: 1, cancelled: 0} ==
+               Oban.drain_queue(queue: :gcs)
+
+      refute_enqueued(worker: GcsWorker, prefix: "global")
+
+      assert %MessageMedia{gcs_error: gcs_error, gcs_url: nil} =
+               Repo.get!(MessageMedia, media.id)
+
+      assert gcs_error =~ "GCS Download timeout"
+    end
+  end
+
   test "perform_periodic/2, queuing only media_ids not older than a month, unsynced", attrs do
     with_mock(
       Goth.Token,

--- a/test/glific/gcs_worker_test.exs
+++ b/test/glific/gcs_worker_test.exs
@@ -139,12 +139,13 @@ defmodule Glific.GcsWorkerTest do
     end
   end
 
-  test "perform/1 discards (does not fail/retry) when the GCS download times out",
+  test "perform/1 retries on a non-final attempt when the GCS download times out",
        attrs do
-    # Simulates the AppSignal incident #292 flood: the download step times out on
-    # every attempt. Mocking Tesla to return {:error, :timeout} drives the worker
-    # through the exact same `download_file_to_temp/3` -> `do_perform/1` case clause
-    # that raised Oban.PerformError on every retry before the fix.
+    # Incident #292 follow-up: a network timeout is transient and most likely to
+    # succeed on a quick retry, so a non-final attempt should let Oban retry
+    # normally rather than give up immediately. Mocking Tesla to return
+    # {:error, :timeout} drives the worker through the exact same
+    # `download_file_to_temp/3` -> `do_perform/3` case clause as the incident.
     Tesla.Mock.mock(fn %{method: :get} -> {:error, :timeout} end)
 
     with_mock(
@@ -169,17 +170,61 @@ defmodule Glific.GcsWorkerTest do
       assert :ok = GcsWorker.perform_periodic(attrs.organization_id, %{phase: "incremental"})
       assert_enqueued(worker: GcsWorker, prefix: "global")
 
-      # Oban.drain_queue actually runs the enqueued job through `perform/1`, so this
-      # exercises the real Oban execution path (not a direct call to the private
-      # `do_perform/1`). A `{:discard, _}` return lands in `discard`, with `failure`
-      # at 0 and no retry left enqueued. Before the fix, `do_perform/1` returned
-      # `{:error, error}` here, which Oban treats as a job failure — this same
-      # assertion would instead see `failure: 1, discard: 0` and Oban would schedule
-      # a retry that re-raises Oban.PerformError on the next attempt too.
-      assert %{success: 0, failure: 0, snoozed: 0, discard: 1, cancelled: 0} ==
+      # Oban.drain_queue actually runs the enqueued job through `perform/1` on its
+      # first attempt, so this exercises the real Oban execution path (not a direct
+      # call to the private `do_perform/3`). The worker's `max_attempts: 2`, so
+      # attempt 1 < max_attempts means `do_perform/3` returns `{:error, _}` here —
+      # Oban treats that as a job failure and schedules a retry (not a discard).
+      assert %{success: 0, failure: 1, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :gcs)
 
-      refute_enqueued(worker: GcsWorker, prefix: "global")
+      # The job is still around, scheduled for its next (final) attempt rather than
+      # discarded outright.
+      assert %MessageMedia{gcs_error: nil, gcs_url: nil} =
+               Repo.get!(MessageMedia, media.id)
+    end
+  end
+
+  test "perform/1 discards on the final attempt when the GCS download times out",
+       attrs do
+    # Once the final attempt is reached, retrying further would only wait out
+    # Oban's backoff forever without success (the timeout is real, not a one-off),
+    # so the worker gives up cleanly: discard, not error, so Oban doesn't raise
+    # `Oban.PerformError`. Recovery still happens later via the periodic sweep.
+    Tesla.Mock.mock(fn %{method: :get} -> {:error, :timeout} end)
+
+    with_mock(
+      Goth.Token,
+      [],
+      fetch: fn _url ->
+        {:ok, %{token: "mock_access_token", expires: System.system_time(:second) + 120}}
+      end
+    ) do
+      media =
+        Fixtures.message_media_fixture(%{
+          organization_id: attrs.organization_id
+        })
+
+      args = %{
+        "media" => %{
+          "id" => media.id,
+          "url" => "https://example.com/file.mp3",
+          "type" => "audio",
+          "contact_id" => 1,
+          "flow_id" => 0,
+          "organization_id" => attrs.organization_id,
+          "sync_phase" => "incremental"
+        }
+      }
+
+      # perform_job/3's opts override the built job's own fields (attempt,
+      # max_attempts), so this still drives the real `perform/1` callback --
+      # simulating being on the last of 2 attempts, not calling `do_perform/3`
+      # directly with a hand-built struct.
+      assert {:discard, error} =
+               perform_job(GcsWorker, args, attempt: 2, max_attempts: 2)
+
+      assert error =~ "GCS Download timeout"
 
       assert %MessageMedia{gcs_error: gcs_error, gcs_url: nil} =
                Repo.get!(MessageMedia, media.id)


### PR DESCRIPTION
## AppSignal incident

[#292](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/292) — `Oban.PerformError`, 70 total occurrences, 8 in the last 7 days. Source: AppSignal.

## Root cause

`Glific.GCS.GcsWorker.do_perform/1` (`lib/glific/third_party/gcs/gcs_worker.ex`) has a 3-branch `case` over `download_file_to_temp/3`'s result. The `{:error, :timeout}` branch returned `{:error, error}`, which Oban treats as a job failure — it raises `Oban.PerformError` and (per this repo's own AppSignal telemetry handler, `lib/glific/appsignal.ex`) reports to AppSignal once `attempt >= max_attempts` (this worker has `max_attempts: 2`). Its two sibling branches (`{:error, :invalid_media_id}` and the generic catch-all) already return `{:discard, error}` for a comparable "this attempt didn't work" outcome — the `:timeout` branch was the one inconsistent case.

## Fix

**v1 (first commit) unconditionally discarded on `:timeout`**, matching its siblings. Review feedback pointed out this over-corrected: a network timeout is exactly the kind of transient error most likely to succeed on an immediate retry, and `Glific.Appsignal` only reports to AppSignal once `attempt >= max_attempts` — so retrying on non-final attempts was already silent under the *original* code too. Unconditionally discarding traded a fast Oban retry (~17s) for the slow periodic-sweep recovery path (worst case ~20h) without needing to, just to suppress a report that only ever fired once per job (on the final attempt) anyway.

**v2 (current) retries on non-final attempts, discards only on the last one:**
- `perform/1` now pattern-matches `attempt`/`max_attempts` off the `%Oban.Job{}` and passes them into `do_perform/3` (arity bumped from 1 to 3).
- The `:timeout` branch: `attempt < max_attempts` → `{:error, error}` (normal Oban retry, silent per the AppSignal-reporting rule above); `attempt >= max_attempts` → `{:discard, error}` as before, so Oban never raises on the last attempt and recovery still falls back to the periodic sweep if the retries are exhausted.
- `@spec`s on `perform/1` and `do_perform/3` include `{:error, String.t()}` again (removed in v1, restored here since the retry branch needs it).

## Verified during review (adversarial `code-reviewer` pass, both rounds)

- Confirmed via `Glific.Appsignal`'s telemetry handler why only the final attempt ever reported, both before and after this fix — the retry-then-discard shape preserves that exact reporting cadence while adding back the fast-retry opportunity for the common transient case.
- Confirmed `uploading_to_gcs/2`'s own `{:error, _}` branch is *not* part of this incident's blast radius — that function unconditionally returns `:ok` after its case, so it never surfaces an error to Oban in the first place.
- Confirmed `download_file_to_temp/3`'s full return surface is exhausted by the `case` (no remaining unhandled `{:error, _}` path).
- No media is lost either way (`gcs_url` stays `nil`, no invalid-media marker is set on discard, so the row stays eligible for later sync).

## Verification

⚠️ This sandbox has no Elixir/Erlang toolchain (no `mix`, no `erl`) — `mix format`, `mix compile --warnings-as-errors`, and `mix test` could not be run. The fix and regression tests were produced by `backend-engineer`/`test-automator` agents and adversarially reviewed, hand-tracing the Oban/telemetry/`download_file_to_temp` call chains in detail. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.** Opened as draft (Tier 2 resilience change, per this routine's rules).

## Regression tests

`test/glific/gcs_worker_test.exs`:
1. **Non-final attempt** — mocks the download to return `{:error, :timeout}`, drives the job through the real `Oban.drain_queue/1` path, and asserts it lands in `failure` (a scheduled retry), not `discard`.
2. **Final attempt** — uses `Oban.Testing`'s `perform_job/3` with `attempt: 2, max_attempts: 2` overrides (still drives the real `perform/1` callback, not a hand-built struct calling the private `do_perform/3` directly) and asserts `{:discard, _}`, with `gcs_error` set and `gcs_url` staying `nil`.

---
Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged.