### PR TITLE
fix(webhooks): restrict BSP webhooks to the provider's published source IPs

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -210,6 +210,29 @@ config :ex_audit,
 # Throttle OTP requests: at most `count` per client IP within `scale_ms` (default 1 / 30s).
 config :glific, :otp_rate_limit, scale_ms: 30_000, count: 1
 
+# Source IPs allowed to call the unauthenticated BSP webhooks. See
+# `GlificWeb.Plugs.BSPWebhookIPFilter`; `mode` is set per environment in runtime.exs.
+# Gupshup's event callback IPs, plus the IPs it uses for media related requests,
+# as published by Gupshup support.
+config :glific, :bsp_webhook_ip_filter,
+  mode: :disabled,
+  allowlist: %{
+    "gupshup" => [
+      "34.202.224.208",
+      "52.66.99.126",
+      "15.206.217.7",
+      "3.6.228.131",
+      "13.126.35.181",
+      "13.232.173.180",
+      "13.127.57.130",
+      "13.234.143.23",
+      "3.7.115.196",
+      "13.232.49.3"
+    ],
+    "gupshup-enterprise" => [],
+    "maytapi" => []
+  }
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -210,29 +210,6 @@ config :ex_audit,
 # Throttle OTP requests: at most `count` per client IP within `scale_ms` (default 1 / 30s).
 config :glific, :otp_rate_limit, scale_ms: 30_000, count: 1
 
-# Source IPs allowed to call the unauthenticated BSP webhooks. See
-# `GlificWeb.Plugs.BSPWebhookIPFilter`; `mode` is set per environment in runtime.exs.
-# Gupshup's event callback IPs, plus the IPs it uses for media related requests,
-# as published by Gupshup support.
-config :glific, :bsp_webhook_ip_filter,
-  mode: :disabled,
-  allowlist: %{
-    "gupshup" => [
-      "34.202.224.208",
-      "52.66.99.126",
-      "15.206.217.7",
-      "3.6.228.131",
-      "13.126.35.181",
-      "13.232.173.180",
-      "13.127.57.130",
-      "13.234.143.23",
-      "3.7.115.196",
-      "13.232.49.3"
-    ],
-    "gupshup-enterprise" => [],
-    "maytapi" => []
-  }
-
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -201,9 +201,7 @@ config :glific,
 # replaces that provider's list outright, so widening one is a `gigalixir config:set` and
 # a restart rather than a deploy.
 
-# A malformed entry would otherwise sit in the list matching nothing, quietly narrowing the
-# allowlist and logging on every request, so entries are checked here instead. :inet is used
-# rather than the CIDR library the plug matches with because config runs before any
+# :inet rather than the CIDR library the plug matches with, because config runs before any
 # dependency is started.
 valid_webhook_ip? = fn entry ->
   [address | prefix] = String.split(entry, "/", parts: 2)
