### PR TITLE
feat(flows): support more Enum functions + actionable expression-rejection errors

### DIFF
--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -587,8 +587,8 @@ defmodule Glific.Flows.Action do
         :ok ->
           errors
 
-        {:error, _reason} ->
-          [{EEx, "#{label} has an unsupported expression", "Critical"} | errors]
+        {:error, reason} ->
+          [{EEx, "#{label} has an unsupported expression: #{reason}", "Critical"} | errors]
       end
     end)
   end

--- a/lib/glific/flows/expression.ex
+++ b/lib/glific/flows/expression.ex
@@ -560,6 +560,12 @@ defmodule Glific.Flows.Expression do
       else: {:error, "unsupported capture"}
   end
 
+  # bare module name used as a value, e.g. `String` on its own instead of
+  # `String.upcase(x)` (twin of the eval_node clause). Rejected like before, but
+  # with an author-actionable message instead of the opaque "__aliases__/N".
+  defp validate_ast({:__aliases__, _, segments}) when is_list(segments),
+    do: {:error, alias_as_value_error(segments)}
+
   # operators / Kernel calls on the @kernel table
   defp validate_ast({op, _, args}) when is_atom(op) and is_list(args) do
     if {op, length(args)} in @kernel,
@@ -820,6 +826,11 @@ defmodule Glific.Flows.Expression do
   defp eval_node({:&, _, [inner]}, bindings),
     do: make_capture(max_placeholder(inner, 0), inner, bindings)
 
+  # bare module name used as a value (e.g. `String` on its own, not
+  # `String.upcase(x)`). Still fail-closed; only the message is friendlier.
+  defp eval_node({:__aliases__, _, segments}, _bindings) when is_list(segments),
+    do: reject(alias_as_value_error(segments))
+
   # allowed operators / Kernel calls
   defp eval_node({op, _, args}, bindings) when is_atom(op) and is_list(args) do
     if {op, length(args)} in @kernel,
@@ -1000,5 +1011,11 @@ defmodule Glific.Flows.Expression do
     node |> Macro.to_string() |> String.slice(0, 60)
   rescue
     _ -> "unsupported construct"
+  end
+
+  @spec alias_as_value_error([atom()]) :: String.t()
+  defp alias_as_value_error(segments) do
+    path = Enum.join(segments, ".")
+    "module #{path} used as a value; call it as #{path}.function(...)"
   end
 end

--- a/lib/glific/flows/expression.ex
+++ b/lib/glific/flows/expression.ex
@@ -103,10 +103,11 @@ defmodule Glific.Flows.Expression do
     {:Enum, :find, 3} => &Enum.find/3,
     {:Enum, :sort_by, 2} => &Enum.sort_by/2,
     {:Enum, :sum, 1} => &Enum.sum/1,
+    {:Enum, :max, 2} => &Enum.max/2,
+    {:Enum, :max_by, 2} => &Enum.max_by/2,
     {:Enum, :map_join, 3} => &Enum.map_join/3,
-    # NOTE: Enum.random/1 is NOT pure (non-deterministic). Included for the corpus
-    # audit only; decide deliberately before enabling.
     {:Enum, :random, 1} => &Enum.random/1,
+    {:Enum, :take_random, 2} => &Enum.take_random/2,
     {:List, :first, 1} => &List.first/1,
     {:List, :last, 1} => &List.last/1,
     {:List, :wrap, 1} => &List.wrap/1,

--- a/lib/glific/flows/router.ex
+++ b/lib/glific/flows/router.ex
@@ -151,8 +151,9 @@ defmodule Glific.Flows.Router do
       :ok ->
         errors
 
-      {:error, _reason} ->
-        [{EEx, "Node #{node_uuid_sliced} has unsupported expression", "Critical"}] ++ errors
+      {:error, reason} ->
+        [{EEx, "Node #{node_uuid_sliced} has unsupported expression: #{reason}", "Critical"}] ++
+          errors
     end
   end
 

--- a/lib/glific/flows/wait.ex
+++ b/lib/glific/flows/wait.ex
@@ -96,8 +96,11 @@ defmodule Glific.Flows.Wait do
   @spec validate_expression(Wait.t(), Keyword.t(), non_neg_integer()) :: Keyword.t()
   defp validate_expression(%{expression: expression}, errors, organization_id) do
     case Glific.validate_flow_expression(expression, organization_id) do
