### PR TITLE
  fix: surface actionable error messages for CSV decode failures

### DIFF
--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -205,24 +205,23 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end)
   end
 
+  @golden_qa_csv_escape_max_lines 10
+
   @spec validate_csv_structure(struct()) :: {:ok, non_neg_integer()} | {:error, String.t()}
   defp validate_csv_structure(%{path: path}) do
     path
     |> File.stream!()
-    |> CSV.decode(headers: false, escape_max_lines: 1000)
+    |> CSV.decode!(headers: false, escape_max_lines: @golden_qa_csv_escape_max_lines)
     |> Enum.reduce_while({:await_header, 0}, fn
-      {:ok, row}, {:await_header, _} ->
+      row, {:await_header, _} ->
         if row == ["question", "answer"] do
           {:cont, {:count, 0}}
         else
           {:halt, {:error, "CSV must have exactly two columns: 'question' and 'answer'"}}
         end
 
-      {:ok, _row}, {:count, n} ->
+      _row, {:count, n} ->
         {:cont, {:count, n + 1}}
-
-      {:error, _reason}, _acc ->
-        {:halt, {:error, "Unable to parse the uploaded CSV file"}}
     end)
     |> case do
       {:count, n} -> {:ok, n}
@@ -230,7 +229,27 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:error, _} = err -> err
     end
   rescue
-    _ -> {:error, "Unable to parse the uploaded CSV file"}
+    e in CSV.StrayEscapeCharacterError ->
+      {:error,
+       "Row #{e.line} of the CSV has an unescaped \" character inside a field. " <>
+         "Either remove it or escape it by doubling it up (e.g. \"\"), or wrap the whole field in quotes."}
+
+    e in CSV.EscapeSequenceError ->
+      {:error,
+       "Row #{escape_sequence_error_row(e)} of the CSV has a quoted field that is malformed " <>
+         "or spans more than #{@golden_qa_csv_escape_max_lines} lines. " <>
+         "Check for a missing closing quote."}
+
+    _ ->
+      {:error, "Unable to parse the uploaded CSV file"}
+  end
+
+  @spec escape_sequence_error_row(Exception.t()) :: String.t()
+  defp escape_sequence_error_row(%CSV.EscapeSequenceError{message: message}) do
+    case Regex.run(~r/on line (\d+)/, message) do
+      [_match, row] -> row
+      _ -> "unknown"
+    end
   end
 
   @spec validate_golden_qa_question_limit(non_neg_integer(), integer()) ::

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -205,7 +205,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end)
   end
 
-  @golden_qa_csv_escape_max_lines 10
+  @golden_qa_csv_escape_max_lines 1000
 
   @spec validate_csv_structure(struct()) :: {:ok, non_neg_integer()} | {:error, String.t()}
   defp validate_csv_structure(%{path: path}) do

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -231,14 +231,17 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   rescue
     e in CSV.StrayEscapeCharacterError ->
       {:error,
-       "Row #{e.line} of the CSV has an unescaped \" character inside a field. " <>
-         "Either remove it or escape it by doubling it up (e.g. \"\"), or wrap the whole field in quotes."}
+       "Row #{e.line} of the CSV has an unescaped \" character inside a field, for example: " <>
+         "He said \"hi\" to me. Wrap the whole field in quotes and double up the inner quotes " <>
+         "to fix it, for example: \"He said \"\"hi\"\" to me\"."}
 
     e in CSV.EscapeSequenceError ->
       {:error,
-       "Row #{escape_sequence_error_row(e)} of the CSV has a quoted field that is malformed " <>
-         "or spans more than #{@golden_qa_csv_escape_max_lines} lines. " <>
-         "Check for a missing closing quote."}
+       "Row #{escape_sequence_error_row(e)} of the CSV has a malformed quoted field (a value " <>
+         "wrapped in double quotes, for example: \"This is an answer\") — check for a missing " <>
+         "closing quote, for example: \"This answer never closes. If the field is legitimately " <>
+         "longer than #{@golden_qa_csv_escape_max_lines} lines, please reduce it to under " <>
+         "#{@golden_qa_csv_escape_max_lines} lines."}
 
     _ ->
       {:error, "Unable to parse the uploaded CSV file"}

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -702,10 +702,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert msg == "Unable to parse the uploaded CSV file"
     end
 