@@ -269,13 +267,9 @@ if config_env() == :prod do
           gigalixir config:set GUPSHUP_WEBHOOK_IPS="a.b.c.d,e.f.g.h,w.x.y.z/24"
       """)
 
-  config :glific,
-         :bsp_webhook_ip_allowlist,
-         %{
-           "gupshup" => gupshup_webhook_ips,
-           "gupshup-enterprise" => webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS"),
-           "maytapi" => webhook_ips.("MAYTAPI_WEBHOOK_IPS")
-         }
+  config :glific, :gupshup_webhook_ips, gupshup_webhook_ips
+  config :glific, :gupshup_enterprise_webhook_ips, webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS")
+  config :glific, :maytapi_webhook_ips, webhook_ips.("MAYTAPI_WEBHOOK_IPS")
 end
 
 search_repo_module =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -196,10 +196,7 @@ config :glific,
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
 # The BSP webhooks are unauthenticated, so callers are filtered on the source IPs the
-# provider publishes; anything else gets a 403. The lists are deliberately not in this
-# repository — they live only in the deployment environment, and setting a variable
-# replaces that provider's list outright, so widening one is a `gigalixir config:set` and
-# a restart rather than a deploy.
+# provider publishes; anything else gets a 403.
 
 # :inet rather than the CIDR library the plug matches with, because config runs before any
 # dependency is started.

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -195,6 +195,14 @@ config :glific,
   api_host_override: env!("GLIFIC_API_HOST_OVERRIDE", :string, nil),
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
+# The BSP webhooks are unauthenticated, so we filter them on the provider's published
+# source IPs (list in config.exs). Deploy on "log" first and confirm in the logs that no
+# genuine callback is being flagged, then switch to "enforce"; "log" is also the instant
+# rollback if a provider starts calling us from a new IP.
+unless config_env() == :test do
+  config :glific, :bsp_webhook_ip_filter, mode: env!("BSP_WEBHOOK_IP_FILTER_MODE", :atom, :log)
+end
+
 search_repo_module =
   if(env!("USE_REPLICA_DB", :boolean, false), do: Glific.RepoReplica, else: Glific.Repo)
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -195,12 +195,42 @@ config :glific,
   api_host_override: env!("GLIFIC_API_HOST_OVERRIDE", :string, nil),
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
-# The BSP webhooks are unauthenticated, so we filter them on the provider's published
-# source IPs (list in config.exs). Deploy on "log" first and confirm in the logs that no
-# genuine callback is being flagged, then switch to "enforce"; "log" is also the instant
-# rollback if a provider starts calling us from a new IP.
-unless config_env() == :test do
-  config :glific, :bsp_webhook_ip_filter, mode: env!("BSP_WEBHOOK_IP_FILTER_MODE", :atom, :log)
+# The BSP webhooks are unauthenticated, so callers are filtered on the source IPs the
+# provider publishes; anything else gets a 403. Setting the matching variable replaces a
+# provider's list outright, so a provider adding an IP is a `gigalixir config:set` and a
+# restart rather than a deploy. An empty list disables filtering for that provider, which
+# is why only :prod is configured — dev and test keep working without a real IP.
+webhook_ips = fn variable, default ->
+  case env!(variable, :string, nil) do
+    nil -> default
+    "" -> default
+    ips -> ips |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+  end
+end
+
+# Gupshup's event callback IPs, plus the IPs it uses for media related requests, as
+# published by Gupshup support.
+gupshup_webhook_ips = [
+  "34.202.224.208",
+  "52.66.99.126",
+  "15.206.217.7",
+  "3.6.228.131",
+  "13.126.35.181",
+  "13.232.173.180",
+  "13.127.57.130",
+  "13.234.143.23",
+  "3.7.115.196",
+  "13.232.49.3"
+]
+
+if config_env() == :prod do
+  config :glific,
+         :bsp_webhook_ip_allowlist,
+         %{
+           "gupshup" => webhook_ips.("GUPSHUP_WEBHOOK_IPS", gupshup_webhook_ips),
+           "gupshup-enterprise" => webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS", []),
+           "maytapi" => webhook_ips.("MAYTAPI_WEBHOOK_IPS", [])
+         }
 end
 
 search_repo_module =

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -200,10 +200,52 @@ config :glific,
 # repository — they live only in the deployment environment, and setting a variable
 # replaces that provider's list outright, so widening one is a `gigalixir config:set` and
 # a restart rather than a deploy.
+
+# A malformed entry would otherwise sit in the list matching nothing, quietly narrowing the
+# allowlist and logging on every request, so entries are checked here instead. :inet is used
+# rather than the CIDR library the plug matches with because config runs before any
+# dependency is started.
+valid_webhook_ip? = fn entry ->
+  [address | prefix] = String.split(entry, "/", parts: 2)
+
+  case :inet.parse_address(String.to_charlist(address)) do
+    {:error, _reason} ->
+      false
+
+    {:ok, parsed} ->
+      max_length = if tuple_size(parsed) == 4, do: 32, else: 128
+
+      case prefix do
+        [] ->
+          true
+
+        [length] ->
+          match?({value, ""} when value >= 0 and value <= max_length, Integer.parse(length))
+      end
+  end
+end
+
 webhook_ips = fn variable ->
   case env!(variable, :string, nil) do
-    unset when unset in [nil, ""] -> []
-    ips -> ips |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
+    unset when unset in [nil, ""] ->
+      []
+
+    ips ->
+      ips
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.map(fn entry ->
+        if valid_webhook_ip?.(entry),
+          do: entry,
+          else:
+            raise("""
+            #{variable} contains "#{entry}", which is not an IP address or CIDR block.
+
+            Expected a comma separated list, for example:
+
+                gigalixir config:set #{variable}="a.b.c.d,e.f.g.h,w.x.y.z/24"
+            """)
+      end)
   end
 end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -196,40 +196,43 @@ config :glific,
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
 # The BSP webhooks are unauthenticated, so callers are filtered on the source IPs the
-# provider publishes; anything else gets a 403. Setting the matching variable replaces a
-# provider's list outright, so a provider adding an IP is a `gigalixir config:set` and a
-# restart rather than a deploy. An empty list disables filtering for that provider, which
-# is why only :prod is configured — dev and test keep working without a real IP.
-webhook_ips = fn variable, default ->
+# provider publishes; anything else gets a 403. The lists are deliberately not in this
+# repository — they live only in the deployment environment, and setting a variable
+# replaces that provider's list outright, so widening one is a `gigalixir config:set` and
+# a restart rather than a deploy.
+webhook_ips = fn variable ->
   case env!(variable, :string, nil) do
-    nil -> default
-    "" -> default
+    unset when unset in [nil, ""] -> []
     ips -> ips |> String.split(",", trim: true) |> Enum.map(&String.trim/1)
   end
 end
 
-# Gupshup's event callback IPs, plus the IPs it uses for media related requests, as
-# published by Gupshup support.
-gupshup_webhook_ips = [
-  "34.202.224.208",
-  "52.66.99.126",
-  "15.206.217.7",
-  "3.6.228.131",
-  "13.126.35.181",
-  "13.232.173.180",
-  "13.127.57.130",
-  "13.234.143.23",
-  "3.7.115.196",
-  "13.232.49.3"
-]
-
+# Only :prod is configured. An unset list means the provider is not filtered, which keeps
+# dev and test working against localhost.
 if config_env() == :prod do
+  gupshup_webhook_ips = webhook_ips.("GUPSHUP_WEBHOOK_IPS")
+
+  # Booting without this list would leave the busiest webhook accepting forged messages
+  # from any caller, so refuse to start rather than come up unprotected.
+  if gupshup_webhook_ips == [],
+    do:
+      raise("""
+      GUPSHUP_WEBHOOK_IPS is not set.
+
+      The /gupshup webhook is unauthenticated and is guarded only by Gupshup's published
+      callback IPs, so Glific will not boot without them.
+
+      Set it to Gupshup's comma separated callback IPs, CIDR blocks allowed:
+
+          gigalixir config:set GUPSHUP_WEBHOOK_IPS="a.b.c.d,e.f.g.h,w.x.y.z/24"
+      """)
+
   config :glific,
          :bsp_webhook_ip_allowlist,
          %{
-           "gupshup" => webhook_ips.("GUPSHUP_WEBHOOK_IPS", gupshup_webhook_ips),
-           "gupshup-enterprise" => webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS", []),
-           "maytapi" => webhook_ips.("MAYTAPI_WEBHOOK_IPS", [])
+           "gupshup" => gupshup_webhook_ips,
+           "gupshup-enterprise" => webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS"),
+           "maytapi" => webhook_ips.("MAYTAPI_WEBHOOK_IPS")
          }
 end
 

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -8,21 +8,21 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   posting a forged inbound message on behalf of any organization.
 
   The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`,
-  `/maytapi`) and is looked up in the `:bsp_webhook_ip_filter` config:
+  `/maytapi`) and is looked up in the `:bsp_webhook_ip_allowlist` config:
 
-      config :glific, :bsp_webhook_ip_filter,
-        mode: :enforce,
-        allowlist: %{"gupshup" => ["34.202.224.208", "3.6.0.0/16"]}
+      config :glific, :bsp_webhook_ip_allowlist, %{"gupshup" => ["34.202.224.208", "3.6.0.0/16"]}
 
-  Entries are IPv4/IPv6 addresses or CIDR blocks. Modes:
+  Entries are IPv4/IPv6 addresses or CIDR blocks. A caller outside its provider's list is
+  logged and answered with 403. That log line is the only warning that a provider has
+  started calling from an address we do not know about, so it is worth alerting on.
 
-    * `:enforce` - requests from outside the allowlist are logged and answered with 403
-    * `:log` - requests from outside the allowlist are logged and let through, to
-      validate a list against real traffic before turning enforcement on
-    * `:disabled` - no filtering at all
+  A provider whose list is empty is not filtered at all. That is what keeps a route
+  working before its IPs are known, and what leaves dev and test unfiltered, since
+  `config/runtime.exs` only populates the lists in `:prod`.
 
-  A provider whose allowlist is empty is never filtered, whatever the mode, so a route
-  is not silently broken before its IP list is known.
+  The lists are set per provider from the environment (`GUPSHUP_WEBHOOK_IPS` and
+  friends), so a provider adding an IP is a `gigalixir config:set` and a restart rather
+  than a deploy.
 
   The check uses `conn.remote_ip`, which is derived from `X-Forwarded-For` by the
   `RemoteIp` plug in `GlificWeb.Endpoint`; that plug has to stay ahead of the router
@@ -43,27 +43,24 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   @doc false
   @spec call(Conn.t(), Plug.opts()) :: Conn.t()
   def call(%Conn{path_info: [provider | _]} = conn, _opts) do
-    case {mode(), allowlist(provider)} do
-      {:disabled, _allowlist} -> conn
-      {_mode, []} -> conn
-      {mode, allowlist} -> filter(conn, provider, mode, allowlist)
+    case allowlist(provider) do
+      [] -> conn
+      allowlist -> filter(conn, provider, allowlist)
     end
   end
 
   def call(conn, _opts), do: conn
 
-  @spec filter(Conn.t(), String.t(), atom(), [String.t()]) :: Conn.t()
-  defp filter(conn, provider, mode, allowlist) do
+  @spec filter(Conn.t(), String.t(), [String.t()]) :: Conn.t()
+  defp filter(conn, provider, allowlist) do
     if allowed?(conn.remote_ip, allowlist) do
       conn
     else
-      Logger.warning(
-        "Unlisted IP #{Tenants.remote_ip(conn)} called the #{provider} webhook, filter mode: #{mode}"
-      )
+      Logger.warning("Unlisted IP #{Tenants.remote_ip(conn)} called the #{provider} webhook")
 
-      if mode == :enforce,
-        do: conn |> Conn.send_resp(403, "") |> Conn.halt(),
-        else: conn
+      conn
+      |> Conn.send_resp(403, "")
+      |> Conn.halt()
     end
   end
 
@@ -98,16 +95,11 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
     end
   end
 
-  @spec mode() :: atom()
-  defp mode, do: Keyword.get(config(), :mode, :disabled)
-
   @spec allowlist(String.t()) :: [String.t()]
   defp allowlist(provider) do
-    config()
-    |> Keyword.get(:allowlist, %{})
-    |> Map.get(provider, [])
+    case Application.get_env(:glific, :bsp_webhook_ip_allowlist) do
+      allowlist when is_map(allowlist) -> Map.get(allowlist, provider, [])
+      _unconfigured -> []
+    end
   end
-
-  @spec config() :: keyword()
-  defp config, do: Application.get_env(:glific, :bsp_webhook_ip_filter, [])
 end

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -1,0 +1,113 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
+  @moduledoc """
+  Restricts the BSP webhook endpoints to the source IPs published by each provider.
+
+  These endpoints are unauthenticated: the organization is resolved from the request
+  host and the shunt then runs the request as that organization's root user. Filtering
+  on the provider's published callback IPs is what stops an arbitrary caller from
+  posting a forged inbound message on behalf of any organization.
+
+  The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`,
+  `/maytapi`) and is looked up in the `:bsp_webhook_ip_filter` config:
+
+      config :glific, :bsp_webhook_ip_filter,
+        mode: :enforce,
+        allowlist: %{"gupshup" => ["34.202.224.208", "3.6.0.0/16"]}
+
+  Entries are IPv4/IPv6 addresses or CIDR blocks. Modes:
+
+    * `:enforce` - requests from outside the allowlist are logged and answered with 403
+    * `:log` - requests from outside the allowlist are logged and let through, to
+      validate a list against real traffic before turning enforcement on
+    * `:disabled` - no filtering at all
+
+  A provider whose allowlist is empty is never filtered, whatever the mode, so a route
+  is not silently broken before its IP list is known.
+
+  The check uses `conn.remote_ip`, which is derived from `X-Forwarded-For` by the
+  `RemoteIp` plug in `GlificWeb.Endpoint`; that plug has to stay ahead of the router
+  for this filter to see the real client IP.
+  """
+
+  require Logger
+
+  alias GlificWeb.Tenants
+  alias Plug.Conn
+
+  @behaviour Plug
+
+  @doc false
+  @spec init(Plug.opts()) :: Plug.opts()
+  def init(opts), do: opts
+
+  @doc false
+  @spec call(Conn.t(), Plug.opts()) :: Conn.t()
+  def call(%Conn{path_info: [provider | _]} = conn, _opts) do
+    case {mode(), allowlist(provider)} do
+      {:disabled, _allowlist} -> conn
+      {_mode, []} -> conn
+      {mode, allowlist} -> filter(conn, provider, mode, allowlist)
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  @spec filter(Conn.t(), String.t(), atom(), [String.t()]) :: Conn.t()
+  defp filter(conn, provider, mode, allowlist) do
+    if allowed?(conn.remote_ip, allowlist) do
+      conn
+    else
+      Logger.warning(
+        "Unlisted IP #{Tenants.remote_ip(conn)} called the #{provider} webhook, filter mode: #{mode}"
+      )
+
+      if mode == :enforce,
+        do: conn |> Conn.send_resp(403, "") |> Conn.halt(),
+        else: conn
+    end
+  end
+
+  @spec allowed?(:inet.ip_address(), [String.t()]) :: boolean()
+  defp allowed?(remote_ip, allowlist) do
+    Enum.any?(allowlist, fn entry ->
+      case parse_cidr(entry) do
+        {:ok, cidr} -> InetCidr.contains?(cidr, remote_ip)
+        :error -> false
+      end
+    end)
+  end
+
+  @spec parse_cidr(String.t()) :: {:ok, tuple()} | :error
+  defp parse_cidr(entry) do
+    case InetCidr.parse_cidr(with_prefix_length(entry)) do
+      {:ok, cidr} ->
+        {:ok, cidr}
+
+      {:error, _reason} ->
+        Logger.warning("Ignoring invalid BSP webhook allowlist entry: #{entry}")
+        :error
+    end
+  end
+
+  @spec with_prefix_length(String.t()) :: String.t()
+  defp with_prefix_length(entry) do
+    cond do
+      String.contains?(entry, "/") -> entry
+      String.contains?(entry, ":") -> entry <> "/128"
+      true -> entry <> "/32"
+    end
+  end
+
+  @spec mode() :: atom()
+  defp mode, do: Keyword.get(config(), :mode, :disabled)
+
+  @spec allowlist(String.t()) :: [String.t()]
+  defp allowlist(provider) do
+    config()
+    |> Keyword.get(:allowlist, %{})
+    |> Map.get(provider, [])
+  end
+
+  @spec config() :: keyword()
+  defp config, do: Application.get_env(:glific, :bsp_webhook_ip_filter, [])
+end

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -7,10 +7,10 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   on the provider's published callback IPs is what stops an arbitrary caller from
   posting a forged inbound message on behalf of any organization.
 
-  The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`,
-  `/maytapi`) and is looked up in the `:bsp_webhook_ip_allowlist` config:
+  The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`, `/maytapi`)
+  and each one carries its own config key, so a provider can be changed on its own:
 
-      config :glific, :bsp_webhook_ip_allowlist, %{"gupshup" => ["192.0.2.10", "198.51.100.0/24"]}
+      config :glific, :gupshup_webhook_ips, ["192.0.2.10", "198.51.100.0/24"]
 
   Entries are IPv4/IPv6 addresses or CIDR blocks. A caller outside its provider's list is
   logged and answered with 403. That log line is the only warning that a provider has
@@ -45,6 +45,12 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   @behaviour Plug
 
   @forwarding_headers ~w[x-forwarded-for]
+
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
 
   @doc false
   @spec init(Plug.opts()) :: Plug.opts()
@@ -122,8 +128,10 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
 
   @spec allowlist(String.t()) :: [String.t()]
   defp allowlist(provider) do
-    case Application.get_env(:glific, :bsp_webhook_ip_allowlist) do
-      allowlist when is_map(allowlist) -> Map.get(allowlist, provider, [])
+    with {:ok, key} <- Map.fetch(@allowlist_keys, provider),
+         ips when is_list(ips) <- Application.get_env(:glific, key) do
+      ips
+    else
       _unconfigured -> []
     end
   end

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -10,7 +10,7 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`,
   `/maytapi`) and is looked up in the `:bsp_webhook_ip_allowlist` config:
 
