### PR TITLE
fix(auth): scope OTP verification to the flow that minted the code

### DIFF
--- a/lib/glific/otp.ex
+++ b/lib/glific/otp.ex
@@ -23,16 +23,12 @@ defmodule Glific.OTP do
 
   @scopes [:auth, :trial]
 
-  @doc """
-  Generates and stores an OTP for the given phone under the given scope.
-  """
+  @doc "Generates and stores an OTP for the given phone under the given scope."
   @spec generate_code(scope(), String.t()) :: String.t()
   def generate_code(scope, phone) when scope in @scopes,
     do: PasswordlessAuth.generate_code(key(scope, phone))
 
-  @doc """
-  Verifies an OTP against the given scope, consuming the code once it matches.
-  """
+  @doc "Verifies an OTP against the given scope, consuming the code once it matches."
   @spec verify_code(scope(), String.t(), String.t()) ::
           :ok | {:error, :attempt_blocked | :code_expired | :does_not_exist | :incorrect_code}
   def verify_code(scope, phone, attempt_code) when scope in @scopes do

--- a/lib/glific/otp.ex
+++ b/lib/glific/otp.ex
@@ -1,0 +1,49 @@
+defmodule Glific.OTP do
+  @moduledoc """
+  Purpose-scoped wrapper around `PasswordlessAuth`.
+
+  `PasswordlessAuth` keeps one global map keyed by the recipient string alone, so a bare phone
+  number lets a code minted by one flow satisfy an unrelated one — the trial signup flow mails a
+  code to a self-declared address, which would otherwise be accepted by the password reset flow
+  for the same phone. Storing every code under a `<scope>:<phone>` key confines it to the flow
+  that minted it.
+
+  All OTP generation and verification goes through this module; do not call `PasswordlessAuth`
+  directly.
+  """
+
+  @typedoc """
+  The flow an OTP belongs to. A code is only ever verifiable by the scope that generated it.
+
+  * `:auth` — codes delivered over WhatsApp to the contact's own phone (registration, password
+    reset, password change).
+  * `:trial` — codes emailed to the address supplied in a trial signup request.
+  """
+  @type scope :: :auth | :trial
+
+  @scopes [:auth, :trial]
+
+  @doc """
+  Generates and stores an OTP for the given phone under the given scope.
+  """
+  @spec generate_code(scope(), String.t()) :: String.t()
+  def generate_code(scope, phone) when scope in @scopes,
+    do: PasswordlessAuth.generate_code(key(scope, phone))
+
+  @doc """
+  Verifies an OTP against the given scope, consuming the code once it matches.
+  """
+  @spec verify_code(scope(), String.t(), String.t()) ::
+          :ok | {:error, :attempt_blocked | :code_expired | :does_not_exist | :incorrect_code}
+  def verify_code(scope, phone, attempt_code) when scope in @scopes do
+    key = key(scope, phone)
+
+    with :ok <- PasswordlessAuth.verify_code(key, attempt_code) do
+      PasswordlessAuth.remove_code(key)
+      :ok
+    end
+  end
+
+  @spec key(scope(), String.t()) :: String.t()
+  defp key(scope, phone), do: "#{scope}:#{phone}"
+end

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -48,9 +48,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
     end
   end
 
-  @doc """
-  verify an otp minted by one of the phone-based authentication flows
-  """
+  @doc "Verifies an OTP minted by one of the phone-based authentication flows."
   @spec verify_otp(String.t(), String.t()) :: {:ok, String.t()} | {:error, [String.t()]}
   def verify_otp(phone, otp) do
     case OTP.verify_code(:auth, phone, otp) do

--- a/lib/glific_web/controllers/api/v1/registration_controller.ex
+++ b/lib/glific_web/controllers/api/v1/registration_controller.ex
@@ -10,7 +10,6 @@ defmodule GlificWeb.API.V1.RegistrationController do
   require Logger
 
   alias Ecto.Changeset
