### PR TITLE
Bump version from 8.9.6 to 8.9.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Glific.MixProject do
   def project do
     [
       app: :glific,
-      version: "8.9.6",
+      version: "8.9.7",
       elixir: "~> 1.18.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [


### PR DESCRIPTION
Version bump 8.9.6 -> 8.9.7, opened by bin/gigalixir-release.sh.