-    test "returns error when CSV contains malformed rows (escape sequence errors)", %{
-      staff: user
-    } do
-      # Unclosed quote triggers {:error, _} from CSV.decode; reduce_while halts immediately
+    test "returns error naming the row when CSV has a malformed quoted field (unclosed quote)",
+         %{staff: user} do
       csv_path =
         Path.join(
           System.tmp_dir!(),
@@ -736,7 +734,45 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert {:ok, %{errors: [%{message: msg}]}} =
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
-      assert msg == "Unable to parse the uploaded CSV file"
+      assert msg =~ "Row 7"
+      assert msg =~ "malformed"
+      assert msg =~ "missing closing quote"
+    end
+
+    test "returns error naming the row when CSV has a stray escape character inside a field", %{
+      staff: user
+    } do
+      csv_path =
+        Path.join(
+          System.tmp_dir!(),
+          "stray_escape_csv_#{System.unique_integer([:positive])}.csv"
+        )
+
+      content = "question,answer\nWhat is Glific?,A \"quick\" answer\n"
+      File.write!(csv_path, content)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "stray_escape.csv"
+      }
+
+      args = %{
+        input: %{
+          name: "valid_name",
+          file: upload,
+          duplication_factor: 1
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{errors: [%{message: msg}]}} =
+               AIEvaluations.create_golden_qa(nil, args, resolution)
+
+      assert msg =~ "Row 2"
+      assert msg =~ "unescaped"
     end
 
     test "accepts a properly quoted answer field with exactly escape_max_lines (1000) embedded line breaks (boundary)",
@@ -772,7 +808,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert {:ok, %{errors: [%{message: msg}]}} =
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
-      assert msg == "Unable to parse the uploaded CSV file"
+      assert msg =~ "spans more than 1000 lines"
+      assert msg =~ "malformed"
     end
 
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -808,8 +808,9 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert {:ok, %{errors: [%{message: msg}]}} =
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
-      assert msg =~ "spans more than 1000 lines"
       assert msg =~ "malformed"
+      assert msg =~ "longer than 1000 lines"
+      assert msg =~ "reduce it"
     end
 
     test "returns error when CSV columns are not exactly 'question' and 'answer'", %{


### PR DESCRIPTION
## Summary
- `validate_csv_structure/1` collapsed every CSV decode failure (unclosed/malformed quoted field, stray `"` inside a field, etc.) into one generic "Unable to parse the uploaded CSV file" message, leaving users with no idea what was actually wrong with their Golden QA upload or which row to fix.
- Switched from `CSV.decode/2` (which inlines errors into plain strings) to `CSV.decode!/2`, so decode failures raise the library's actual exception structs and can be pattern-matched by type in a `rescue` block:
 - `CSV.StrayEscapeCharacterError` → names the row and explains there's an unescaped `"` inside a field, with how to fix it (escape it or quote the field).
 - `CSV.EscapeSequenceError` → names the row where the quoted field starts and explains it's malformed or spans too many lines. This exception doesn't populate a `line` field on the struct (only bakes the row number into its free-text `message`), so `escape_sequence_error_row/1` extracts it from the  message via regex, falling back to  `"unknown"` if that format ever changes.
  - Anything else still falls back to the original generic message — no behavior regression for unrecognized errors.

## ss


<img width="847" height="317" alt="Screenshot 2026-08-12 at 3 51 43 PM" src="https://github.com/user-attachments/assets/88b284d3-7860-43f1-b6b0-85e3fbfc1b93" />