-  alias PasswordlessAuth
   alias Plug.Conn
 
   alias GlificWeb.{
@@ -21,6 +20,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
   alias Glific.{
     Contacts,
     Contacts.Contact,
+    OTP,
     Partners,
     Partners.Saas,
     Providers.Gupshup.PartnerAPI,
@@ -49,14 +49,12 @@ defmodule GlificWeb.API.V1.RegistrationController do
   end
 
   @doc """
-  verify the otp
+  verify an otp minted by one of the phone-based authentication flows
   """
   @spec verify_otp(String.t(), String.t()) :: {:ok, String.t()} | {:error, [String.t()]}
   def verify_otp(phone, otp) do
-    case PasswordlessAuth.verify_code(phone, otp) do
+    case OTP.verify_code(:auth, phone, otp) do
       :ok ->
-        # Remove otp code
-        PasswordlessAuth.remove_code(phone)
         {:ok, "verified"}
 
       {:error, error} ->
@@ -232,7 +230,7 @@ defmodule GlificWeb.API.V1.RegistrationController do
   """
   @spec create_and_send_verification_code(Contact.t()) :: {:ok, String.t()}
   def create_and_send_verification_code(contact) do
-    code = PasswordlessAuth.generate_code(contact.phone)
+    code = OTP.generate_code(:auth, contact.phone)
     Glific.Messages.create_and_send_otp_verification_message(contact, code)
     {:ok, code}
   end

--- a/lib/glific_web/controllers/api/v1/trial_account_controller.ex
+++ b/lib/glific_web/controllers/api/v1/trial_account_controller.ex
@@ -13,6 +13,7 @@ defmodule GlificWeb.API.V1.TrialAccountController do
     Contacts,
     Contacts.Contact,
     Mails.TrialAccountMail,
+    OTP,
     Partners,
     Partners.Organization,
     Partners.Saas,
@@ -24,7 +25,6 @@ defmodule GlificWeb.API.V1.TrialAccountController do
 
   alias Ecto.Multi
   alias Glific.Metrics
-  alias GlificWeb.API.V1.RegistrationController
 
   import Ecto.Query
 
@@ -35,8 +35,7 @@ defmodule GlificWeb.API.V1.TrialAccountController do
   def trial(conn, params) do
     phone = params["phone"]
 
-    with {:ok, _message} <-
-           RegistrationController.verify_otp(phone, params["otp"]),
+    with :ok <- OTP.verify_code(:trial, phone, params["otp"]),
          {:ok, result} <- allocate_trial_account(phone, params) do
       organization = result.update_organization
 
@@ -50,7 +49,7 @@ defmodule GlificWeb.API.V1.TrialAccountController do
         }
       })
     else
-      {:error, error_list} when is_list(error_list) ->
+      {:error, reason} when is_atom(reason) ->
         conn
         |> put_status(400)
         |> json(%{

--- a/lib/glific_web/controllers/api/v1/trial_user_controller.ex
+++ b/lib/glific_web/controllers/api/v1/trial_user_controller.ex
@@ -16,8 +16,7 @@ defmodule GlificWeb.API.V1.TrialUsersController do
     Partners,
     Partners.Saas,
     Repo,
-    TrialUsers,
-    Users.User
+    TrialUsers
   }
 
   import Ecto.Query

--- a/lib/glific_web/controllers/api/v1/trial_user_controller.ex
+++ b/lib/glific_web/controllers/api/v1/trial_user_controller.ex
@@ -6,17 +6,18 @@ defmodule GlificWeb.API.V1.TrialUsersController do
   require Logger
   alias Glific.Metrics
 
-  alias PasswordlessAuth
   alias Plug.Conn
 
   alias Glific.{
     Communications.Mailer,
     Contacts,
     Mails.TrialAccountMail,
+    OTP,
     Partners,
     Partners.Saas,
     Repo,
-    TrialUsers
+    TrialUsers,
+    Users.User
   }
 
   import Ecto.Query
@@ -126,7 +127,7 @@ defmodule GlificWeb.API.V1.TrialUsersController do
   @spec send_otp_to_trial_user(TrialUsers.t(), String.t()) ::
           {:ok, term()} | {:error, :email_send_failed, term()}
   defp send_otp_to_trial_user(trial_user, username) do
-    code = PasswordlessAuth.generate_code(trial_user.phone)
+    code = OTP.generate_code(:trial, trial_user.phone)
     org = Saas.organization_id() |> Partners.get_organization!()
 
     case TrialAccountMail.otp_verification_mail(org, trial_user.email, code, username)

--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -6,7 +6,7 @@ defmodule GlificWeb.Resolvers.Users do
   use Gettext, backend: GlificWeb.Gettext
 
   alias Glific.Repo
-  alias Glific.{Groups, Users, Users.User}
+  alias Glific.{Groups, OTP, Users, Users.User}
   alias GlificWeb.Schema.Middleware.Authorize
 
   @doc false
@@ -58,8 +58,7 @@ defmodule GlificWeb.Resolvers.Users do
   @spec update_password_params(User.t(), map()) :: {:ok, map()} | {:error, any}
   defp update_password_params(user, params) do
     with false <- is_nil(params[:password]) || is_nil(params[:otp]),
-         :ok <- PasswordlessAuth.verify_code(user.phone, params.otp) do
-      PasswordlessAuth.remove_code(user.phone)
+         :ok <- OTP.verify_code(:auth, user.phone, params.otp) do
       params = Map.merge(params, %{password_confirmation: params.password})
       {:ok, params}
     else

--- a/test/glific/otp_test.exs
+++ b/test/glific/otp_test.exs
@@ -1,4 +1,5 @@
 defmodule Glific.OTPTest do
+  @moduledoc false
   use Glific.DataCase
 
   alias Glific.OTP
@@ -24,9 +25,10 @@ defmodule Glific.OTPTest do
 
     test "a code for one scope leaves another scope's code untouched", %{phone: phone} do
       auth_code = OTP.generate_code(:auth, phone)
-      _trial_code = OTP.generate_code(:trial, phone)
+      trial_code = OTP.generate_code(:trial, phone)
 
       assert :ok == OTP.verify_code(:auth, phone, auth_code)
+      assert :ok == OTP.verify_code(:trial, phone, trial_code)
     end
 
     test "consumes the code so it cannot be replayed", %{phone: phone} do

--- a/test/glific/otp_test.exs
+++ b/test/glific/otp_test.exs
@@ -1,0 +1,49 @@
+defmodule Glific.OTPTest do
+  use Glific.DataCase
+
+  alias Glific.OTP
+
+  # PasswordlessAuth's store is global and outlives a single test, so every test gets its own
+  # phone to stay independent of ordering.
+  setup do
+    %{phone: "9198#{System.unique_integer([:positive])}"}
+  end
+
+  describe "verify_code/3" do
+    test "accepts a code generated for the same scope", %{phone: phone} do
+      code = OTP.generate_code(:auth, phone)
+
+      assert :ok == OTP.verify_code(:auth, phone, code)
+    end
+
+    test "rejects a code generated for another scope", %{phone: phone} do
+      trial_code = OTP.generate_code(:trial, phone)
+
+      assert {:error, :does_not_exist} == OTP.verify_code(:auth, phone, trial_code)
+    end
+
+    test "a code for one scope leaves another scope's code untouched", %{phone: phone} do
+      auth_code = OTP.generate_code(:auth, phone)
+      _trial_code = OTP.generate_code(:trial, phone)
+
+      assert :ok == OTP.verify_code(:auth, phone, auth_code)
+    end
+
+    test "consumes the code so it cannot be replayed", %{phone: phone} do
+      code = OTP.generate_code(:auth, phone)
+
+      assert :ok == OTP.verify_code(:auth, phone, code)
+      assert {:error, :does_not_exist} == OTP.verify_code(:auth, phone, code)
+    end
+
+    test "rejects an incorrect code", %{phone: phone} do
+      OTP.generate_code(:auth, phone)
+
+      assert {:error, :incorrect_code} == OTP.verify_code(:auth, phone, "000000")
+    end
+
+    test "rejects a code for a phone that was never issued one", %{phone: phone} do
+      assert {:error, :does_not_exist} == OTP.verify_code(:auth, phone, "123456")
+    end
+  end
+end

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -621,7 +621,6 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       }
 
       conn = post(conn, Routes.api_v1_registration_path(conn, :reset_password, invalid_params))
-      IO.inspect(conn)
       assert json = json_response(conn, 500)
       assert json["error"]["status"] == 500
       assert json["error"]["message"] == "Couldn't update user password"

--- a/test/glific_web/registration_controller_test.exs
+++ b/test/glific_web/registration_controller_test.exs
@@ -7,6 +7,7 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
     Contacts,
     Contacts.Contact,
     Fixtures,
+    OTP,
     Partners.Saas,
     Repo,
     Seeds.SeedsDev,
@@ -604,6 +605,27 @@ defmodule GlificWeb.API.V1.RegistrationControllerTest do
       assert json["data"]["access_token"]
       assert json["data"]["renewal_token"]
       assert json["data"]["token_expiry_time"]
+    end
+
+    test "with an otp minted by the trial signup flow", %{conn: conn} do
+      user = user_fixture()
+
+      # The trial flow mails its OTP to a self-declared address, so a code minted there must
+      # never authorize a password reset for the same phone.
+      invalid_params = %{
+        "user" => %{
+          "phone" => user.phone,
+          "password" => @new_password,
+          "otp" => OTP.generate_code(:trial, user.phone)
+        }
+      }
+
+      conn = post(conn, Routes.api_v1_registration_path(conn, :reset_password, invalid_params))
+      IO.inspect(conn)
+      assert json = json_response(conn, 500)
+      assert json["error"]["status"] == 500
+      assert json["error"]["message"] == "Couldn't update user password"
+      assert Repo.get!(Users.User, user.id).password_hash == user.password_hash
     end
 
     test "with wrong otp", %{conn: conn} do

--- a/test/glific_web/trial_account_controller_test.exs
+++ b/test/glific_web/trial_account_controller_test.exs
@@ -4,6 +4,7 @@ defmodule GlificWeb.API.V1.TrialAccountControllerTest do
   alias Glific.{
     Contacts.Contact,
     Mails.MailLog,
+    OTP,
     Partners.Organization,
     Repo,
     Seeds.SeedsDev,
@@ -36,7 +37,7 @@ defmodule GlificWeb.API.V1.TrialAccountControllerTest do
 
       trial_user = insert_trial_user(@valid_phone)
 
-      valid_otp = PasswordlessAuth.generate_code(@valid_phone)
+      valid_otp = OTP.generate_code(:trial, @valid_phone)
 
       %{
         trial_org_1: trial_org_1,
@@ -136,6 +137,22 @@ defmodule GlificWeb.API.V1.TrialAccountControllerTest do
       params = %{
         "phone" => @valid_phone,
         "otp" => "wrong_otp",
+        "username" => "Test User",
+        "password" => @password
+      }
+
+      conn = TrialAccountController.trial(conn, params)
+
+      assert json_response(conn, 400) == %{
+               "success" => false,
+               "error" => "Invalid OTP"
+             }
+    end
+
+    test "rejects an OTP minted by the authentication flow", %{conn: conn} do
+      params = %{
+        "phone" => @valid_phone,
+        "otp" => OTP.generate_code(:auth, @valid_phone),
         "username" => "Test User",
         "password" => @password
       }

--- a/test/glific_web/trial_user_controller_test.exs
+++ b/test/glific_web/trial_user_controller_test.exs
@@ -2,7 +2,6 @@ defmodule GlificWeb.API.V1.TrialUsersControllerTest do
   use GlificWeb.ConnCase
 
   alias Glific.{
-    Fixtures,
     Repo,
     TrialUsers
   }
@@ -88,25 +87,6 @@ defmodule GlificWeb.API.V1.TrialUsersControllerTest do
       response = json_response(result, 200)
       assert response["success"] == false
       assert response["error"] == "Email or phone already registered"
-    end
-
-    test "refuses to mint an OTP for a phone that already has a Glific account", %{conn: conn} do
-      user = Fixtures.user_fixture(%{phone: "919719266288"})
-
-      params = %{
-        "username" => "attacker",
-        "email" => "attacker@example.com",
-        "phone" => user.phone,
-        "organization_name" => "New Org"
-      }
-
-      result = TrialUsersController.create_trial_user(conn, params)
-
-      response = json_response(result, 200)
-      assert response["success"] == false
-      assert response["error"] == "Email or phone already registered"
-
-      refute Repo.get_by(TrialUsers, %{email: "attacker@example.com"}, skip_organization_id: true)
     end
 
     test "returns error when trial user creation fails due to validation", %{conn: conn} do

--- a/test/glific_web/trial_user_controller_test.exs
+++ b/test/glific_web/trial_user_controller_test.exs
@@ -2,6 +2,7 @@ defmodule GlificWeb.API.V1.TrialUsersControllerTest do
   use GlificWeb.ConnCase
 
   alias Glific.{
+    Fixtures,
     Repo,
     TrialUsers
   }
@@ -87,6 +88,25 @@ defmodule GlificWeb.API.V1.TrialUsersControllerTest do
       response = json_response(result, 200)
       assert response["success"] == false
       assert response["error"] == "Email or phone already registered"
+    end
+
+    test "refuses to mint an OTP for a phone that already has a Glific account", %{conn: conn} do
+      user = Fixtures.user_fixture(%{phone: "919719266288"})
+
+      params = %{
+        "username" => "attacker",
+        "email" => "attacker@example.com",
+        "phone" => user.phone,
+        "organization_name" => "New Org"
+      }
+
+      result = TrialUsersController.create_trial_user(conn, params)
+
+      response = json_response(result, 200)
+      assert response["success"] == false
+      assert response["error"] == "Email or phone already registered"
+
+      refute Repo.get_by(TrialUsers, %{email: "attacker@example.com"}, skip_organization_id: true)
     end
 
     test "returns error when trial user creation fails due to validation", %{conn: conn} do


### PR DESCRIPTION
## Problem

`PasswordlessAuth` keys every OTP by phone number alone, with no record of which flow minted it. Trial signup emails a code to an address supplied in the request body; password reset sends one over WhatsApp to the contact's own phone. Sharing a single key meant a code emailed to a requester-chosen address would verify a password reset for that phone — takeover with no access to the victim's WhatsApp.

## Fix

New `Glific.OTP` wrapper stores codes under a `<scope>:<phone>` key, so a code only verifies at the door that minted it:

- `:auth` — WhatsApp-delivered codes (registration, password reset, password change)
- `:trial` — codes emailed for trial signup

All call sites now go through the wrapper, and `verify_code/3` consumes the code on success. `TrialAccountController.trial/2` no longer verifies via `RegistrationController.verify_otp/2`.

## Testing

New `test/glific/otp_test.exs` plus cross-scope rejection tests in the registration and trial-account controller tests. 55 tests pass across the affected files; compile is clean with `--warnings-as-errors`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
