### PR TITLE
feat(evaluationv2): evaluation run

### DIFF
--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -664,6 +664,27 @@ defmodule Glific.ThirdParty.Kaapi do
   end
 
   @doc """
+  Create an evaluation on Kaapi via the v2 endpoint.
+  """
+  @spec create_evaluation_v2(map(), non_neg_integer()) :: {:ok, map()} | {:error, any()}
+  def create_evaluation_v2(params, organization_id) do
+    with {:ok, secrets} <- fetch_kaapi_creds(organization_id),
+         {:ok, result} <- ApiClient.create_evaluation_v2(params, secrets["api_key"]) do
+      {:ok, result}
+    else
+      {:error, reason} ->
+        Glific.log_exception(%Error{
+          message:
+            "Kaapi evaluation v2 creation failed: evaluation_name=#{params[:experiment_name]}",
+          organization_id: organization_id,
+          reason: safe_inspect(reason)
+        })
+
+        {:error, reason}
+    end
+  end
+
+  @doc """
   Get full scores for a completed evaluation from Kaapi (includes all evaluators via Langfuse).
   """
   @spec get_evaluation_scores(non_neg_integer(), non_neg_integer()) ::

--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -260,6 +260,17 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
   end
 
   @doc """
+  Create an evaluation in Kaapi (v2)
+  """
+  @spec create_evaluation_v2(map(), String.t()) :: {:ok, map()} | {:error, any()}
+  def create_evaluation_v2(params, org_api_key) do
+    org_api_key
+    |> client()
+    |> Tesla.post("/api/v2/evaluations", params)
+    |> parse_kaapi_response()
+  end
+
+  @doc """
   Get full scores for a completed evaluation from Kaapi (includes all evaluators via Langfuse).
   """
   @spec get_evaluation_scores(non_neg_integer(), String.t()) :: {:ok, map()} | {:error, any()}

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -371,6 +371,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
+  @known_ai_evaluation_statuses ~w(create_in_progress processing failed completed)
+
   @doc """
   Create an AI Evaluation by sending the input to Kaapi, storing the result in the DB,
   and returning the evaluation.
@@ -399,11 +401,12 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         {:ok, %{data: data}} <- Kaapi.create_evaluation(kaapi_input, user.organization_id),
+         {:ok, %{data: data}} <- run_kaapi_evaluation(kaapi_input, user.organization_id),
+         {:status, {:ok, status}} <- {:status, parse_ai_evaluation_status(data.status)},
          {:ok, evaluation} <-
            AIEvaluations.create_ai_evaluation(%{
              name: input.evaluation_name,
-             status: String.to_existing_atom(data.status),
+             status: status,
              failure_reason: (data.status == "failed" && Map.get(data, :error_message)) || nil,
              kaapi_evaluation_id: data.id,
              golden_qa_id: input.golden_qa_id,
@@ -423,6 +426,10 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:error,
          "The specified Golden QA dataset does not exist or does not belong to your organization."}
 
+      {:status, {:error, msg}} ->
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
+        {:error, msg}
+
       {:error, :timeout} ->
         Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
         {:error, "Timeout occurred, please try again."}
@@ -440,4 +447,22 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
         {:error, "An unknown error occurred, please contact Glific support."}
     end
   end
+
+  @spec run_kaapi_evaluation(map(), non_neg_integer()) :: {:ok, map()} | {:error, any()}
+  defp run_kaapi_evaluation(kaapi_input, organization_id) do
+    organization = Partners.organization(organization_id)
+
+    if Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization) do
+      Kaapi.create_evaluation_v2(kaapi_input, organization_id)
+    else
+      Kaapi.create_evaluation(kaapi_input, organization_id)
+    end
+  end
+
+  @spec parse_ai_evaluation_status(String.t()) :: {:ok, atom()} | {:error, String.t()}
+  defp parse_ai_evaluation_status(status) when status in @known_ai_evaluation_statuses,
+    do: {:ok, String.to_existing_atom(status)}
+
+  defp parse_ai_evaluation_status(status),
+    do: {:error, "Unexpected evaluation status received from Kaapi: #{status}"}
 end

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -373,7 +373,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
-  @known_ai_evaluation_statuses ~w(create_in_progress processing failed completed)
+  @known_ai_evaluation_statuses ~w(processing failed completed)
 
   @doc """
   Create an AI Evaluation by sending the input to Kaapi, storing the result in the DB,