-      :ok -> errors
-      {:error, _reason} -> [{EEx, "Wait timeout has unsupported expression", "Critical"} | errors]
+      :ok ->
+        errors
+
+      {:error, reason} ->
+        [{EEx, "Wait timeout has unsupported expression: #{reason}", "Critical"} | errors]
     end
   end
 

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -1666,6 +1666,20 @@ defmodule Glific.Flows.ActionTest do
       assert message =~ "Message template expression has an unsupported expression"
     end
 
+    test "surfaces the specific interpreter reason to the author" do
+      # Fresh org so the ETS-cached flag never leaks into the shared org-1 tests;
+      # the DB write rolls back with the SQL sandbox (mirrors glific_test.exs).
+      organization = Fixtures.organization_fixture()
+      FunWithFlags.enable(:safe_expressions, for_actor: %{organization_id: organization.id})
+
+      flow = %{organization_id: organization.id}
+      action = %Action{type: "set_run_result", value: ~s|<%= System.cmd("id", []) %>|}
+
+      assert [{EEx, message, "Critical"}] = Action.validate_expressions(action, [], flow)
+      assert message =~ "Action value has an unsupported expression:"
+      assert message =~ "System.cmd/2"
+    end
+
     test "ignores non-string values (set_contact_profile stores a map)", %{flow: flow} do
       # action.value is not always a string: set_contact_profile holds a map. It is
       # never evaluated as an expression, so validating it must not flag the flow.

--- a/test/glific/flows/expression_test.exs
+++ b/test/glific/flows/expression_test.exs
@@ -348,6 +348,23 @@ defmodule Glific.Flows.ExpressionTest do
                Expression.validate(~S|<%= Enum.max_by(@l, &(System.cmd(&1, []))) %>|)
     end
 
+    test "a bare module used as a value rejects with an actionable message" do
+      # single-segment and multi-segment aliases both get a clear message
+      assert {:error, "module String used as a value; call it as String.function(...)"} =
+               Expression.eval("<%= String %>")
+
+      assert {:error, "module Foo.Bar used as a value; call it as Foo.Bar.function(...)"} =
+               Expression.validate("<%= Foo.Bar %>")
+
+      # a bare module as an argument is rejected the same way
+      assert {:error, "module Date used as a value" <> _} =
+               Expression.eval("<%= Enum.max_by([1, 2], Date) %>")
+
+      # the completed form still works
+      assert {:ok, "3"} =
+               Expression.eval("<%= String.length(@name) %>", %{"name" => "abc"})
+    end
+
     test "anonymous functions (fn and & capture) with Enum" do
       results = %{"results" => %{"list" => [1, 2, 3, 4, 5]}}
 

--- a/test/glific/flows/expression_test.exs
+++ b/test/glific/flows/expression_test.exs
@@ -330,6 +330,24 @@ defmodule Glific.Flows.ExpressionTest do
       assert {:ok, "1"} = Expression.eval("<%= Enum.count(List.wrap(1)) %>")
     end
 
+    test "Enum.max_by/2, Enum.max/2 and Enum.take_random/2 (issue #5530)" do
+      # max_by/2 is higher-order: the mapper is one of our own closures
+      assert {:ok, "bbb"} =
+               Expression.eval(
+                 ~S|<%= Enum.max_by(["a", "bbb", "cc"], fn s -> String.length(s) end) %>|
+               )
+
+      # max/2 with an explicit sorter closure
+      assert {:ok, "5"} = Expression.eval("<%= Enum.max([1, 5, 3], fn a, b -> a >= b end) %>")
+
+      # take_random/2 is non-deterministic; assert on the count of what it returns
+      assert {:ok, "2"} = Expression.eval("<%= Enum.count(Enum.take_random([1, 2, 3], 2)) %>")
+
+      # a disallowed call inside the mapper closure is still rejected
+      assert {:error, _} =
+               Expression.validate(~S|<%= Enum.max_by(@l, &(System.cmd(&1, []))) %>|)
+    end
+
     test "anonymous functions (fn and & capture) with Enum" do
       results = %{"results" => %{"list" => [1, 2, 3, 4, 5]}}
 

--- a/test/glific/flows/expression_test.exs
+++ b/test/glific/flows/expression_test.exs
@@ -363,6 +363,13 @@ defmodule Glific.Flows.ExpressionTest do
       # the completed form still works
       assert {:ok, "3"} =
                Expression.eval("<%= String.length(@name) %>", %{"name" => "abc"})
