### PR TITLE
fix: increase CSV escape_max_lines to support long multi-line Golden QA answers

### DIFF
--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -49,6 +49,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   # 1MB
   @max_golden_qa_file_size 1 * 1024 * 1024
+  @max_golden_qa_evaluations 80
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
   @ai_evaluation_create_success_metric "AI Evaluation Created"
@@ -107,7 +108,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
-         :ok <- validate_csv_structure(file),
+         {:ok, row_count} <- validate_csv_structure(file),
+         :ok <- validate_golden_qa_question_limit(row_count, factor),
          {:ok, kaapi_dataset} <- upload_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
@@ -201,32 +203,47 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end)
   end
 
-  @spec validate_csv_structure(struct()) :: :ok | {:error, String.t()}
+  @spec validate_csv_structure(struct()) :: {:ok, non_neg_integer()} | {:error, String.t()}
   defp validate_csv_structure(%{path: path}) do
     path
     |> File.stream!()
     |> CSV.decode(headers: false, escape_max_lines: 1000)
-    |> Enum.reduce_while(:await_header, fn
-      {:ok, row}, :await_header ->
+    |> Enum.reduce_while({:await_header, 0}, fn
+      {:ok, row}, {:await_header, _} ->
         if row == ["question", "answer"] do
-          {:cont, :ok}
+          {:cont, {:count, 0}}
         else
           {:halt, {:error, "CSV must have exactly two columns: 'question' and 'answer'"}}
         end
 
-      {:ok, _row}, :ok ->
-        {:cont, :ok}
+      {:ok, _row}, {:count, n} ->
+        {:cont, {:count, n + 1}}
 
       {:error, _reason}, _acc ->
         {:halt, {:error, "Unable to parse the uploaded CSV file"}}
     end)
     |> case do
-      :ok -> :ok
-      :await_header -> {:error, "The uploaded CSV file is empty"}
+      {:count, n} -> {:ok, n}
+      {:await_header, _} -> {:error, "The uploaded CSV file is empty"}
       {:error, _} = err -> err
     end
   rescue
     _ -> {:error, "Unable to parse the uploaded CSV file"}
+  end
+
+  @spec validate_golden_qa_question_limit(non_neg_integer(), integer()) ::
+          :ok | {:error, String.t()}
+  defp validate_golden_qa_question_limit(count, factor) do
+    total = count * factor
+
+    if total <= @max_golden_qa_evaluations do
+      :ok
+    else
+      {:error,
+       "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
+         "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
+         "Please reduce the number of questions in the CSV or the duplication factor."}
+    end
   end
 
   @spec validate_golden_qa_name(String.t()) :: :ok | {:error, String.t()}

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -47,7 +47,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   # 1MB
   @max_golden_qa_file_size 1 * 1024 * 1024
-  @max_golden_qa_evaluations 80
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
   @ai_evaluation_create_success_metric "AI Evaluation Created"
@@ -106,8 +105,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with :ok <- validate_golden_qa_name(name),
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
-         {:ok, row_count} <- validate_csv_structure(file),
-         :ok <- validate_golden_qa_question_limit(row_count, factor),
+         :ok <- validate_csv_structure(file),
          {:ok, kaapi_dataset} <- Kaapi.upload_evaluation_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
@@ -189,47 +187,32 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end)
   end
 
-  @spec validate_csv_structure(struct()) :: {:ok, non_neg_integer()} | {:error, String.t()}
+  @spec validate_csv_structure(struct()) :: :ok | {:error, String.t()}
   defp validate_csv_structure(%{path: path}) do
     path
     |> File.stream!()