@@ -389,7 +389,10 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
             })},
          {:assistant_config_version, {:ok, config_version}} <-
            {:assistant_config_version,
-            Repo.fetch_by(AssistantConfigVersion, %{id: input.config_id})},
+            Repo.fetch_by(AssistantConfigVersion, %{
+              id: input.config_id,
+              organization_id: user.organization_id
+            })},
          config_version = Repo.preload(config_version, :assistant),
          {:golden_qa, {:ok, golden_qa}} <-
            {:golden_qa,

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -428,7 +428,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         {:ok, %{data: data}} <- run_kaapi_evaluation(kaapi_input, user.organization_id),
+         {:ok, kaapi_response} <- run_kaapi_evaluation(kaapi_input, user.organization_id),
+         {:kaapi_response, {:ok, data}} <-
+           {:kaapi_response, validate_kaapi_evaluation_response(kaapi_response)},
          {:status, {:ok, status}} <- {:status, parse_ai_evaluation_status(data.status)},
          {:ok, evaluation} <-
            AIEvaluations.create_ai_evaluation(%{
@@ -452,6 +454,10 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
       {:golden_qa, {:error, _}} ->
         {:error,
          "The specified Golden QA dataset does not exist or does not belong to your organization."}
+
+      {:kaapi_response, {:error, msg}} ->
+        Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
+        {:error, msg}
 
       {:status, {:error, msg}} ->
         Metrics.increment(@ai_evaluation_create_failure_metric, user.organization_id)
@@ -492,6 +498,19 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   defp parse_ai_evaluation_status(status),
     do: {:error, "Unexpected evaluation status received from Kaapi: #{status}"}
+
+  @spec validate_kaapi_evaluation_response(map()) :: {:ok, map()} | {:error, String.t()}
+  defp validate_kaapi_evaluation_response(%{data: %{status: _status, id: _id} = data}),
+    do: {:ok, data}
+
+  defp validate_kaapi_evaluation_response(response) do
+    Glific.log_exception(%Kaapi.Error{
+      message: "Kaapi evaluation creation returned an unexpected response shape",
+      reason: safe_inspect(response)
+    })
+
+    {:error, "Invalid evaluation response received from Kaapi."}
+  end
 
   @doc """
   Requests a v2 (native-judge) prompt improvement from Kaapi for a completed

--- a/test/glific/third_party/kaapi/api_client_test.exs
+++ b/test/glific/third_party/kaapi/api_client_test.exs
@@ -533,6 +533,45 @@ defmodule Glific.ThirdParty.Kaapi.ApiClientTest do
     end
   end
 
+  describe "create_evaluation_v2/2" do
+    @evaluation_params %{
+      experiment_name: "antaratrial",
+      config_id: "d186d8eb-1211-4a7b-aa28-e8a22f8163c9",
+      config_version: 7,
+      dataset_id: 651
+    }
+
+    test "successfully creates an evaluation on the v2 endpoint" do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v2/evaluations"
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{id: 777, run_name: "antaratrial", status: "processing"}}
+        }
+      end)
+
+      assert {:ok, %{data: %{id: 777, status: "processing"}}} =
+               ApiClient.create_evaluation_v2(@evaluation_params, @org_kaapi_api_key)
+    end
+
+    test "returns error when kaapi returns error status" do
+      mock(fn %Tesla.Env{method: :post} ->
+        %Tesla.Env{status: 422, body: %{error: "Invalid config_id"}}
+      end)
+
+      assert {:error, %{status: 422, body: %{error: "Invalid config_id"}}} =
+               ApiClient.create_evaluation_v2(@evaluation_params, @org_kaapi_api_key)
+    end
+
+    test "returns error on transport failure/timeout" do
+      mock(fn %Tesla.Env{method: :post} -> {:error, :timeout} end)
+
+      assert {:error, :timeout} =
+               ApiClient.create_evaluation_v2(@evaluation_params, @org_kaapi_api_key)
+    end
+  end
+
   defp create_dataset_upload_params(_context) do
     tmp_path =
       Path.join(

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -76,6 +76,37 @@ defmodule Glific.ThirdParty.KaapiTest do
     end
   end
 
+  describe "create_evaluation_v2/2" do
+    setup [:enable_kaapi_credential]
+
+    @evaluation_params %{
+      experiment_name: "antaratrial",
+      config_id: "d186d8eb-1211-4a7b-aa28-e8a22f8163c9",
+      config_version: 7,
+      dataset_id: 651
+    }
+
+    test "forwards a well-shaped v2 response unchanged", %{organization_id: organization_id} do
+      mock(fn %Tesla.Env{method: :post, url: url} ->
+        assert url =~ "/api/v2/evaluations"
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{id: 777, run_name: "antaratrial", status: "processing"}}
+        }
+      end)
+
+      assert {:ok, %{data: %{id: 777, status: "processing"}}} =
+               Kaapi.create_evaluation_v2(@evaluation_params, organization_id)
+    end
+
+    test "passes an upstream error through unchanged", %{organization_id: organization_id} do
+      mock(fn %Tesla.Env{method: :post} -> {:error, :timeout} end)
+
+      assert {:error, :timeout} = Kaapi.create_evaluation_v2(@evaluation_params, organization_id)
+    end
+  end
+
   describe "normalize_kaapi_body/1" do
     test "treats a 200 body with success:false as a logical failure" do
       assert %{

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1773,6 +1773,111 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
         for_actor: %{organization_id: user.organization_id}
       )
     end
+
+    test "returns a controlled error when Kaapi response is missing data", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn %{method: :post} ->
+        %Tesla.Env{status: 200, body: %{}}
+      end)
+
+      count_before = Repo.aggregate(AIEvaluation, :count, :id)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "missing_data_response",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, "Invalid evaluation response received from Kaapi."} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert Repo.aggregate(AIEvaluation, :count, :id) == count_before
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "returns a controlled error when Kaapi response is missing status", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn %{method: :post} ->
+        %Tesla.Env{status: 200, body: %{data: %{id: 779}}}
+      end)
+
+      count_before = Repo.aggregate(AIEvaluation, :count, :id)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "missing_status_response",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, "Invalid evaluation response received from Kaapi."} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert Repo.aggregate(AIEvaluation, :count, :id) == count_before
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "returns a controlled error when Kaapi response is missing id", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn %{method: :post} ->
+        %Tesla.Env{status: 200, body: %{data: %{status: "processing"}}}
+      end)
+
+      count_before = Repo.aggregate(AIEvaluation, :count, :id)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "missing_id_response",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, "Invalid evaluation response received from Kaapi."} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert Repo.aggregate(AIEvaluation, :count, :id) == count_before
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
   end
 
   defp create_config_version(%{organization_id: organization_id}) do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1625,6 +1625,82 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
     end
   end
 
+  describe "create_evaluation/3 v2 (is_ai_evaluation_enabled)" do
+    setup [:enable_kaapi, :create_config_version, :create_golden_qa_fixture]
+
+    test "v2 path: hits the v2 endpoint and persists the returned status", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url} ->
+          assert url =~ "/api/v2/evaluations"
+
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{id: 777, run_name: "test_experiment", status: "processing"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "test_experiment",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{evaluation: evaluation}} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert evaluation.status == :processing
+      assert evaluation.kaapi_evaluation_id == 777
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "returns an error instead of crashing on an unrecognized status", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{status: 200, body: %{data: %{id: 778, status: "queued"}}}
+      end)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "test_experiment_unrecognized",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, reason} = AIEvaluations.create_evaluation(nil, args, resolution)
+      assert reason == "Unexpected evaluation status received from Kaapi: queued"
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+  end
+
   defp create_config_version(%{organization_id: organization_id}) do
     {:ok, assistant} =
       %Assistant{}


### PR DESCRIPTION
## Summary
Target issue is  https://github.com/glific/glific/issues/5485
Adds support for Kaapi's v2 evaluation API and routes evaluation creation to it for organizations with the `is_ai_evaluation_enabled` flag turned on, so v2 can be rolled out per-org without breaking existing v1 behaviour.

**What changed**

- `ApiClient.create_evaluation_v2/2` — posts to `/api/v2/evaluations`, same response parsing as v1.
- `Kaapi.create_evaluation_v2/2` — fetches org credentials and logs failures with the evaluation name and organization context.
- `Resolvers.AIEvaluations` — `run_kaapi_evaluation/2` picks v2 when `is_ai_evaluation_enabled` is on for the org, v1 otherwise.
- Evaluation status from Kaapi is now validated against a known list (`create_in_progress`, `processing`, `failed`, `completed`) before being persisted. Previously `String.to_existing_atom/1` was called directly on the response, which raised on an unexpected value; it now returns `{:error, "Unexpected evaluation status received from Kaapi: <status>"}` and increments the create-failure metric.

**Rollout / rollback:** flag off (default) keeps every org on v1. Flipping `is_ai_evaluation_enabled` off reverts an org to v1 with no deploy.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. — N/A, no new Glific API; this is an outbound call to Kaapi.
- [x] Coding standard and conventions are followed.

## Notes

Tests added for the new client function (success, 4xx, timeout), the Kaapi wrapper (pass-through of success and error), and the resolver v2 path (flag on → v2 endpoint hit and status persisted; unrecognized status → error instead of a crash).

Branch currently conflicts with `master` (`mergeable_state: dirty`) — needs a rebase before merge.