+
+      # render/2 trusts its compiled input and skips re-validation, so it is the
+      # path that actually reaches eval_node's bare-alias clause -- verifying the
+      # sole security boundary fails closed with the same message even when the
+      # safe_shape twin is bypassed.
+      assert {:error, "module String used as a value; call it as String.function(...)"} =
+               Expression.render([{:expr, {:__aliases__, [], [:String]}}], %{})
     end
 
     test "anonymous functions (fn and & capture) with Enum" do

--- a/test/glific/flows/router_test.exs
+++ b/test/glific/flows/router_test.exs
@@ -303,6 +303,24 @@ defmodule Glific.Flows.RouterTest do
     {:ok, _, _} = Router.execute(router, context, [])
   end
 
+  test "validate/3 surfaces the specific interpreter reason for a bad operand", %{
+    organization_id: organization_id
+  } do
+    router = %Router{
+      type: "switch",
+      operand: ~s|<%= System.cmd("id", []) %>|,
+      node_uuid: Ecto.UUID.generate(),
+      categories: [],
+      cases: [],
+      wait: nil
+    }
+
+    assert [{EEx, message, "Critical"}] =
+             Router.validate(router, [], %Flow{organization_id: organization_id})
+
+    assert message =~ "has unsupported expression:"
+  end
+
   test "router with split by expression with EEx code for wa_group flow", attrs do
     flow = %Flow{uuid: "Flow UUID 1", id: 1}
     exit_uuid = Ecto.UUID.generate()


### PR DESCRIPTION
## Summary

Addresses **scope item 1** of #5530 — support the easy functions the flow expression interpreter (`Glific.Flows.Expression`) was rejecting in production — and makes the "unsupported expression" errors actionable for flow authors.

## Changes

### 1. Allowlist three `Enum` functions (`604b84527`)

Added to the `@mfa` table (both `eval_node/2` and `validate/1` key off it, so no other wiring needed):

- **`Enum.max_by/2`** — the biggest offender, **139** prod rejections. Higher-order; safe because the mapper is one of our own interpreted closures.
- **`Enum.max/2`** — its sorter arg is likewise one of our closures.
- **`Enum.take_random/2`** — grouped with the existing non-deterministic `Enum.random/1`.

### 2. Actionable error for a bare module used as a value (`dc0392add`, `17e9b4e4c`)

`<%= String %>` (a module name on its own, not a call) previously rejected with the opaque **`__aliases__/1`**. It now rejects with a message an author can act on:

```
module String used as a value; call it as String.function(...)
```

Implemented as a fail-closed clause in **both** `eval_node/2` and `validate_ast/1` (kept as structural twins).

> This does **not** add `alias` support — it only clarifies the message for a module name that appears where a value belongs. Real alias resolution remains a deliberate non-goal (it's the exact "validate one representation, execute another" attack the module is built to reject).

### 3. Show the specific rejection reason to flow authors (`0e55c660f`)

The publish-time validators (`action` / `wait` / `router`) now append the interpreter's reason to their message, so an author sees **exactly what was rejected** instead of a generic notice:

```
Action value has an unsupported expression: alias/2
Action value has an unsupported expression: System.cmd/1
```

The interpreter returns the **bare signature** (`alias/2`, `System.cmd/1`) — the validator wrapper already supplies the "unsupported expression" framing, so prefixing the reason would just double the word. The runtime log (AppSignal) is unchanged.

## Screenshot — author-facing errors in the flow editor's publish dialog
<img width="565" height="445" alt="Screenshot 2026-08-17 at 8 15 04 PM" src="https://github.com/user-attachments/assets/4e14eb51-9b69-436c-9ff9-57b8061d4f57" />


## Scope / non-goals

- Covers the two **statically-detectable** rejection categories relevant to item 1. The runtime, data-dependent ones (`field access on non-map`, `output too large`) are not addressed here — they're traced via AppSignal.
- No `alias` support; no change to the runtime evaluation log.

## Testing

- `expression_test.exs`, `action_test.exs`, `wait_test.exs`, `router_test.exs`, `glific_test.exs` — all green.
- Every changed line is covered (router got a new `validate/3` test, since nothing hit that branch before).
- `mix format` + Credo + compile (warnings-as-errors) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