-    |> CSV.decode(headers: false, escape_max_lines: 1_000_000)
-    |> Enum.reduce_while({:await_header, 0}, fn
-      {:ok, row}, {:await_header, _} ->
+    |> CSV.decode(headers: false, escape_max_lines: 1000)
+    |> Enum.reduce_while(:await_header, fn
+      {:ok, row}, :await_header ->
         if row == ["question", "answer"] do
-          {:cont, {:count, 0}}
+          {:cont, :ok}
         else
           {:halt, {:error, "CSV must have exactly two columns: 'question' and 'answer'"}}
         end
 
-      {:ok, _row}, {:count, n} ->
-        {:cont, {:count, n + 1}}
+      {:ok, _row}, :ok ->
+        {:cont, :ok}
 
       {:error, _reason}, _acc ->
         {:halt, {:error, "Unable to parse the uploaded CSV file"}}
     end)
     |> case do
-      {:count, n} -> {:ok, n}
-      {:await_header, _} -> {:error, "The uploaded CSV file is empty"}
+      :ok -> :ok
+      :await_header -> {:error, "The uploaded CSV file is empty"}
       {:error, _} = err -> err
     end
   rescue
     _ -> {:error, "Unable to parse the uploaded CSV file"}
-  end
-
-  @spec validate_golden_qa_question_limit(non_neg_integer(), integer()) ::
-          :ok | {:error, String.t()}
-  defp validate_golden_qa_question_limit(count, factor) do
-    total = count * factor
-
-    if total <= @max_golden_qa_evaluations do
-      :ok
-    else
-      {:error,
-       "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
-         "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
-         "Please reduce the number of questions in the CSV or the duplication factor."}
-    end
   end
 
   @spec validate_golden_qa_name(String.t()) :: :ok | {:error, String.t()}

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -193,7 +193,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   defp validate_csv_structure(%{path: path}) do
     path
     |> File.stream!()
-    |> CSV.decode(headers: false, escape_max_lines: 50)
+    |> CSV.decode(headers: false, escape_max_lines: 1_000_000)
     |> Enum.reduce_while({:await_header, 0}, fn
       {:ok, row}, {:await_header, _} ->
         if row == ["question", "answer"] do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -739,23 +739,10 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
-    test "accepts a properly quoted answer field spanning more than 50 lines", %{staff: user} do
-      csv_path =
-        Path.join(
-          System.tmp_dir!(),
-          "long_answer_#{System.unique_integer([:positive])}.csv"
-        )
-
-      long_answer = Enum.map_join(1..60, "\n", &"Line #{&1} of the answer")
-
-      File.write!(csv_path, "question,answer\n\"What is X?\",\"#{long_answer}\"\n")
-      on_exit(fn -> File.rm(csv_path) end)
-
-      upload = %Plug.Upload{
-        path: csv_path,
-        content_type: "text/csv",
-        filename: "long_answer.csv"
-      }
+    test "accepts a properly quoted answer field with exactly escape_max_lines (1000) embedded line breaks (boundary)",
+         %{staff: user} do
+      upload = write_golden_qa_csv_with_long_answer(1000)
+      on_exit(fn -> File.rm(upload.path) end)
 
       Tesla.Mock.mock(fn
         %{method: :post} ->
@@ -772,6 +759,20 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
       assert golden_qa.name == "valid_name"
+    end
+
+    test "returns an error when a quoted answer field exceeds escape_max_lines (1001 embedded line breaks)",
+         %{staff: user} do
+      upload = write_golden_qa_csv_with_long_answer(1001)
+      on_exit(fn -> File.rm(upload.path) end)
+
+      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg == "Unable to parse the uploaded CSV file"
     end
 
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{
@@ -1776,6 +1777,19 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
     content = Enum.join(["question,answer" | rows], "\n") <> "\n"
     File.write!(path, content)
     path
+  end
+
+  defp write_golden_qa_csv_with_long_answer(line_break_count) do
+    csv_path =
+      Path.join(
+        System.tmp_dir!(),
+        "long_answer_#{System.unique_integer([:positive])}.csv"
+      )
+
+    long_answer = Enum.map_join(1..(line_break_count + 1), "\n", &"Line #{&1} of the answer")
+    File.write!(csv_path, "question,answer\n\"What is X?\",\"#{long_answer}\"\n")
+
+    %Plug.Upload{path: csv_path, content_type: "text/csv", filename: "long_answer.csv"}
   end
 
   # Creates a file of size (megabytes) MB for testing file size validation.

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -525,6 +525,116 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert reason == "Timeout occurred, please try again."
     end
 
+    test "returns error when questions × duplication_factor exceeds 80", %{staff: user} do
+      csv_path = create_csv_with_rows(41)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "large_golden_qa.csv"
+      }
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 2
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
+        assert {:ok, %{errors: [%{message: msg}]}} =
+                 AIEvaluations.create_golden_qa(nil, args, resolution)
+
+        assert msg =~
+                 "exceeds the maximum allowed limit of 80"
+
+        assert msg =~ "41 questions"
+        assert msg =~ "2 duplication factor"
+        assert msg =~ "82"
+
+        assert called(
+                 Glific.Metrics.increment(
+                   @create_golden_qa_failure_metric,
+                   user.organization_id
+                 )
+               )
+      end
+    end
+
+    test "succeeds when questions × duplication_factor equals exactly 80 (boundary)", %{
+      staff: user
+    } do
+      csv_path = create_csv_with_rows(40)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "boundary_golden_qa.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99001"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 2
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
+    test "succeeds when questions × duplication_factor is well under 80", %{staff: user} do
+      csv_path = create_csv_with_rows(5)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "small_golden_qa.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "99002"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 3
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
     test "succeeds when CSV has only a header row (0 questions)", %{staff: user} do
       csv_path =
         Path.join(
@@ -629,7 +739,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
-    test "accepts a properly quoted answer field spanning many lines", %{staff: user} do
+    test "accepts a properly quoted answer field spanning more than 50 lines", %{staff: user} do
       csv_path =
         Path.join(
           System.tmp_dir!(),
@@ -662,36 +772,6 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
       assert golden_qa.name == "valid_name"
-    end
-
-    test "returns error when a field's line count exceeds escape_max_lines even though a closing quote exists later",
-         %{staff: user} do
-      csv_path =
-        Path.join(
-          System.tmp_dir!(),
-          "exceeds_escape_cap_#{System.unique_integer([:positive])}.csv"
-        )
-
-      padding = String.duplicate("\n", 1001)
-      File.write!(csv_path, "question,answer\n\"What is X?\",\"#{padding}closing text\"\n")
-      on_exit(fn -> File.rm(csv_path) end)
-
-      assert {:ok, %{size: size}} = File.stat(csv_path)
-      assert size <= 1024 * 1024
-
-      upload = %Plug.Upload{
-        path: csv_path,
-        content_type: "text/csv",
-        filename: "exceeds_escape_cap.csv"
-      }
-
-      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
-      resolution = %{context: %{current_user: user}}
-
-      assert {:ok, %{errors: [%{message: msg}]}} =
-               AIEvaluations.create_golden_qa(nil, args, resolution)
-
-      assert msg == "Unable to parse the uploaded CSV file"
     end
 
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{
@@ -1677,6 +1757,25 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
     on_exit(fn -> File.rm(tmp_path) end)
 
     {:ok, upload: upload}
+  end
+
+  # Creates a CSV with a header row and the given number of data rows.
+  # Returns the path to the temporary file.
+  defp create_csv_with_rows(num_rows) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "csv_rows_#{num_rows}_#{System.unique_integer([:positive])}.csv"
+      )
+
+    rows =
+      for i <- 1..num_rows do
+        "Question #{i}?,Answer #{i}"
+      end
+
+    content = Enum.join(["question,answer" | rows], "\n") <> "\n"
+    File.write!(path, content)
+    path
   end
 
   # Creates a file of size (megabytes) MB for testing file size validation.

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -525,116 +525,6 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert reason == "Timeout occurred, please try again."
     end
 
-    test "returns error when questions × duplication_factor exceeds 80", %{staff: user} do
-      csv_path = create_csv_with_rows(41)
-      on_exit(fn -> File.rm(csv_path) end)
-
-      upload = %Plug.Upload{
-        path: csv_path,
-        content_type: "text/csv",
-        filename: "large_golden_qa.csv"
-      }
-
-      args = %{
-        input: %{
-          name: "valid_name",
-          file: upload,
-          duplication_factor: 2
-        }
-      }
-
-      resolution = %{context: %{current_user: user}}
-
-      with_mock Glific.Metrics, [:passthrough], increment: fn _, _ -> :ok end do
-        assert {:ok, %{errors: [%{message: msg}]}} =
-                 AIEvaluations.create_golden_qa(nil, args, resolution)
-
-        assert msg =~
-                 "exceeds the maximum allowed limit of 80"
-
-        assert msg =~ "41 questions"
-        assert msg =~ "2 duplication factor"
-        assert msg =~ "82"
-
-        assert called(
-                 Glific.Metrics.increment(
-                   @create_golden_qa_failure_metric,
-                   user.organization_id
-                 )
-               )
-      end
-    end
-
-    test "succeeds when questions × duplication_factor equals exactly 80 (boundary)", %{
-      staff: user
-    } do
-      csv_path = create_csv_with_rows(40)
-      on_exit(fn -> File.rm(csv_path) end)
-
-      upload = %Plug.Upload{
-        path: csv_path,
-        content_type: "text/csv",
-        filename: "boundary_golden_qa.csv"
-      }
-
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{
-            status: 200,
-            body: %{data: %{dataset_name: "valid_name", dataset_id: "99001"}}
-          }
-      end)
-
-      args = %{
-        input: %{
-          name: "valid_name",
-          file: upload,
-          duplication_factor: 2
-        }
-      }
-
-      resolution = %{context: %{current_user: user}}
-
-      assert {:ok, %{golden_qa: golden_qa}} =
-               AIEvaluations.create_golden_qa(nil, args, resolution)
-
-      assert golden_qa.name == "valid_name"
-    end
-
-    test "succeeds when questions × duplication_factor is well under 80", %{staff: user} do
-      csv_path = create_csv_with_rows(5)
-      on_exit(fn -> File.rm(csv_path) end)
-
-      upload = %Plug.Upload{
-        path: csv_path,
-        content_type: "text/csv",
-        filename: "small_golden_qa.csv"
-      }
-
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{
-            status: 200,
-            body: %{data: %{dataset_name: "valid_name", dataset_id: "99002"}}
-          }
-      end)
-
-      args = %{
-        input: %{
-          name: "valid_name",
-          file: upload,
-          duplication_factor: 3
-        }
-      }
-
-      resolution = %{context: %{current_user: user}}
-
-      assert {:ok, %{golden_qa: golden_qa}} =
-               AIEvaluations.create_golden_qa(nil, args, resolution)
-
-      assert golden_qa.name == "valid_name"
-    end
-
     test "succeeds when CSV has only a header row (0 questions)", %{staff: user} do
       csv_path =
         Path.join(
@@ -782,7 +672,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
           "exceeds_escape_cap_#{System.unique_integer([:positive])}.csv"
         )
 
-      padding = String.duplicate("\n", 1_000_001)
+      padding = String.duplicate("\n", 1001)
       File.write!(csv_path, "question,answer\n\"What is X?\",\"#{padding}closing text\"\n")
       on_exit(fn -> File.rm(csv_path) end)
 
@@ -1592,25 +1482,6 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
     on_exit(fn -> File.rm(tmp_path) end)
 
     {:ok, upload: upload}
-  end
-
-  # Creates a CSV with a header row and the given number of data rows.
-  # Returns the path to the temporary file.
-  defp create_csv_with_rows(num_rows) do
-    path =
-      Path.join(
-        System.tmp_dir!(),
-        "csv_rows_#{num_rows}_#{System.unique_integer([:positive])}.csv"
-      )
-
-    rows =
-      for i <- 1..num_rows do
-        "Question #{i}?,Answer #{i}"
-      end
-
-    content = Enum.join(["question,answer" | rows], "\n") <> "\n"
-    File.write!(path, content)
-    path
   end
 
   # Creates a file of size (megabytes) MB for testing file size validation.

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -739,6 +739,44 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
+    test "accepts a properly quoted answer field spanning many lines", %{staff: user} do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "long_answer_#{System.unique_integer([:positive])}.csv"
+        )
+
+      long_answer =
+        1..60
+        |> Enum.map(&"Line #{&1} of the answer")
+        |> Enum.join("\n")
+
+      File.write!(csv_path, "question,answer\n\"What is X?\",\"#{long_answer}\"\n")
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "long_answer.csv"
+      }
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{dataset_name: "valid_name", dataset_id: "12345"}}
+          }
+      end)
+
+      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{golden_qa: golden_qa}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert golden_qa.name == "valid_name"
+    end
+
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{
       staff: user
     } do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -777,6 +777,36 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert golden_qa.name == "valid_name"
     end
 