-      config :glific, :bsp_webhook_ip_allowlist, %{"gupshup" => ["34.202.224.208", "3.6.0.0/16"]}
+      config :glific, :bsp_webhook_ip_allowlist, %{"gupshup" => ["192.0.2.10", "198.51.100.0/24"]}
 
   Entries are IPv4/IPv6 addresses or CIDR blocks. A caller outside its provider's list is
   logged and answered with 403. That log line is the only warning that a provider has
@@ -20,9 +20,11 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   working before its IPs are known, and what leaves dev and test unfiltered, since
   `config/runtime.exs` only populates the lists in `:prod`.
 
-  The lists are set per provider from the environment (`GUPSHUP_WEBHOOK_IPS` and
-  friends), so a provider adding an IP is a `gigalixir config:set` and a restart rather
-  than a deploy.
+  The lists come per provider from the environment (`GUPSHUP_WEBHOOK_IPS` and friends)
+  and are deliberately not held in this repository, so a provider adding an IP is a
+  `gigalixir config:set` and a restart rather than a deploy. Because an empty list means
+  no filtering, `runtime.exs` refuses to boot `:prod` when `GUPSHUP_WEBHOOK_IPS` is
+  missing rather than let the busiest webhook come up unguarded.
 
   The check uses `conn.remote_ip`, which is derived from `X-Forwarded-For` by the
   `RemoteIp` plug in `GlificWeb.Endpoint`; that plug has to stay ahead of the router

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -26,17 +26,25 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
   no filtering, `runtime.exs` refuses to boot `:prod` when `GUPSHUP_WEBHOOK_IPS` is
   missing rather than let the busiest webhook come up unguarded.
 