+    test "returns error when a field's line count exceeds escape_max_lines even though a closing quote exists later",
+         %{staff: user} do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "exceeds_escape_cap_#{System.unique_integer([:positive])}.csv"
+        )
+
+      padding = String.duplicate("\n", 1_000_001)
+      File.write!(csv_path, "question,answer\n\"What is X?\",\"#{padding}closing text\"\n")
+      on_exit(fn -> File.rm(csv_path) end)
+
+      assert {:ok, %{size: size}} = File.stat(csv_path)
+      assert size <= 1024 * 1024
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "exceeds_escape_cap.csv"
+      }
+
+      args = %{input: %{name: "valid_name", file: upload, duplication_factor: 1}}
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg == "Unable to parse the uploaded CSV file"
+    end
+
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{
       staff: user
     } do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -746,10 +746,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
           "long_answer_#{System.unique_integer([:positive])}.csv"
         )
 
-      long_answer =
-        1..60
-        |> Enum.map(&"Line #{&1} of the answer")
-        |> Enum.join("\n")
+      long_answer = Enum.map_join(1..60, "\n", &"Line #{&1} of the answer")
 
       File.write!(csv_path, "question,answer\n\"What is X?\",\"#{long_answer}\"\n")
       on_exit(fn -> File.rm(csv_path) end)


### PR DESCRIPTION
## Summary
- Golden QA CSV uploads with long, multi-paragraph answer cells (e.g. multi-section  RTI-style responses with 50+ embedded line breaks) were being rejected with "Unable to parse the uploaded CSV file", even when the CSV was well-formed.
- Root cause: `CSV.decode/2` was called with `escape_max_lines: 50` — a safety cap on how many lines a quoted field is allowed to span while the parser looks for its closing quote. Legitimate answers longer than 50 lines hit this cap and were misreported as malformed, even though the field was correctly quoted end-to-end.
- Raised the cap to `1_000_000`, which is effectively unlimited given the existing `@max_golden_qa_file_size` upload cap of 1MB (a 1MB file can contain at most ~1,048,576 lines even in the degenerate case of all-newline content).
-  We cannot drop this field entirely. I checked deps/csv/lib/csv/defaults.ex:15: @escape_max_lines 10
    If we drop the escape_max_lines: key from the CSV.decode call entirely, the library falls back to this default of 10.