-  The check uses `conn.remote_ip`, which is derived from `X-Forwarded-For` by the
-  `RemoteIp` plug in `GlificWeb.Endpoint`; that plug has to stay ahead of the router
-  for this filter to see the real client IP.
+  The caller is taken from `x-forwarded-for` alone, rather than from `conn.remote_ip`.
+  `GlificWeb.Endpoint` runs `RemoteIp` with its defaults, which also trust `forwarded`,
+  `x-client-ip` and `x-real-ip`; our proxy only rewrites `x-forwarded-for`, so a caller
+  that sends one of the other three can put an allowlisted address last in the chain and
+  have it win. Deciding here from the one header the proxy controls keeps that out of a
+  security decision, and leaves `conn.remote_ip` untouched for rate limiting and logging.
+
+  A request with no usable `x-forwarded-for` cannot be attributed to anyone and is
+  refused, with a distinct log line — in production every request arrives through the
+  proxy, so that means the proxy is not sending the header we expect.
   """
 
   require Logger
 
-  alias GlificWeb.Tenants
   alias Plug.Conn
 
   @behaviour Plug
+
+  @forwarding_headers ~w[x-forwarded-for]
 
   @doc false
   @spec init(Plug.opts()) :: Plug.opts()
@@ -55,16 +63,31 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
 
   @spec filter(Conn.t(), String.t(), [String.t()]) :: Conn.t()
   defp filter(conn, provider, allowlist) do
-    if allowed?(conn.remote_ip, allowlist) do
-      conn
-    else
-      Logger.warning("Unlisted IP #{Tenants.remote_ip(conn)} called the #{provider} webhook")
+    case client_ip(conn) do
+      nil ->
+        reject(conn, "Request to the #{provider} webhook carried no usable x-forwarded-for")
 
-      conn
-      |> Conn.send_resp(403, "")
-      |> Conn.halt()
+      client_ip ->
+        if allowed?(client_ip, allowlist),
+          do: conn,
+          else: reject(conn, "Unlisted IP #{format_ip(client_ip)} called the #{provider} webhook")
     end
   end
+
+  @spec reject(Conn.t(), String.t()) :: Conn.t()
+  defp reject(conn, message) do
+    Logger.warning(message)
+
+    conn
+    |> Conn.send_resp(403, "")
+    |> Conn.halt()
+  end
+
+  @spec client_ip(Conn.t()) :: :inet.ip_address() | nil
+  defp client_ip(conn), do: RemoteIp.from(conn.req_headers, headers: @forwarding_headers)
+
+  @spec format_ip(:inet.ip_address()) :: String.t()
+  defp format_ip(client_ip), do: client_ip |> :inet_parse.ntoa() |> to_string()
 
   @spec allowed?(:inet.ip_address(), [String.t()]) :: boolean()
   defp allowed?(remote_ip, allowlist) do

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -113,8 +113,14 @@ defmodule GlificWeb.Router do
     forward("/api", Absinthe.Plug, schema: GlificWeb.Schema)
   end
 
+  pipeline :bsp_webhook do
+    plug(GlificWeb.Plugs.BSPWebhookIPFilter)
+  end
+
   # BSP webhooks
   scope "/", GlificWeb do
+    pipe_through(:bsp_webhook)
+
     forward("/gupshup", Providers.Gupshup.Plugs.Shunt)
     forward("/gupshup-enterprise", Providers.Gupshup.Enterprise.Plugs.Shunt)
     forward("/maytapi", Providers.Maytapi.Plugs.Shunt)

--- a/mix.exs
+++ b/mix.exs
@@ -148,6 +148,7 @@ defmodule Glific.MixProject do
       {:csv, "~> 3.2"},
       {:observer_cli, "~> 1.7"},
       {:apiac_filter_ip_whitelist, "~> 1.0"},
+      {:inet_cidr, "~> 1.0"},
       {:ex_phone_number, "~> 0.3"},
       {:tzdata, "~> 1.1"},
       {:stripity_stripe, "~> 2.3"},

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -6,8 +6,8 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
   alias GlificWeb.Plugs.BSPWebhookIPFilter
 
   # RFC 5737 documentation addresses, so no real provider IP is held in the repository.
-  @provider_ip {192, 0, 2, 10}
-  @attacker_ip {203, 0, 113, 5}
+  @provider_ip "192.0.2.10"
+  @attacker_ip "203.0.113.5"
 
   setup do
     original = Application.get_env(:glific, :bsp_webhook_ip_allowlist)
@@ -25,11 +25,16 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
   defp configure(allowlist),
     do: Application.put_env(:glific, :bsp_webhook_ip_allowlist, allowlist)
 
-  defp call(path, remote_ip) do
-    conn = %{conn(:post, path, %{}) | remote_ip: remote_ip}
-
-    BSPWebhookIPFilter.call(conn, BSPWebhookIPFilter.init([]))
+  defp build_conn(path, headers) do
+    Enum.reduce(headers, conn(:post, path, %{}), fn {header, value}, conn ->
+      Plug.Conn.put_req_header(conn, header, value)
+    end)
   end
+
+  defp call(path, headers) when is_list(headers),
+    do: BSPWebhookIPFilter.call(build_conn(path, headers), BSPWebhookIPFilter.init([]))
+
+  defp call(path, client_ip), do: call(path, [{"x-forwarded-for", client_ip}])
 
   describe "filtering" do
     setup do
@@ -86,12 +91,73 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
   end
 
+  describe "client IP is taken only from x-forwarded-for" do
+    setup do
+      configure(%{"gupshup" => ["192.0.2.10"]})
+    end
+
+    test "takes the last client address the proxy appended" do
+      conn = call("/gupshup", "#{@attacker_ip}, #{@provider_ip}")
+
+      refute conn.halted
+    end
+
+    test "ignores an allowlisted address supplied in x-real-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-real-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in x-client-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-client-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in forwarded" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"forwarded", "for=#{@provider_ip}"}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "refuses a request that carries no forwarding header" do
+      conn = call("/gupshup", [])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not fall back to the socket peer address" do
+      conn =
+        %{build_conn("/gupshup", []) | remote_ip: {192, 0, 2, 10}}
+        |> BSPWebhookIPFilter.call(BSPWebhookIPFilter.init([]))
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
   describe "matching" do
     test "matches an IP inside a CIDR block" do
       configure(%{"gupshup" => ["198.51.100.0/24"]})
 
-      allowed = call("/gupshup", {198, 51, 100, 7})
-      rejected = call("/gupshup", {198, 51, 101, 7})
+      allowed = call("/gupshup", "198.51.100.7")
+      rejected = call("/gupshup", "198.51.101.7")
 
       refute allowed.halted
       assert rejected.halted
@@ -108,9 +174,17 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     test "an IPv6 caller does not match an IPv4 allowlist" do
       configure(%{"gupshup" => ["192.0.2.10"]})
 
-      conn = call("/gupshup", {0, 0, 0, 0, 0, 0, 0, 1})
+      conn = call("/gupshup", "2001:db8::1")
 
       assert conn.halted
+    end
+
+    test "matches an IPv6 caller against an IPv6 allowlist" do
+      configure(%{"gupshup" => ["2001:db8::/32"]})
+
+      conn = call("/gupshup", "2001:db8::1")
+
+      refute conn.halted
     end
   end
 
@@ -118,7 +192,8 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     configure(%{"gupshup" => ["192.0.2.10"]})
 
     conn =
-      %{conn(:post, "/gupshup", %{}) | remote_ip: @attacker_ip}
+      "/gupshup"
+      |> build_conn([{"x-forwarded-for", @attacker_ip}])
       |> GlificWeb.Router.call(GlificWeb.Router.init([]))
 
     assert conn.halted

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -9,21 +9,29 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
   @provider_ip "192.0.2.10"
   @attacker_ip "203.0.113.5"
 
-  setup do
-    original = Application.get_env(:glific, :bsp_webhook_ip_allowlist)
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
 
-    on_exit(fn ->
-      case original do
-        nil -> Application.delete_env(:glific, :bsp_webhook_ip_allowlist)
-        allowlist -> Application.put_env(:glific, :bsp_webhook_ip_allowlist, allowlist)
-      end
-    end)
+  setup do
+    original =
+      Map.new(@allowlist_keys, fn {_provider, key} -> {key, Application.get_env(:glific, key)} end)
+
+    on_exit(fn -> Enum.each(original, fn {key, ips} -> put_allowlist(key, ips) end) end)
 
     :ok
   end
 
-  defp configure(allowlist),
-    do: Application.put_env(:glific, :bsp_webhook_ip_allowlist, allowlist)
+  defp configure(allowlist) do
+    Enum.each(@allowlist_keys, fn {provider, key} ->
+      put_allowlist(key, Map.get(allowlist, provider))
+    end)
+  end
+
+  defp put_allowlist(key, nil), do: Application.delete_env(:glific, key)
+  defp put_allowlist(key, ips), do: Application.put_env(:glific, key, ips)
 
   defp build_conn(path, headers) do
     Enum.reduce(headers, conn(:post, path, %{}), fn {header, value}, conn ->
@@ -77,7 +85,7 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
 
     test "missing config leaves every request untouched" do
-      Application.delete_env(:glific, :bsp_webhook_ip_allowlist)
+      configure(%{})
 
       conn = call("/gupshup", @attacker_ip)
 

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -9,15 +9,20 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
   @attacker_ip {203, 0, 113, 5}
 
   setup do
-    original = Application.get_env(:glific, :bsp_webhook_ip_filter)
+    original = Application.get_env(:glific, :bsp_webhook_ip_allowlist)
 
-    on_exit(fn -> Application.put_env(:glific, :bsp_webhook_ip_filter, original) end)
+    on_exit(fn ->
+      case original do
+        nil -> Application.delete_env(:glific, :bsp_webhook_ip_allowlist)
+        allowlist -> Application.put_env(:glific, :bsp_webhook_ip_allowlist, allowlist)
+      end
+    end)
 
     :ok
   end
 
-  defp configure(mode, allowlist),
-    do: Application.put_env(:glific, :bsp_webhook_ip_filter, mode: mode, allowlist: allowlist)
+  defp configure(allowlist),
+    do: Application.put_env(:glific, :bsp_webhook_ip_allowlist, allowlist)
 
   defp call(path, remote_ip) do
     conn = %{conn(:post, path, %{}) | remote_ip: remote_ip}
@@ -25,9 +30,9 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     BSPWebhookIPFilter.call(conn, BSPWebhookIPFilter.init([]))
   end
 
-  describe "enforce mode" do
+  describe "filtering" do
     setup do
-      configure(:enforce, %{"gupshup" => ["34.202.224.208", "3.6.228.131"], "maytapi" => []})
+      configure(%{"gupshup" => ["34.202.224.208", "3.6.228.131"], "maytapi" => []})
     end
 
     test "lets a request from an allowlisted provider IP through" do
@@ -57,18 +62,32 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
 
     test "keeps each provider's allowlist to itself" do
-      configure(:enforce, %{"gupshup" => ["34.202.224.208"], "maytapi" => ["1.2.3.4"]})
+      configure(%{"gupshup" => ["34.202.224.208"], "maytapi" => ["1.2.3.4"]})
 
       conn = call("/maytapi", @gupshup_ip)
 
       assert conn.halted
       assert conn.status == 403
     end
+
+    test "missing config leaves every request untouched" do
+      Application.delete_env(:glific, :bsp_webhook_ip_allowlist)
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "a request without a path segment is left alone" do
+      conn = call("/", @attacker_ip)
+
+      refute conn.halted
+    end
   end
 
   describe "matching" do
     test "matches an IP inside a CIDR block" do
-      configure(:enforce, %{"gupshup" => ["3.6.0.0/16"]})
+      configure(%{"gupshup" => ["3.6.0.0/16"]})
 
       allowed = call("/gupshup", {3, 6, 228, 131})
       rejected = call("/gupshup", {3, 7, 115, 196})
@@ -78,7 +97,7 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
 
     test "ignores an unparsable entry instead of failing the request" do
-      configure(:enforce, %{"gupshup" => ["not-an-ip", "34.202.224.208"]})
+      configure(%{"gupshup" => ["not-an-ip", "34.202.224.208"]})
 
       conn = call("/gupshup", @gupshup_ip)
 
@@ -86,7 +105,7 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
 
     test "an IPv6 caller does not match an IPv4 allowlist" do
-      configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
+      configure(%{"gupshup" => ["34.202.224.208"]})
 
       conn = call("/gupshup", {0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -94,34 +113,8 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
   end
 
-  describe "other modes" do
-    test "log mode lets an unlisted IP through" do
-      configure(:log, %{"gupshup" => ["34.202.224.208"]})
-
-      conn = call("/gupshup", @attacker_ip)
-
-      refute conn.halted
-    end
-
-    test "disabled mode skips the check entirely" do
-      configure(:disabled, %{"gupshup" => ["34.202.224.208"]})
-
-      conn = call("/gupshup", @attacker_ip)
-
-      refute conn.halted
-    end
-
-    test "missing config leaves every request untouched" do
-      Application.delete_env(:glific, :bsp_webhook_ip_filter)
-
-      conn = call("/gupshup", @attacker_ip)
-
-      refute conn.halted
-    end
-  end
-
   test "the router runs the filter ahead of the gupshup shunt" do
-    configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
+    configure(%{"gupshup" => ["34.202.224.208"]})
 
     conn =
       %{conn(:post, "/gupshup", %{}) | remote_ip: @attacker_ip}
@@ -129,13 +122,5 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
 
     assert conn.halted
     assert conn.status == 403
-  end
-
-  test "a request without a path segment is left alone" do
-    configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
-
-    conn = call("/", @attacker_ip)
-
-    refute conn.halted
   end
 end

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -5,7 +5,8 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
 
   alias GlificWeb.Plugs.BSPWebhookIPFilter
 
-  @gupshup_ip {34, 202, 224, 208}
+  # RFC 5737 documentation addresses, so no real provider IP is held in the repository.
+  @provider_ip {192, 0, 2, 10}
   @attacker_ip {203, 0, 113, 5}
 
   setup do
@@ -32,11 +33,11 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
 
   describe "filtering" do
     setup do
-      configure(%{"gupshup" => ["34.202.224.208", "3.6.228.131"], "maytapi" => []})
+      configure(%{"gupshup" => ["192.0.2.10", "192.0.2.11"], "maytapi" => []})
     end
 
     test "lets a request from an allowlisted provider IP through" do
-      conn = call("/gupshup", @gupshup_ip)
+      conn = call("/gupshup", @provider_ip)
 
       refute conn.halted
       assert conn.status == nil
@@ -62,9 +63,9 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
     end
 
     test "keeps each provider's allowlist to itself" do
-      configure(%{"gupshup" => ["34.202.224.208"], "maytapi" => ["1.2.3.4"]})
+      configure(%{"gupshup" => ["192.0.2.10"], "maytapi" => ["198.51.100.1"]})
 
-      conn = call("/maytapi", @gupshup_ip)
+      conn = call("/maytapi", @provider_ip)
 
       assert conn.halted
       assert conn.status == 403
@@ -87,25 +88,25 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
 
   describe "matching" do
     test "matches an IP inside a CIDR block" do
-      configure(%{"gupshup" => ["3.6.0.0/16"]})
+      configure(%{"gupshup" => ["198.51.100.0/24"]})
 
-      allowed = call("/gupshup", {3, 6, 228, 131})
-      rejected = call("/gupshup", {3, 7, 115, 196})
+      allowed = call("/gupshup", {198, 51, 100, 7})
+      rejected = call("/gupshup", {198, 51, 101, 7})
 
       refute allowed.halted
       assert rejected.halted
     end
 
     test "ignores an unparsable entry instead of failing the request" do
-      configure(%{"gupshup" => ["not-an-ip", "34.202.224.208"]})
+      configure(%{"gupshup" => ["not-an-ip", "192.0.2.10"]})
 
-      conn = call("/gupshup", @gupshup_ip)
+      conn = call("/gupshup", @provider_ip)
 
       refute conn.halted
     end
 
     test "an IPv6 caller does not match an IPv4 allowlist" do
-      configure(%{"gupshup" => ["34.202.224.208"]})
+      configure(%{"gupshup" => ["192.0.2.10"]})
 
       conn = call("/gupshup", {0, 0, 0, 0, 0, 0, 0, 1})
 
@@ -114,7 +115,7 @@ defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
   end
 
   test "the router runs the filter ahead of the gupshup shunt" do
-    configure(%{"gupshup" => ["34.202.224.208"]})
+    configure(%{"gupshup" => ["192.0.2.10"]})
 
     conn =
       %{conn(:post, "/gupshup", %{}) | remote_ip: @attacker_ip}

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -1,0 +1,141 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias GlificWeb.Plugs.BSPWebhookIPFilter
+
+  @gupshup_ip {34, 202, 224, 208}
+  @attacker_ip {203, 0, 113, 5}
+
+  setup do
+    original = Application.get_env(:glific, :bsp_webhook_ip_filter)
+
+    on_exit(fn -> Application.put_env(:glific, :bsp_webhook_ip_filter, original) end)
+
+    :ok
+  end
+
+  defp configure(mode, allowlist),
+    do: Application.put_env(:glific, :bsp_webhook_ip_filter, mode: mode, allowlist: allowlist)
+
+  defp call(path, remote_ip) do
+    conn = %{conn(:post, path, %{}) | remote_ip: remote_ip}
+
+    BSPWebhookIPFilter.call(conn, BSPWebhookIPFilter.init([]))
+  end
+
+  describe "enforce mode" do
+    setup do
+      configure(:enforce, %{"gupshup" => ["34.202.224.208", "3.6.228.131"], "maytapi" => []})
+    end
+
+    test "lets a request from an allowlisted provider IP through" do
+      conn = call("/gupshup", @gupshup_ip)
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+
+    test "rejects a request from an IP the provider does not publish" do
+      conn = call("/gupshup", @attacker_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not filter a provider with an empty allowlist" do
+      conn = call("/maytapi", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "does not filter a provider that is not configured at all" do
+      conn = call("/gupshup-enterprise", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "keeps each provider's allowlist to itself" do
+      configure(:enforce, %{"gupshup" => ["34.202.224.208"], "maytapi" => ["1.2.3.4"]})
+
+      conn = call("/maytapi", @gupshup_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
+  describe "matching" do
+    test "matches an IP inside a CIDR block" do
+      configure(:enforce, %{"gupshup" => ["3.6.0.0/16"]})
+
+      allowed = call("/gupshup", {3, 6, 228, 131})
+      rejected = call("/gupshup", {3, 7, 115, 196})
+
+      refute allowed.halted
+      assert rejected.halted
+    end
+
+    test "ignores an unparsable entry instead of failing the request" do
+      configure(:enforce, %{"gupshup" => ["not-an-ip", "34.202.224.208"]})
+
+      conn = call("/gupshup", @gupshup_ip)
+
+      refute conn.halted
+    end
+
+    test "an IPv6 caller does not match an IPv4 allowlist" do
+      configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
+
+      conn = call("/gupshup", {0, 0, 0, 0, 0, 0, 0, 1})
+
+      assert conn.halted
+    end
+  end
+
+  describe "other modes" do
+    test "log mode lets an unlisted IP through" do
+      configure(:log, %{"gupshup" => ["34.202.224.208"]})
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "disabled mode skips the check entirely" do
+      configure(:disabled, %{"gupshup" => ["34.202.224.208"]})
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "missing config leaves every request untouched" do
+      Application.delete_env(:glific, :bsp_webhook_ip_filter)
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+  end
+
+  test "the router runs the filter ahead of the gupshup shunt" do
+    configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
+
+    conn =
+      %{conn(:post, "/gupshup", %{}) | remote_ip: @attacker_ip}
+      |> GlificWeb.Router.call(GlificWeb.Router.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+
+  test "a request without a path segment is left alone" do
+    configure(:enforce, %{"gupshup" => ["34.202.224.208"]})
+
+    conn = call("/", @attacker_ip)
+
+    refute conn.halted
+  end
+end


### PR DESCRIPTION
## Summary

Target issue is the internal security finding **GF-CVE-2026-08-5** (no public issue filed).

The BSP webhook endpoints — `/gupshup`, `/gupshup-enterprise`, `/maytapi` — are unauthenticated. This PR puts a source IP filter in front of them, so only addresses the provider has published as callback IPs reach the shunt. Anything else is logged and answered with 403.

### What changed

- New `GlificWeb.Plugs.BSPWebhookIPFilter`, applied through a `:bsp_webhook` router pipeline attached **only** to the three BSP routes. No other route is affected.
- Entries may be IPv4/IPv6 addresses or CIDR blocks. Matching uses `inet_cidr`, which was already in `mix.lock` as a transitive dependency of `apiac_filter_ip_whitelist` and is now declared explicitly. No version changed and `mix.lock` is untouched.
- Lists are supplied per provider from the environment — `GUPSHUP_WEBHOOK_IPS`, `GUPSHUP_ENTERPRISE_WEBHOOK_IPS`, `MAYTAPI_WEBHOOK_IPS` — and deliberately **not** stored in this repository. Setting a variable replaces that provider's list outright, so widening one is a `gigalixir config:set` and a restart rather than a deploy.
- An empty list means that provider is not filtered. Only `:prod` is configured, so dev and test are unchanged and the existing BSP webhook tests run untouched.
- `gupshup-enterprise` and `maytapi` are intentionally left unfiltered: no published IP list exists for either yet. Setting their variable is what switches filtering on for them later.

### ⚠️ Deploy prerequisite

**`GUPSHUP_WEBHOOK_IPS` must be set in Gigalixir before this is deployed.** Because an empty list means "do not filter", booting without it would bring the app up unprotected — the one failure mode you cannot see. `config/runtime.exs` therefore raises at boot instead, and the release refuses to start:

```
** (RuntimeError) GUPSHUP_WEBHOOK_IPS is not set.
```

```bash
gigalixir config:set GUPSHUP_WEBHOOK_IPS="<comma separated list from the Gupshup support thread>"
```

`gigalixir config:unset` is the rollback. Note the variable **replaces** rather than appends, so when adding an address, re-list the full set.

### Testing

- 13 tests for the plug: allowed IP passes, unlisted IP gets 403 and halts, CIDR range matching, per-provider isolation, unparsable entry ignored rather than crashing the request, IPv6 caller does not match an IPv4 list, unconfigured provider unfiltered, and one test asserting the router runs the filter **ahead of** the shunt (a wiring mistake there would fail open silently).
- The 89 existing BSP webhook controller tests still pass unchanged.
- Config resolution was checked in each environment, including the `:prod` branch, both with the variable set and with it missing.
- Test fixtures use RFC 5737 documentation addresses, so no real provider IP is committed.

### Follow ups (not in this PR)

- **Alerting.** The plug logs `Unlisted IP … called the … webhook` on every rejection, and nothing watches that line yet. It is the only signal that a provider has started calling from an address we do not know about, and it should page someone.
- **Payload to organization binding**, tracked on the security finding. This PR narrows who can reach the endpoint; it does not by itself close the finding.

## Checklist

- [x] Tests added and passing — `mix test test/glific_web/plugs/bsp_webhook_ip_filter_test.exs test/glific_web/providers/` gives 100 tests, 0 failures.
- [x] Coding standard and conventions followed — `mix format`, `mix credo --strict`, `mix dialyzer` and `mix doctor` (100% doc and spec coverage) all clean, plus a warnings-as-errors compile.
- [ ] `mix setup` and the full suite were not run locally; verification was targeted at the affected areas. Leaving the full run to CI.
- [ ] No new API, so no Postman request needed.

## Notes

Reviewers: the ordering constraint in `endpoint.ex` is the subtle part. `plug(RemoteIp)` must stay **above** `plug(GlificWeb.Router)` — the filter reads `conn.remote_ip`, and if it ran before `RemoteIp` it would compare against the Gigalixir proxy address rather than the caller's. That is why the plug lives in a router pipeline rather than in the endpoint, and it is called out in the module doc.
