### PR TITLE
fix(rbac): block privilege escalation and close authorization gaps

### DIFF
--- a/assets/gql/searches/collection_stats.gql
+++ b/assets/gql/searches/collection_stats.gql
@@ -1,0 +1,3 @@
+query collectionStats($organizationId: ID!) {
+  collectionStats(organizationId: $organizationId)
+}

--- a/fixes.md
+++ b/fixes.md
@@ -1,0 +1,134 @@
+# RBAC Phase 1 — review
+
+Branch `worktree-rbac-fixes`, uncommitted. Detail: `plans/rbac-audit/`.
+Roles themselves are unchanged (`glific_admin > admin > manager > staff > none`) — only how they
+are stored, enforced, and tested.
+
+**Green:** 3001 tests / 0 failures · dialyzer 0 new · credo --strict · format · frontend 57 tests + tsc.
+
+## Root cause
+
+The hierarchy had **no single owner** — `Authorize`, `Users.check_access_role`, and the frontend
+each re-derived it, with three different spellings of `glific_admin`. And `updateUser` checked the
+target's *current* role instead of the *requested* one: a "may I touch this row" check answering
+"may I write this value".
+
+New `lib/glific/users/roles.ex` owns the ranking. Fails closed (unknown label → rank 0, was
+`manager`). Two predicates, deliberately separate: `can_manage_user?` (whose row) and
+`can_grant_roles?` (which value) — that split is why the fix is stricter *and* still lets an admin
+edit a peer admin.
+
+## Fixes
+
+| Sev | What | Where |
+|---|---|---|
+| **CRIT** | `collectionStats` took `organization_id` **from query args**, gated `:staff`, and counted via `Repo.all(skip_organization_id: true)` → any staff read any tenant's data. Now pinned to the session; the arg is accepted but ignored. *(Found in the scan, not in the reported 5.)* | `resolvers/searches.ex` |
+| **CRIT** | `updateUser` let a manager set `roles: ["Admin"]` / `["glific_admin"]`, incl. on themselves. Now validates requested roles from **both** `roles` and `add_role_ids`. | `resolvers/users.ex` |
+| HIGH | `deleteUser` had no role check — manager could delete their org's admins. | `resolvers/users.ex` |
+| HIGH | `languages` is a `global`-prefix table (writes hit **every tenant**) but was writable at `:manager` → `:glific_admin`. | `schema/language_types.ex` |
+| HIGH | 3 org exports at `:staff` use **raw SQL**, so no org-scoping and no permission filter → `:admin`. | `schema/organization_types.ex` |
+| HIGH | `check_access_role` fell back to `["manager"]` for any unrecognised label, and its `"Glific Admin"` clause was dead code (seeded label is `Glific_admin`). | `glific/users.ex` |
+| MED | Role change didn't invalidate sessions on a bare `roles` write — cached creds embed roles, 30-min TTL, so **demoting a compromised account left it privileged for 30 min**. | `glific/users.ex` |
+| MED | `export_collection` skipped `add_permission` — restricted staff exported unassigned collections. | `glific/groups.ex` |
+| MED | Contact phone redaction ran **backwards**: `staff && !is_restricted`. Restricted users saw *more*. | `schema/contact_types.ex` |
+| LOW | `bspbalance` had no gate at all → `:staff`. | `schema/provider_types.ex` |
+| LOW | Role dropdown filtered on `'Glific admin'`, never matched `'Glific_admin'` — option was always visible. UX only. | frontend `StaffManagement.tsx` |
+| **HIGH** | *Found by e2e against a live server, in this PR's own code.* `Roles.rank/1`'s atom clause consulted only `@rank`, never the alias map. The `:role_label` scalar downcases input to an atom, so `"Glific Admin"` arrived as `:"glific admin"` → rank **0** → `can_grant_roles?` returned true and a manager sailed past the escalation check. Only the Ecto enum stopped the write, as a MatchError 500. | `users/roles.ex` |
+| **MED** | *Same source.* An `addRoleIds` value that doesn't resolve (another org's role, or nonexistent) produced `[]`, which `can_grant_roles?(_, [])` allows and `check_access_role` maps to the lowest role — so a manager could **silently demote** any user to `none`, and `update_user_roles/2` attached a cross-org `user_roles` row. Unresolvable ids are now refused. | `resolvers/users.ex` |
+
+Two hunks are **chained**: fixing the `Glific_admin` typo turns dead code into a live escalation
+path via `add_role_ids`, which the `updateUser` fix closes. Review them together.
+
+## `collectionStats` — why `skip_organization_id` stays
+
+The fix is entirely in the resolver: the org now comes from `current_user`, so the argument no
+longer selects the tenant. That is sufficient, and it is verified safe —
+`APIAuthPlug.get_credentials/3` (api_auth_plug.ex:36) **rejects the token when the subdomain org ≠
+`user.organization_id`**, and GraphQL is authenticated before Absinthe runs
+(`forward("/api", Absinthe.Plug)` sits behind `[:api, :api_protected]`, so
+`Pow.Plug.RequireAuthenticated` 401s and `ContextPlug` guarantees `current_user`).
+
+`Repo.all(skip_organization_id: true)` inside `CollectionCount.make_result/3` is **left as-is on
+purpose**: `MinuteWorker` `"five_minute_tasks"` calls `CollectionCount.collection_stats()` for
+*all* orgs in one `group_by organization_id` query with **no org in the process dict**, so
+auto-scoping there would hit `prepare_query`'s
+`raise "expected organization_id or skip_organization_id to be set"` and kill the 5-minute cron.
+Splitting that path is a refactor, not a security fix, and is deliberately out of scope here.
+
+The `organization_id` arg stays `non_null` and is simply ignored, so no client change is needed.
+
+## Behaviour changes / judgement calls
+
+- Managers & admins can **no longer** manage languages. If admins should, the answer is per-org
+  languages, not a lower gate — product call.
+- `bspbalance` is `:staff`, not the `:admin` I'd proposed: `WalletBalance` renders in the drawer for
+  every role. Tightest gate that doesn't break the UI; still closes `:none`.
+- `can_manage_user?` is `>=`, not `>` — strict `>` would block admin-edits-peer-admin.
+
+## Not fixed
+
+- **Finding 4** (`/flow-editor/`* unauthorized): needs a `RequireRole` plug — `RequireAuthenticated`
+  is presence-only, so *every* REST route is role-blind. Its two claimed exploit chains were **not
+  reproduced**; reported as a route gap only.
+- `AddOrganization` uses `Map.put_new` → client `organization_id` still wins wherever a resolver
+  reads it from args.
+- 17 fields still ungated (all subscriptions). Nothing makes a missing gate fail to compile — that's
+  how `bspbalance` happened.
+
+- **`createAccessRole` sits at `:manager`** and accepts `is_reserved` in its input, so a manager can
+  write rows in the very table that drives role assignment. The label→`reserved` mapping neutralises
+  the escalation (verified), but a manager writing to an authorization-governing table deserves a
+  second look. Pre-existing; not touched here.
+
+Corrections to the audit's ratings: finding 2 is intra-org not platform-wide; finding 5 is
+intra-tenant not cross-tenant; finding 1 was **understated**.
+
+## E2E verification against a running server
+
+All ten fixes were exercised over real HTTP + GraphQL on a local `mix phx.server` — tokens from
+`POST /api/v1/session`, users at all five role levels plus a restricted staff user, and a real
+second organization. **All ten held.** Highlights worth trusting more than a unit test:
+
+- `collectionStats(organizationId: "2")` as org-1 staff, with org 2 holding 7 contacts, returned
+  keys `['1']` only.
+- Session invalidation: with a raw-SQL demotion (bypassing `update_user`) the old token still
+  returned `roles:["Admin"]` and 200 on the admin-gated export — the stale-privilege window is
+  real. Through `updateUser`, `fetchUserSessions` went 2→0 and the old token got **401
+  immediately**. A name-only write does *not* purge, so there's no over-invalidation.
+- `languages` confirmed to live in the `global` Postgres schema, and admin as well as manager now
+  get `Unauthorized`.
+
+**Trap for anyone writing tests here:** a 401 response has no GraphQL `errors` array, so a naive
+harness reads it as success. Any `updateUser` touching a user purges *that user's* sessions, which
+can kill a token mid-test and make later assertions "pass" against `data: null`. Assert on HTTP
+status, not just `errors`.
+
+## Tests — 13 added, each seen failing before its fix
+
+Read the **deletions** in `user_test.exs`: `roles = ["Staff", "Admin"]` was a *passing* assertion
+that a manager can promote to admin. The suite was green **because** the escalation worked.
+
+`collectionStats` had **no `.gql` asset and no schema test** — which is why the cross-tenant hole
+survived. Both now exist; the test passes another org's id and asserts you still get your own
+stats. Against the old resolver it fails with `left: ["1525"]` vs `right: ["1"]` — org 1's staff
+user reading org 1525's stats, the exploit demonstrated rather than argued.
+
+Two of my own tests were broken in the same way as the bugs: the groups test copied a `with`
+without an `else`, so the user switch silently no-op'd and it ran as admin (failed open, like
+finding 5); the frontend test passed pre-fix because the mock had no `Glific_admin` row.
+
+## Review order
+
+1. `roles.ex` + its test — the new contract alone.
+2. `resolvers/users.ex` **with** `glific/users.ex` — the chained fix.
+3. `resolvers/searches.ex` — 2 lines, biggest impact.
+4. The 4 gate changes — confirm the levels match product intent.
+
+
+## TODO
+
+- Split `CollectionCount`'s cron and per-user paths so the resolver side can drop
+  `skip_organization_id: true` (the cron genuinely needs it — see the `collectionStats` section).
+  Then drop the ignored `organization_id` arg once no client sends it. Refactor, not a fix.
+- Refactor update_user as its too complex
+- We need to remove is_restricted column from the user table

--- a/lib/glific/groups.ex
+++ b/lib/glific/groups.ex
@@ -176,6 +176,9 @@ defmodule Glific.Groups do
   """
   @spec export_collection(integer) :: map()
   def export_collection(group_id) do
+    if has_permission?(group_id) == false,
+      do: raise(RuntimeError, message: "Permission denied")
+
     result =
       ContactGroup
       |> join(:inner, [cg], c in Contact, as: :c, on: cg.contact_id == c.id)

--- a/lib/glific/users.ex
+++ b/lib/glific/users.ex
@@ -14,6 +14,7 @@ defmodule Glific.Users do
     AccessControl.UserRole,
     Repo,
     Settings.Language,
+    Users.Roles,
     Users.User
   }
 
@@ -114,9 +115,11 @@ defmodule Glific.Users do
       |> check_access_role(attrs)
 
     # lets invalidate the tokens and socket for this user
-    # we do this ONLY if either the role or is_restricted has changed
+    # the cached credentials embed the roles, so a bare `roles` write has to
+    # invalidate too - otherwise a demotion does not take effect until the TTL expires
     if validate_add_role_ids?(attrs) ||
          updated?(user.is_restricted, attrs[:is_restricted]) ||
+         updated?(user.roles, attrs[:roles]) ||
          validate_delete_role_ids?(attrs) do
       GlificWeb.APIAuthPlug.delete_all_user_sessions(@pow_config, user)
     end
@@ -147,23 +150,30 @@ defmodule Glific.Users do
   defp check_access_role(false, attrs), do: attrs
 
   defp check_access_role(true, %{add_role_ids: add_role_ids} = attrs) do
-    roles =
-      Role
-      |> select([r], r.label)
-      |> where([r], r.id in ^add_role_ids)
-      |> Repo.all()
-
     role =
-      cond do
-        Enum.any?(roles, fn role -> role == "Admin" end) -> ["admin"]
-        Enum.any?(roles, fn role -> role == "Manager" end) -> ["manager"]
-        Enum.any?(roles, fn role -> role == "Staff" end) -> ["staff"]
-        Enum.any?(roles, fn role -> role == "No access" end) -> ["none"]
-        Enum.any?(roles, fn role -> role == "Glific Admin" end) -> ["glific_admin"]
-        true -> ["manager"]
+      add_role_ids
+      |> role_labels_by_ids()
+      |> Enum.map(&Roles.reserved/1)
+      |> Enum.reject(&is_nil/1)
+      |> case do
+        [] -> ["none"]
+        roles -> [roles |> Enum.max_by(&Roles.rank/1) |> Atom.to_string()]
       end
 
     Map.put(attrs, :roles, role)
+  end
+
+  @doc """
+  Labels of the access roles matching the given ids
+  """
+  @spec role_labels_by_ids(list()) :: [String.t()]
+  def role_labels_by_ids([]), do: []
+
+  def role_labels_by_ids(role_ids) do
+    Role
+    |> select([r], r.label)
+    |> where([r], r.id in ^role_ids)
+    |> Repo.all()
   end
 
   @spec update_user_roles(map(), User.t()) :: {:ok, User.t()}

--- a/lib/glific/users/roles.ex
+++ b/lib/glific/users/roles.ex
@@ -1,0 +1,89 @@
+defmodule Glific.Users.Roles do
+  @moduledoc """
+  The legacy role hierarchy (`glific_admin > admin > manager > staff > none`) and the
+  comparisons built on top of it.
+
+  This is the single source of truth for what a role name means and how two principals
+  rank against each other. `GlificWeb.Schema.Middleware.Authorize` delegates here rather
+  than keeping a second copy of the hierarchy.
+  """
+
+  @rank %{glific_admin: 4, admin: 3, manager: 2, staff: 1, none: 0}
+
+  @reserved %{
+    "admin" => :admin,
+    "manager" => :manager,
+    "staff" => :staff,
+    "no access" => :none,
+    "none" => :none,
+    "glific_admin" => :glific_admin,
+    "glific admin" => :glific_admin
+  }
+
+  @doc """
+  Numeric rank of a single role. Unknown roles rank lowest so comparisons fail closed.
+  """
+  @spec rank(atom() | String.t()) :: non_neg_integer()
+  def rank(role) when is_atom(role) do
+    # the :role_label scalar downcases input into an atom, so "Glific Admin" arrives as
+    # :"glific admin" - it has to resolve through the alias map or it would rank 0
+    case Map.get(@rank, role) do
+      nil -> role |> Atom.to_string() |> rank()
+      rank -> rank
+    end
+  end
+
+  def rank(role) when is_binary(role) do
+    case reserved(role) do
+      nil -> 0
+      atom -> Map.get(@rank, atom, 0)
+    end
+  end
+
+  def rank(_role), do: 0
+
+  @doc """
+  Highest rank held across a list of roles.
+
+  A user holding `[:staff, :glific_admin]` is a glific_admin, so every comparison must
+  use the maximum rather than the first element.
+  """
+  @spec highest_rank(list()) :: non_neg_integer()
+  def highest_rank(roles) when is_list(roles) do
+    roles
+    |> Enum.map(&rank/1)
+    |> Enum.max(fn -> 0 end)
+  end
+
+  def highest_rank(_roles), do: 0
+
+  @doc """
+  Can the actor administer the target user?
+
+  Peers may still manage each other, which preserves long-standing behaviour such as one
+  admin editing another. Escalation is prevented by `can_grant_roles?/2`, not here - this
+  check only stops reaching *up* the hierarchy.
+  """
+  @spec can_manage_user?(list(), list()) :: boolean()
+  def can_manage_user?(actor_roles, target_roles),
+    do: highest_rank(actor_roles) >= highest_rank(target_roles)
+
+  @doc """
+  Can the actor grant this set of roles? Nobody may grant a role above their own.
+  """
+  @spec can_grant_roles?(list(), list()) :: boolean()
+  def can_grant_roles?(_actor_roles, []), do: true
+
+  def can_grant_roles?(actor_roles, requested) when is_list(requested),
+    do: highest_rank(actor_roles) >= highest_rank(requested)
+
+  def can_grant_roles?(_actor_roles, _requested), do: false
+
+  @doc """
+  Maps a role label to its reserved legacy role, or nil for a custom role.
+  """
+  @spec reserved(String.t()) :: atom() | nil
+  def reserved(label) when is_binary(label), do: Map.get(@reserved, String.downcase(label))
+
+  def reserved(_label), do: nil
+end

--- a/lib/glific_web/resolvers/groups.ex
+++ b/lib/glific_web/resolvers/groups.ex
@@ -35,6 +35,8 @@ defmodule GlificWeb.Resolvers.Groups do
           {:ok, any} | {:error, any}
   def export_collection(_, %{id: id}, _) do
     {:ok, Groups.export_collection(id)}
+  rescue
+    _ -> {:error, ["Group", dgettext("errors", "Group not found or permission denied.")]}
   end
 
   @doc """

--- a/lib/glific_web/resolvers/searches.ex
+++ b/lib/glific_web/resolvers/searches.ex
@@ -46,8 +46,8 @@ defmodule GlificWeb.Resolvers.Searches do
   Get the collection count
   """
   @spec collection_stats(Absinthe.Resolution.t(), map(), %{context: map()}) :: {:ok, map()}
-  def collection_stats(_, %{organization_id: org_id}, _) do
-    {:ok, CollectionCount.collection_stats([org_id], true)}
+  def collection_stats(_, _args, %{context: %{current_user: user}}) do
+    {:ok, CollectionCount.collection_stats([user.organization_id], true)}
   end
 
   @doc false

--- a/lib/glific_web/resolvers/users.ex
+++ b/lib/glific_web/resolvers/users.ex
@@ -78,11 +78,52 @@ defmodule GlificWeb.Resolvers.Users do
           {:ok, any} | {:error, any}
   def update_user(_, %{id: id, input: params}, %{context: %{current_user: current_user}}) do
     with {:ok, user} <-
-           Repo.fetch_by(User, %{id: id, organization_id: current_user.organization_id}) do
-      current_user.roles
-      |> Authorize.valid_role?(hd(user.roles))
-      |> do_update_user(user, params)
+           Repo.fetch_by(User, %{id: id, organization_id: current_user.organization_id}),
+         :ok <- authorize_user_update(current_user, user, params) do
+      do_update_user(user, params)
     end
+  end
+
+  @spec authorize_user_update(User.t(), User.t(), map()) :: :ok | {:error, String.t()}
+  defp authorize_user_update(current_user, user, params) do
+    if Authorize.can_manage_user?(current_user.roles, user.roles),
+      do: authorize_requested_roles(current_user, params),
+      else: {:error, dgettext("errors", "Does not have access to the user")}
+  end
+
+  @spec authorize_requested_roles(User.t(), map()) :: :ok | {:error, String.t()}
+  defp authorize_requested_roles(current_user, params) do
+    case requested_roles(params) do
+      :error ->
+        {:error, dgettext("errors", "Resource not found")}
+
+      {:ok, requested} ->
+        if Authorize.can_grant_roles?(current_user.roles, requested),
+          do: :ok,
+          else: {:error, dgettext("errors", "Does not have access to assign this role")}
+    end
+  end
+
+  @spec requested_roles(map()) :: {:ok, list()} | :error
+  defp requested_roles(params) do
+    case roles_from_ids(Map.get(params, :add_role_ids, [])) do
+      :error -> :error
+      {:ok, labels} -> {:ok, Map.get(params, :roles, []) ++ labels}
+    end
+  end
+
+  @spec roles_from_ids(list()) :: {:ok, list()} | :error
+  defp roles_from_ids([]), do: {:ok, []}
+
+  defp roles_from_ids(role_ids) do
+    labels = Users.role_labels_by_ids(role_ids)
+
+    # an id that resolves to nothing belongs to another org or does not exist. Refusing
+    # here stops it from reaching check_access_role, which maps an empty label list to
+    # the lowest role and would silently demote the target
+    if length(labels) == length(Enum.uniq(role_ids)),
+      do: {:ok, labels},
+      else: :error
   end
 
   @doc """
@@ -97,10 +138,8 @@ defmodule GlificWeb.Resolvers.Users do
     end
   end
 
-  defp do_update_user(false, _user, _params),
-    do: {:error, dgettext("errors", "Does not have access to the user")}
-
-  defp do_update_user(true, user, params) do
+  @spec do_update_user(User.t(), map()) :: {:ok, map()}
+  defp do_update_user(user, params) do
     {:ok, user} = Users.update_user(user, params)
 
     if Map.has_key?(params, :group_ids) do
@@ -117,9 +156,14 @@ defmodule GlificWeb.Resolvers.Users do
   @doc false
   @spec delete_user(Absinthe.Resolution.t(), %{id: integer}, %{context: map()}) ::
           {:ok, any} | {:error, any}
-  def delete_user(_, %{id: id}, %{context: %{current_user: user}}) do
-    with {:ok, user} <- Repo.fetch_by(User, %{id: id, organization_id: user.organization_id}) do
+  def delete_user(_, %{id: id}, %{context: %{current_user: current_user}}) do
+    with {:ok, user} <-
+           Repo.fetch_by(User, %{id: id, organization_id: current_user.organization_id}),
+         true <- Authorize.can_manage_user?(current_user.roles, user.roles) do
       Users.delete_user(user)
+    else
+      false -> {:error, dgettext("errors", "Does not have access to the user")}
+      error -> error
     end
   end
 end

--- a/lib/glific_web/schema/contact_types.ex
+++ b/lib/glific_web/schema/contact_types.ex
@@ -49,7 +49,7 @@ defmodule GlificWeb.Schema.ContactTypes do
 
     field :phone, :string do
       resolve(fn contact, _, %{context: %{current_user: user}} ->
-        if Enum.member?(user.roles, :staff) && !user.is_restricted,
+        if Enum.member?(user.roles, :staff),
           do: {:ok, ""},
           else: {:ok, contact.phone}
       end)

--- a/lib/glific_web/schema/language_types.ex
+++ b/lib/glific_web/schema/language_types.ex
@@ -67,23 +67,26 @@ defmodule GlificWeb.Schema.LanguageTypes do
     end
   end
 
+  # languages lives in the "global" schema prefix, so Repo.prepare_query does not
+  # scope it by organization - a write here is visible to every tenant. Gated at
+  # :glific_admin to match the sibling global table (providers).
   object :language_mutations do
     field :create_language, :language_result do
       arg(:input, non_null(:language_input))
-      middleware(Authorize, :manager)
+      middleware(Authorize, :glific_admin)
       resolve(&Resolvers.Settings.create_language/3)
     end
 
     field :update_language, :language_result do
       arg(:id, non_null(:id))
       arg(:input, :language_input)
-      middleware(Authorize, :manager)
+      middleware(Authorize, :glific_admin)
       resolve(&Resolvers.Settings.update_language/3)
     end
 
     field :delete_language, :language_result do
       arg(:id, non_null(:id))
-      middleware(Authorize, :manager)
+      middleware(Authorize, :glific_admin)
       resolve(&Resolvers.Settings.delete_language/3)
     end
   end

--- a/lib/glific_web/schema/middleware/authorize.ex
+++ b/lib/glific_web/schema/middleware/authorize.ex
@@ -5,6 +5,8 @@ defmodule GlificWeb.Schema.Middleware.Authorize do
   """
   use Gettext, backend: GlificWeb.Gettext
 
+  alias Glific.Users.Roles
+
   @behaviour Absinthe.Middleware
 
   @doc """
@@ -41,4 +43,16 @@ defmodule GlificWeb.Schema.Middleware.Authorize do
 
   def valid_role?(roles, role) when is_list(role), do: Enum.any?(roles, fn x -> x in role end)
   def valid_role?(_, _), do: false
+
+  @doc """
+  Can the actor administer the target user? Blocks reaching up the hierarchy.
+  """
+  @spec can_manage_user?(list(), list()) :: boolean()
+  defdelegate can_manage_user?(actor_roles, target_roles), to: Roles
+
+  @doc """
+  Can the actor grant this set of roles? Nobody may grant a role above their own.
+  """
+  @spec can_grant_roles?(list(), list()) :: boolean()
+  defdelegate can_grant_roles?(actor_roles, requested_roles), to: Roles
 end

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -321,23 +321,26 @@ defmodule GlificWeb.Schema.OrganizationTypes do
       resolve(&Resolvers.Partners.organization_services/3)
     end
 
+    # These export the whole organization via raw SQL, so neither prepare_query nor
+    # Repo.add_permission applies - a restricted staff user would read every contact
+    # and message in the org. The gate is the only available control.
     @desc "Export organization dynamic data"
     field :organization_export_data, :organization_export_result do
       arg(:filter, :export_filter)
-      middleware(Authorize, :staff)
+      middleware(Authorize, :admin)
       resolve(&Resolvers.Partners.organization_export_data/3)
     end
 
     @desc "Export organization config data"
     field :organization_export_config, :organization_export_result do
-      middleware(Authorize, :staff)
+      middleware(Authorize, :admin)
       resolve(&Resolvers.Partners.organization_export_config/3)
     end
 
     @desc "Export organization stats data"
     field :organization_export_stats, :organization_export_result do
       arg(:filter, :export_filter)
-      middleware(Authorize, :staff)
+      middleware(Authorize, :admin)
       resolve(&Resolvers.Partners.organization_export_stats/3)
     end
 

--- a/lib/glific_web/schema/provider_types.ex
+++ b/lib/glific_web/schema/provider_types.ex
@@ -61,6 +61,7 @@ defmodule GlificWeb.Schema.ProviderTypes do
 
     @desc "getting bsp balance"
     field :bspbalance, :json do
+      middleware(Authorize, :staff)
       resolve(&Resolvers.Partners.bspbalance/3)
     end
 

--- a/plans/rbac-audit/01-findings-verification.md
+++ b/plans/rbac-audit/01-findings-verification.md
@@ -1,0 +1,275 @@
+# Report 1 — Verification of the 5 reported RBAC findings
+
+**Scope:** independent confirmation of each finding against source, at commit `26b702634` (branch `master`, worktree `rbac-fixes`).
+**Method:** read the authorizing middleware gate, the resolver, the context function, the Ecto changeset, and the existing tests for each path. Every claim below cites `file:line`.
+
+> **Status: findings 1, 2, 3 and 5 are FIXED** (see Report 3, "Fix 0"). Finding 4 (the
+> `/flow-editor` REST gap) is **not** fixed — it needs a `RequireRole` plug across 29 routes and is
+> scheduled for phase 3. Line numbers below describe the code **as audited**, before the fix.
+
+## Verdict summary
+
+| # | Finding | Verdict | Actor as stated? | Impact as stated? |
+|---|---------|---------|------------------|-------------------|
+| 1 | `updateUser` checks target's current role, not requested role | **CONFIRMED — and stronger than reported** | Yes (`:manager`) | Yes; escalation path is broader than described |
+| 2 | `deleteUser` has no target-role check | **CONFIRMED** | Yes (`:manager`) | Yes, with one correction (scope is intra-org) |
+| 3 | Global `languages` table writable at `:manager` | **CONFIRMED** | Yes (`:manager`) | Yes — cross-tenant, and applies to create/delete too |
+| 4 | All `/flow-editor/*` routes lack role authorization | **CONFIRMED (route gap) / UNVERIFIED (exploit chain)** | Partially — see below | Downgraded pending reproduction |
+| 5 | Two `:staff` exports bypass the restricted-staff filter | **CONFIRMED** | Yes (restricted `:staff`) | **Corrected: intra-tenant, not cross-tenant** |
+
+Nothing here is a false positive. Two impact statements need correction (4 and 5), and finding 1 understates the problem.
+
+---
+
+## Finding 1 — `updateUser` authorizes against the target's current role
+
+### Verdict: CONFIRMED. Pinned by two passing tests.
+
+**The defect.** `lib/glific_web/resolvers/users.ex:79-86`:
+
+```elixir
+def update_user(_, %{id: id, input: params}, %{context: %{current_user: current_user}}) do
+  with {:ok, user} <-
+         Repo.fetch_by(User, %{id: id, organization_id: current_user.organization_id}) do
+    current_user.roles
+    |> Authorize.valid_role?(hd(user.roles))   # <- target's CURRENT role
+    |> do_update_user(user, params)
+  end
+end
+```
+
+`params` is never inspected. The only authorization question asked is "does the caller out-rank the
+target *today*", never "is the caller allowed to grant the role being requested".
+
+**The gate.** `lib/glific_web/schema/users_types.ex:139-142` — `update_user` is
+`middleware(Authorize, :manager)`. The reported actor (a manager) is correct.
+
+**The write actually lands.** Three links, all verified:
+
+1. `user_input` exposes `field :roles, list_of(:role_label)` — `users_types.ex:81`.
+2. `:role_label` is a free-form scalar, not an enum: `parse_label/1` downcases the string and calls
+   `Glific.safe_string_to_atom/2` (`generic_types.ex:139-149`, `lib/glific.ex:443-454`). That is
+   `String.to_existing_atom/1`, and `:glific_admin` already exists in the atom table because it is a
+   member of the `user_roles_enum` Ecto enum (`lib/glific/enums/ecto_enums.ex:96-100`,
+   `lib/glific/users/user.ex:85`). So `"glific_admin"` parses successfully.
+3. `Glific.Users.update_user/2` (`lib/glific/users.ex:109-131`) calls
+   `check_access_role/2`, which **only** overwrites `attrs.roles` when `add_role_ids` is present and
+   non-empty (`users.ex:146-166`). Send `roles:` **without** `add_role_ids` and the client value
+   passes through untouched into `User.update_fields_changeset/2`, which casts `:roles`
+   (`lib/glific/users/user.ex:150-160`).
+
+**The pinning tests.** `test/glific_web/schema/user_test.exs:209-236` — a **manager** updates
+"NGO Staff" with `roles: ["Staff", "Admin"]` and the test *asserts the update succeeds*:
+
+```elixir
+assert user_result["roles"] == roles   # ["Staff", "Admin"]
+```
+
+Because `Authorize.valid_role?/2` uses `Enum.any?/2` (`authorize.ex:42`), a `roles` list of
+`[:staff, :admin]` satisfies every `:admin` gate. The companion test at `user_test.exs:262-287`
+("update a user of higher role should give an errors") documents the intended model explicitly — it
+only fails because the *target* is an admin. Together these two tests encode "protect the target's
+existing rank" as the design, with no notion of "authorize the requested rank."
+
+### Where the reported impact understates the problem
+
+The report describes self-escalation (`updateUser(id: <own>, roles: ["glific_admin"])`). That works —
+`hd(own.roles)` is `:manager`, and `valid_role?([:manager], :manager)` is `true`. But there are three
+further paths the report misses:
+
+- **Escalating any lower-ranked user**, not just self — a manager can promote any `:staff` or `:none`
+  user in the org to `:glific_admin`. Test `user_test.exs:288-313` demonstrates exactly this shape
+  (manager promotes a `:none` user to `:manager`) and passes.
+- **Role stacking.** `roles` is an array and `valid_role?/2` is `Enum.any?`. Setting
+  `["staff","glific_admin"]` grants glific_admin while `hd/1` still returns `:staff`, so the account
+  *continues to look low-privilege* to this very check — the escalated account can be re-edited by
+  any manager, and reads as "Staff" first in the UI.
+- **Session invalidation does not fire.** `users.ex:116-121` only calls
+  `delete_all_user_sessions/2` when `add_role_ids`/`delete_role_ids` changed or `is_restricted`
+  changed. A pure `roles:` write changes privileges without touching sessions. Whether this makes the
+  escalation immediate or next-login depends on whether roles are re-read per request — see
+  Report 3, "one defect, three enforcement layers".
+
+**Robustness note (not a security issue):** `hd(user.roles)` at `users.ex:83` raises on an empty
+`roles` list. The column defaults to `[:none]` (`user.ex:85`) and `update_fields_changeset` requires
+`:roles`, so this is not currently reachable, but it is a `MatchError` waiting on any code path that
+clears the array.
+
+---
+
+## Finding 2 — `deleteUser` performs no target-role check
+
+### Verdict: CONFIRMED.
+
+`lib/glific_web/resolvers/users.ex:120-124`:
+
+```elixir
+def delete_user(_, %{id: id}, %{context: %{current_user: user}}) do
+  with {:ok, user} <- Repo.fetch_by(User, %{id: id, organization_id: user.organization_id}) do
+    Users.delete_user(user)
+  end
+end
+```
+
+There is no role comparison of any kind — not even the (flawed) `valid_role?(…, hd(user.roles))`
+that `update_user` at least attempts. The gate is `middleware(Authorize, :manager)`
+(`users_types.ex:133-136`). `Glific.Users.delete_user/1` (`lib/glific/users.ex:194-205`) logs the
+deletion and invalidates sessions, but adds no authorization.
+
+The reconnaissance step in the report also holds: `users` is gated `:staff` (`users_types.ex:98-102`)
+and the `:user` object exposes `field :roles` (`users_types.ex:22`), so a manager can enumerate
+targets and their roles before deleting. (`is_restricted` is hidden from staff at
+`users_types.ex:27-33`, but `roles` is not hidden from anyone.)
+
+**Correction to stated impact.** The blast radius is the caller's own organization — `Repo.fetch_by`
+is org-scoped on line 121. A manager can delete their org's admins, and can delete a `:glific_admin`
+account *if that account is a member of their organization*. It is not a route to deleting SaaS
+operators in other tenants. Within one tenant, the lockout + chained-with-finding-1 argument is
+sound.
+
+**Contrast worth noting:** the existing test `user_test.exs:194-207` deletes a fixture user as a
+manager and asserts success — so, as with finding 1, the permissive behaviour is pinned.
+
+---
+
+## Finding 3 — the global `languages` table is writable at `:manager`
+
+### Verdict: CONFIRMED. This is the cleanest cross-tenant finding of the five.
+
+**The table is global.** `lib/glific/settings/language.ex:26-27`:
+
+```elixir
+@schema_prefix "global"
+schema "languages" do
+```
+
+There is no `organization_id` column and no `belongs_to :organization`.
+
+**Tenant scoping is explicitly skipped for it.** `lib/glific/repo_helpers.ex:377-394`:
+
+```elixir
+cond do
+  opts[:skip_organization_id] ||
+    opts[:schema_migration] ||
+    opts[:prefix] == "global" ||
+    query.from.prefix == "global" ||        # <- languages hits this
+      sub_query?(query) ->
+    {query, opts}
+```
+
+So the usual multi-tenancy backstop does not apply. The GraphQL gate is the *only* control.
+
+**The gate is `:manager`, and it covers all three mutations** — the report only names `updateLanguage`,
+but `lib/glific_web/schema/language_types.ex:80-97` gates `create_language`, `update_language` **and**
+`delete_language` at `:manager`. `deleteLanguage` is arguably worse than the reported update: it
+removes a row every other tenant's templates and flows reference.
+
+**The asymmetry the report identifies is real, and inverted.** Compare `provider_types.ex`:
+
+| Table | Tenant scope | Read gate | Write gate |
+|-------|--------------|-----------|------------|
+| `providers` | **org-scoped** | `:admin` (`provider_types.ex:58`) | `:glific_admin` (`:90-105`) |
+| `languages` | **global / cross-tenant** | `:staff` (`language_types.ex:73`) | `:manager` (`:80-97`) |
+
+The table with the *wider* blast radius has the *weaker* gate, by two full levels. Any manager in any
+tenant can flip `is_active` or rewrite `locale` on a language row that every other organization's
+localization depends on.
+
+---
+
+## Finding 4 — `/flow-editor/*` routes have no role authorization
+
+### Verdict: route-level gap CONFIRMED. Exploit chain UNVERIFIED — see caveat.
+
+**Confirmed from `lib/glific_web/router.ex:150-208`:** the entire `/flow-editor` scope pipes through
+`[:api, :api_protected]` only. There is no role plug and no `Authorize` equivalent. The scope
+includes writes: `POST /flow-editor/revisions/*vars` (`router.ex:191`), `POST /flow-editor/fields`,
+`POST /flow-editor/groups`, `POST /flow-editor/labels`, `POST /flow-editor/flow-attachment`. Reads
+include `/flow-editor/sheets`, `/globals`, `/flows/*`, `/revisions/*`.
+
+The GraphQL equivalents of several of these are gated `:manager` or higher, so the REST surface is a
+strictly weaker path to the same data and the same writes. Full per-action comparison is in
+**Report 2**, which treats this as a class rather than an instance.
+
+**What I am NOT asserting.** The source finding self-flagged "PARTIALLY VERIFIED: reproduce the
+draft-trigger execution," and I did not reproduce it either. The following remain unverified and
+should not be reported as fact:
+
+- that a saved malicious revision is reachable via `draft:<keyword>` and executes;
+- that `call_webhook` exfiltration and phishing `send_msg` fire from the org's verified number;
+- the stated actor, "a revoked `:none`-role user." Whether a `:none` user can obtain a valid token
+  at all is a separate question about the login path — resolved in Report 2, TASK 4. Note that
+  `Authorize.valid_role?/2` rejects `:none` users from *every* GraphQL field, including
+  `:none`-gated ones (`authorize.ex:39-40` requires membership in
+  `[:glific_admin, :admin, :manager, :staff]`), which is what makes the REST bypass interesting —
+  but "rejected by GraphQL" does not by itself establish "can still authenticate."
+
+**Report the confirmed claim, which is serious on its own:** any principal holding a valid API token —
+regardless of role, including `:staff` and `:none` if they can authenticate — can read and overwrite
+flow definitions through REST, bypassing the `:manager` gate that governs the same objects in GraphQL.
+
+---
+
+## Finding 5 — two `:staff` exports bypass the restricted-staff permission filter
+
+### Verdict: CONFIRMED, with the impact scope corrected from cross-tenant to intra-tenant.
+
+**What "restricted staff" means.** `lib/glific/repo_helpers.ex:340-347`:
+
+```elixir
+def skip_permission?(user \\ get_current_user()) do
+  cond do
+    is_nil(user) -> raise(RuntimeError, message: "Invalid user")
+    user.is_restricted and Enum.member?(user.roles, :staff) -> false
+    true -> true
+  end
+end
+```
+
+Row-level filtering applies to exactly one population: users with `is_restricted == true` **and**
+`:staff` in `roles`. For them, `Repo.add_permission/3` (`repo_helpers.ex:359-365`) applies the
+context's filter — for groups, `Groups.add_permission/2` (`lib/glific/groups.ex:43-47`) inner-joins
+`user_groups` so only assigned collections are visible.
+
+**Path A — `exportCollection`.** Gate is `:staff` (`group_types.ex:124-126`). Resolver
+`lib/glific_web/resolvers/groups.ex:36-38` passes the client id straight through.
+`Groups.export_collection/1` (`lib/glific/groups.ex:177-190`) queries `ContactGroup` joined to
+`Contact`, selecting `[c.name, c.phone]` with **no** `Repo.add_permission` call. Its immediate
+neighbour `get_group!/1` (`groups.ex:166-172`) *does* call it — the omission is visible in a
+five-line diff.
+
+**Path B — `organizationExportData`.** Gate is `:staff` (`organization_types.ex:325-330`). Resolver
+`lib/glific_web/resolvers/partners.ex:160-164` calls `Export.export_data(user.organization_id, …)`.
+`lib/glific/partners/export.ex` builds **raw SQL** (`sql/3` at `:157-166`, `SELECT JSON_AGG(t) FROM
+(SELECT * …)`), so it bypasses Ecto entirely — `prepare_query` and `add_permission` are both
+structurally out of the picture. `@tables` (`export.ex:13-25`) covers `contacts`, `messages`,
+`messages_media`, `locations`, `flows`, `flow_results`, `groups`, `interactive_templates`,
+`organizations`, `organization_data`, `profiles`. `SELECT *` on `contacts` and `messages` means full
+phone numbers, contact `fields` JSONB, and message bodies.
+
+**Correction to stated impact.** The report says "cross-tenant" is not claimed, and that is right —
+but state it positively, because it is the difference between a High and a Critical: both paths are
+**org-scoped**. Path B interpolates `user.organization_id` from the session
+(`export.ex:169-174`); Path A runs through `prepare_query` on `ContactGroup`, which carries
+`organization_id`. The finding is **intra-tenant privilege bypass**: a restricted staff member reads
+beneficiary PII for the whole organization instead of only their assigned collections. The report's
+own note that credentials and users are not in `@tables` is correct (`export.ex:13-25`).
+
+Rate limiting is absent — `export.ex:41` carries the comment `# Add a rate limiter here, once per
+minute or so per organization`, unimplemented. The 500-row cap (`export.ex:44-45`) is per call, with
+a client-controlled `offset`, so it bounds nothing.
+
+---
+
+## Cross-cutting observation
+
+The five findings are three distinct failure modes, not five instances of one:
+
+1. **No input-content authorization** (finding 1) — the operation is gated, the *payload* is not.
+2. **Silent omission of a non-mandatory check** (findings 2 and 5) — `add_permission` and the
+   resolver-level role comparison are opt-in calls, so forgetting them fails open and looks
+   identical to code that never needed them.
+3. **A second, ungated door to the same resource** (findings 3 and 4) — global-prefix tables escape
+   `prepare_query`; REST routes escape `Authorize`.
+
+Mechanisms for each are in Report 3.

--- a/plans/rbac-audit/02-deep-scan.md
+++ b/plans/rbac-audit/02-deep-scan.md
@@ -1,0 +1,471 @@
+# Report 2 — Deep scan: additional RBAC gaps across backend and frontend
+
+**Scope:** systematic sweep beyond the 5 reported findings — GraphQL gate inventory, REST surface, public endpoints, and frontend page/API consistency.
+**Status of this file:** backend + REST sections are complete and independently verified. Frontend consistency matrix is appended at the end when the frontend sweep lands.
+
+> **Status:** the `collectionStats` cross-tenant leak below, plus `bspbalance`, the inverted phone
+> redaction, and the export gates, are **FIXED** (Report 3, "Fix 0"). Still open: the 29 ungated
+> REST routes (§A), the 17 ungated subscriptions (§G2), unsigned BSP webhooks (§D), the
+> `add_permission` gaps for Messages/Profiles (§H), and the frontend route-tree issues (§F).
+> Line numbers describe the code **as audited**.
+
+## The single most severe finding: `collectionStats` is a cross-tenant read at `:staff`
+
+This is more severe than any of the five reported findings, and no reported finding covers it.
+
+`lib/glific_web/schema/search_type.ex:192-197` declares `arg(:organization_id, non_null(:id))` and
+gates the field at `:staff`. The resolver (`lib/glific_web/resolvers/searches.ex:48-50`) destructures
+that client-supplied id and passes it through **without any comparison to `user.organization_id`**:
+
+```elixir
+def collection_stats(_, %{organization_id: org_id}, _) do
+  {:ok, CollectionCount.collection_stats([org_id], true)}
+end
+```
+
+`Partners.org_id_list/2` (`lib/glific/partners.ex:1395-1403`) simply integer-casts whatever list it
+is handed. `contact_organization_query/1` (`:1410-1417`) then filters `c.organization_id in
+^org_id_list` — the *attacker's* list. And the execution disables the tenant backstop outright,
+`lib/glific/searches/collection_count.ex:86-93`:
+
+```elixir
+|> Repo.all(skip_organization_id: true)
+```
+
+**Impact:** any `:staff` user in any tenant reads contact statistics — All / Unread / Not-responded /
+Not-replied / Optin / Optout counts — for **any other organization on the platform**, by passing that
+org's id. Org ids are small sequential integers. `prepare_query` cannot save this because
+`skip_organization_id: true` is explicit.
+
+**Why this class was missed:** `Middleware.AddOrganization` uses `Map.put_new/3`
+(`lib/glific_web/schema/middleware/add_organization.ex:37`), so a **client-supplied
+`organization_id` argument always wins** over the injected one. Every operation that declares
+`arg(:organization_id, …)` must therefore re-pin it in the resolver. `Resolvers.Billings`
+does this correctly via `target_org_id/2` (`billings.ex:131-133`, glific_admin only);
+`collection_stats` is the one non-`glific_admin` operation that declares the arg and does not.
+
+**Recommended action: fix this first.** The patch is two lines — ignore the arg and use
+`user.organization_id` — and it closes a genuine cross-tenant data leak.
+
+---
+
+## Headline numbers
+
+| Metric | Value | Source |
+|---|---|---|
+| GraphQL fields across `*_queries`/`*_mutations`/`*_subscriptions` | 343 | full schema parse |
+| Gated with `middleware(Authorize, …)` | 325 | — |
+| **Ungated** | **18** (1 query + 17 subscriptions) | see section G |
+| Gate distribution | 154 `:staff` · 118 `:manager` · 30 `:admin` · 23 `:glific_admin` | — |
+| Uses of `:any` / `:none` gates | **0** | two branches of `valid_role?/2` are dead code |
+| REST routes behind `:api_protected` with a role check | **0 of 29** | section A |
+| Tests asserting schema-wide gate coverage | **0** | `test/glific_web/schema/middleware/` holds only `require_feature_flag_test.exs` |
+
+Two structural facts underpin everything below, both verified:
+
+- **There is no default gate.** `lib/glific_web/schema.ex:265` applies only `AddOrganization`,
+  `SafeResolution`, and the error middlewares. A field without an explicit `Authorize` line is
+  reachable by any authenticated user, role `:none` included.
+- **A `:none` user is rejected by every gated field.** `authorize.ex:39-40` handles the `:staff` and
+  `:none` *thresholds* in one clause, but that clause requires the caller to hold one of
+  `[:glific_admin, :admin, :manager, :staff]` — which `:none` does not. This matters for reading the
+  rest of the report: the 18 **ungated** fields and the 29 REST routes are the only places a `:none`
+  principal gets through, which is precisely what makes them worth the attention below.
+
+---
+
+## A. The REST surface has no role enforcement at all — 29 routes
+
+This generalizes reported finding 4 from one scope to the whole non-GraphQL surface.
+
+### The pipeline is presence-only
+
+`lib/glific_web/router.ex:50-53` — `:api_protected` runs `Pow.Plug.RequireAuthenticated` plus
+`GlificWeb.ContextPlug`. `RequireAuthenticated` halts if and only if `current_user == nil`.
+`ContextPlug` (`lib/glific_web/plugs/context_plug.ex:22-40`) puts the user into the process
+dictionary and the Absinthe context — it **reads no roles and rejects nobody**.
+
+So for REST, "authenticated" is the entire authorization model. A `:none` token and a
+`:glific_admin` token are indistinguishable to every controller.
+
+A grep for `valid_role?|Authorize|roles|:admin|:manager|:staff` across all REST controllers returns
+exactly one hit — `flow_editor_controller.ex:212`, the literal string `roles: ["send", "receive"]`
+inside a static WhatsApp-channel JSON blob. **There is no role logic in any REST controller.**
+
+### REST vs GraphQL gate delta (verified)
+
+Every row requires only a valid token over REST:
+
+| REST action | file:line | GraphQL equivalent | GraphQL gate | Delta |
+|---|---|---|---|---|
+| `POST /flow-editor/revisions/*` `save_revisions` | `flow_editor_controller.ex:564` | `update_flow` / `publish_flow` | **`:manager`** | **any role → `:manager` write** |
+| `GET /flow-editor/sheets` | `:606` | `sheets` | **`:manager`** | any role → `:manager` read (incl. Sheet URLs) |
+| `POST /flow-editor/fields` | `:137` | `create_contacts_field` | **`:manager`** | any role → `:manager` write |
+| `GET /flow-editor/fields` | `:104` | `contacts_fields` | **`:manager`** | any role → `:manager` read |
+| `POST /flow-editor/groups` | `:63` | `create_group` | **`:manager`** | any role → `:manager` write |
+| `POST /flow-editor/labels` | `:188` | *no create mutation exists* | n/a | write reachable **only** via ungated REST |
+| `GET /flow-editor/revisions/*`, `/flows/*` | `:553`, `:509` | `flow` / `flows` | `:staff` | any role → `:staff` |
+| `GET /flow-editor/recents/*`, `/activity` | `:628`, `:466` | — | — | verbatim recent end-user message text |
+| `GET /flow-editor/users`, `/recipients` | `:91`, `:415` | `users` / `contacts` | `:staff` | any role → `:staff` |
+| `POST /flow-editor/flow-attachment` | `:587` | `upload_media` | `:staff` | uploads to the org's GCS bucket |
+| `POST /api/v1/get-embed-token` | `superset_controller.ex:19` | — | — | feature-flag check only, no role |
+
+### Two additional defects inside these actions (verified in source)
+
+**A1 — `get_flow_revision/2` ignores the flow it is given.** `lib/glific/flows.ex:455-458`:
+
+```elixir
+def get_flow_revision(_flow_uuid, revision_id) do
+  revision = Repo.get!(FlowRevision, revision_id)
+```
+
+The first parameter is discarded. Cross-org access is still blocked by `prepare_query` (org is set
+by `Plug.put_organization` on every request), but **any revision id within the org is readable
+regardless of the flow named in the path**, and ids are sequential integers.
+
+**A2 — `save_revisions` is an unvalidated overwrite primitive.** `flow_editor_controller.ex:564-568`
+passes the entire request body into `Flows.create_flow_revision/2`, which resolves the target flow
+*solely* from `definition["uuid"]` (`flows.ex:465`) and inserts with no shape validation. Any
+authenticated user of the org can overwrite the draft definition of any flow in that org.
+
+This is the mechanism behind reported finding 4. I still have not reproduced the draft-trigger
+*execution* step, so the confirmed claim remains "unauthorized write of flow drafts", not
+"arbitrary WhatsApp send".
+
+### A3 — the actor in finding 4 is confirmed, with a nuance worth stating
+
+Verified at `lib/glific_web/controllers/api/v1/session_controller.ex:16-22`: login checks
+`%Organization{status: :active}` and the password. **There is no role check on login.** Confirmed at
+`lib/glific/users/user.ex:82-111`: the `users` table has **no `is_active`/`disabled`/`suspended`
+column** — `confirmed_at` exists but is never consulted on any auth path.
+
+So "revoked" in Glific means *demoted to `:none`*, and a `:none` user can always re-login and obtain
+a token that satisfies `:api_protected`. Demotion via `add_role_ids` does kill existing sessions
+(`lib/glific/users.ex:118-122`), but the user simply logs in again. The only true revocation is
+deletion.
+
+---
+
+## B. Session invalidation is conditional — a new finding
+
+`lib/glific/users.ex:116-122`:
+
+```elixir
+if validate_add_role_ids?(attrs) ||
+     updated?(user.is_restricted, attrs[:is_restricted]) ||
+     validate_delete_role_ids?(attrs) do
+  GlificWeb.APIAuthPlug.delete_all_user_sessions(@pow_config, user)
+end
+```
+
+Sessions are purged only when `add_role_ids`, `delete_role_ids`, or `is_restricted` changed — **not
+when the bare `roles` field changed**, which `users_types.ex:81` exposes as a first-class input and
+`User.update_fields_changeset` casts directly (`user.ex:150-160`).
+
+Combined with token caching — `APIAuthPlug.create/3` stores the **whole `%User{}` struct, roles
+included**, in `CredentialsCache` (`api_auth_plug.ex:79-83`), and `get_credentials/3` returns it
+verbatim with no DB reload (`:33-43`), TTL 30 minutes (`:45`) — this produces two symmetric bugs:
+
+- **Demotion doesn't take effect.** `updateUser(roles: ["none"])` with no `add_role_ids` strips a
+  user's privileges in the DB while their existing token keeps presenting `admin`/`manager` to the
+  `Authorize` middleware for up to 30 minutes.
+- **Escalation is delayed, not prevented.** The same caching is why reported finding 1 says "after
+  re-login". It is a 30-minute delay on an attack, not a control.
+
+---
+
+## C. Six additional backend issues found while tracing
+
+**C1 — `check_access_role/2` fails open to `:manager`.** `lib/glific/users.ex:157-164` ends with
+`true -> ["manager"]`. Any custom role whose label doesn't match one of five hardcoded strings
+silently grants legacy `:manager`.
+
+**C2 — the super-admin label never matches.** The same `cond` tests `"Glific Admin"` (with a space,
+`users.ex:162`) but the role is seeded as `"Glific_admin"` (underscore,
+`lib/glific/seeds/seeds_dev.ex:1804`). That branch is unreachable, so a Glific_admin dynamic-role
+assignment falls through to the C1 fallback and yields `:manager`.
+
+**C3 — the dynamic-role system covers list queries only.** `AccessControl.check_access/2` is called
+from exactly three sites: `Groups.list_groups` (`groups.ex:63`), `Triggers` (`triggers.ex:345`),
+`Flows.list_flows` (`flows.ex:45`). The by-id accessors are bare `Repo.get!`:
+`Flows.get_flow!/1` (`flows.ex:219-223`) and `Triggers.get_trigger!/1` (`triggers.ex:312-316`).
+**A user filtered out of the list can still fetch the object by id.**
+
+**C4 — dynamic roles no-op unless a flag is on.** `check_access/2` short-circuits on
+`Flags.get_roles_and_permission(organization)` (`access_control.ex:260`,
+`lib/glific/misc/flags.ex:172`), a FunWithFlags check that is off by default. It *also* requires
+`organization_role?/1` (`:270-274`), which returns true only when the user holds **none** of
+Admin/Manager/Staff. The entire subsystem is inert for every standard-role user.
+
+**C5 — `languages` is not the only global-prefix table.** The `@schema_prefix "global"` escape in
+`prepare_query` (`repo_helpers.ex:383-384`) means any such table loses tenant scoping. Finding 3
+covers `languages`; the same class needs an audit for every other global table, since the GraphQL
+gate is the sole control.
+
+**C6 — feature-flag and dashboard UIs sit behind one shared password.** `/feature-flags`
+(`router.ex:38-41`) exposes the FunWithFlags admin UI — **read and write** — and `/dashboard`
+(`:97`) exposes LiveDashboard, both gated by `Plug.BasicAuth` with a single global
+username/password (`:232-236`). No per-user attribution, no org scoping. Whoever holds it can flip
+`roles_and_permission` (C4) for any org.
+
+---
+
+## D. Public endpoints — writes with no authenticity check
+
+Verified: `grep -rn "signature|hmac|secure_compare|x-api-key" lib/glific_web/providers/` returns
+**zero hits across the entire provider tree.**
+
+| Endpoint | Accepts | Check | Verdict |
+|---|---|---|---|
+| `POST /gupshup/*`, `/gupshup-enterprise/*`, `/maytapi/*` (`router.ex:117-121`) | Inbound messages + billing/template events. `Shunt.build_context` installs the **org root user** as the `Repo` current_user (`providers/gupshup/plugs/shunt.ex:20-24`), then dispatches on attacker-controlled `params["type"]` | **NONE** | **Unauthenticated writes executing as root user** |
+| `POST /webhook/flow_resume` (`:130`) | Resumes a parked flow in the subdomain's org | **NONE** | Unauthenticated flow control |
+| `POST /kaapi/*` (`:135-140`) | LLM callbacks written into Assistants / PromptGenerator / AIEvaluations state | **NONE** — the module documents its own posture as "request_id treated as an unguessable token" | Unauthenticated writes |
+| `POST /api/v1/onboard/update-registration-details` (`:74`) | **Mutates registration data of any `org_id` the caller supplies**, running as that org's root user (`onboard_controller.ex:33-40`) | **NONE** — no captcha, no token, no ownership check. `get_registration/1` is `Repo.fetch_by(Registration, id: registration_id)` (`registrations.ex:34-36`), a sequential integer | **Cross-tenant write via IDOR** |
+| `GET /webhook/exotel/optin` (`:131`) | Opts a phone in and starts a flow | Caller's phone must match an org exotel credential | Weak, parameters guessable |
+| `POST /webhook/stripe` (`:129`) | Billing events | **Signature verified** (`plugs/stripe_webhook.ex`) | OK |
+| `POST /dify/chatbot-diagnose` (`:144`) | Table/query spec | **Shared secret via `Plug.Crypto.secure_compare`, fails closed** (`chatbot_controller.ex:59-68`) | OK |
+
+Stripe and Dify show the codebase knows how to verify a webhook. The BSP providers — the
+highest-volume, highest-trust inbound path — simply don't.
+
+Note `POST /api/v1/registration/reset-password` (`:68`) resets a password and mints a token on OTP
+alone, with **no org-status check** — bypassing the suspended-org gate that `session_controller.ex`
+applies to normal login.
+
+---
+
+## E. Frontend — session storage and the trust boundary
+
+`glific-frontend/src/services/AuthService.tsx:108-122` stores the user object, roles included, in
+**`localStorage`** under `glific_user`; `getUserSession('roles')` reads it back. `context/role.ts:15-24`
+memoizes that into a module-level `role` array driving every UI decision.
+
+This is the correct pattern *provided* the UI is treated as cosmetic and the server re-authorizes —
+which is exactly why the REST gap in section A matters. `localStorage` is attacker-editable, so
+`role.ts` is not a security boundary and cannot be made into one. The relevant question is never
+"can a user edit localStorage to see the admin menu" (yes, and that is fine) but "does every API
+that menu reaches enforce the role server-side" — and for the 29 REST routes, no.
+
+Two structural notes:
+
+- **`AuthenticatedRoute.tsx:237-268` swaps whole route trees**, not per-route guards. A user is
+  either in `staffRoutes` or the full `adminRoutes`. There is no per-page role declaration, so
+  page-level authorization cannot be expressed even where the API distinguishes.
+- **`checkDynamicRole()` routes any non-standard role into the full admin tree**
+  (`role.ts:33-44`, `AuthenticatedRoute.tsx:242`). Combined with C1 — where a custom role grants
+  backend `:manager` — a custom role gets the admin UI *and* manager API rights, neither of which
+  its definition necessarily specifies.
+
+---
+
+## G. The 18 ungated GraphQL fields
+
+**G1 — `bspbalance` (`provider_types.ex:62-65`) is the only ungated query in the schema.** Verified:
+the field has a `resolve` and no `middleware` line, while every sibling in the same file
+(`provider` `:58`, `providers` `:71`, `count_providers` `:78`, `quality_rating` `:84`) is `:admin`.
+Resolver → `Partners.get_bsp_balance/1` scoped to the caller's own org, so this is an
+**intra-org information leak** (BSP wallet balance readable by any authenticated user, including
+`:none`), not a cross-tenant one. Low severity, trivial fix, and a clean example of gate-by-omission.
+
+**G2 — all 17 subscriptions are ungated, and their `config` is a tenant check, not a role check.**
+`Schema.config_fun/2` (`schema.ex:310-318`) compares `args.organization_id` to
+`user.organization_id` and nothing else. Two consequences:
+
+- A `:none` user — rejected by every gated query — can subscribe to `received_message` /
+  `sent_message` and receive the org-wide firehose of inbound and outbound WhatsApp traffic.
+  **This is the most direct contradiction of the role model in the schema**: the same data that
+  `messages` gates at `:staff` streams to anyone with a token.
+- Subscription topics are org-wide, so **`is_restricted` staff receive messages for contacts outside
+  their assigned collections**. The row-level `add_permission` model does not apply to the pubsub
+  path at all — making this a third bypass of the same boundary as reported finding 5.
+
+## H. Row-level permission (`add_permission`) — omissions beyond finding 5
+
+Reported finding 5 named two bypasses. The full picture: `add_permission` is an **opt-in call at
+each query site**, and entire resource families never call it.
+
+| Resource | Coverage | Notable omissions |
+|---|---|---|
+| Contacts | good (6 sites) | `list_contact_history`/`count_contact_history` (`contacts.ex:1009,1024`) — restricted staff read any contact's flow/state history. Resolvers for `update_contact`/`delete_contact`/`contact_location` (`resolvers/contacts.ex:58,119,131`) use raw `Repo.fetch_by`, bypassing `Contacts.get_contact!/1` — org-scoped but **not** collection-scoped |
+| Groups | good (5 sites) | `export_collection` (finding 5); `list_organizations_groups` passes `skip_permission = true` hard-coded (`groups.ex:94`) |
+| Searches | good (7 sites) | — |
+| **Messages** | **none — no `Messages.add_permission` exists** | `list_messages/1` with `filter: {contact_id: N}` (`messages.ex:44`) and `Conversations.do_get_message_ids/3` (`conversations.ex:37-46`) reach message bodies directly. Restricted staff are filtered at the *contact* layer for `search`, but not on these paths |
+| **Profiles** | **none** | `list_profiles/1` accepts `filter: {contact_id: …}` (`profiles.ex:32-39`); `get_profile!/1` is a bare `Repo.get!` |
+| **Export** | **none — raw SQL** | finding 5, path B |
+| Flows/Triggers | different system (`AccessControl`) | see C3/C4 — list-only, and inert by default |
+
+The pattern: **five different mechanisms guard row-level access** (`add_permission`,
+`AccessControl.check_access`, per-field resolvers, resolver-level `valid_role?`, and the
+`upload_contacts` boolean at `contacts/import.ex:79`), none mandatory, each covering a different
+subset of resources.
+
+## I. Gate-consistency anomalies worth triaging
+
+Verified spot-checks; full table in the inventory. These are cases where sibling operations on the
+same resource carry different gates, which usually signals an oversight rather than a decision:
+
+| Anomaly | Detail |
+|---|---|
+| **`contact.phone` redaction is inverted** | `contact_types.ex:50-56`: `if Enum.member?(user.roles, :staff) && !user.is_restricted, do: {:ok, ""}, else: {:ok, contact.phone}`. An **unrestricted** staff member gets `""`; a **restricted** staff member — the more limited role — gets the real phone number. Verified verbatim. Almost certainly a logic bug, and it undercuts finding 5's redaction argument |
+| `clear_messages` `:staff` vs `delete_message` `:admin` | `message_types.ex:325` vs `:319` — bulk destructive delete is gated *lower* than single delete |
+| Assistant CRUD at `:staff` | `assistant_types.ex:188-235` — 7 mutations incl. `set_live_version`, changing production bot behaviour and incurring provider cost; every comparable config CRUD (flow, trigger, sheet, form) is `:manager` |
+| Collection membership at `:staff` | `contact_group_types.ex:88-100` — collection membership **is** the row-level ACL, so staff can mutate the boundary that restricts them, while the `user_groups` half is `:manager` (`user_group_types.ex:59-71`) |
+| `create_access_role`/`update`/`delete` at `:manager` | `role_types.ex:68-81` — managers edit the org's own authorization config |
+| `organization_export_config` at `:staff` | `organization_types.ex:332` — runs `skip_organization_id: true` against `information_schema.columns`: platform-wide schema disclosure |
+| Certificate/template create-vs-delete splits | `certificate_types.ex:40,47` vs `:55`; `session_template_type.ex:226` vs `:238` |
+
+---
+
+## F. Frontend page ↔ API consistency matrix
+
+### F0. How frontend authorization actually works
+
+`AuthenticatedRoute.tsx:230-268` performs a **whole-tree swap**, not per-route guards:
+
+```
+:237  if (userRole.includes('Staff'))            route = staffRoutes        // 8 paths
+:241  if (checkDynamicRole() || Manager || Admin || Glific_admin)
+                                                 route = adminRoutes        // ~70 paths
+```
+
+The second `if` has no `else` and runs after the first, so it **overwrites** it. Three consequences:
+
+1. There are exactly **two** authorization levels in the UI — staff, and everything else. Manager,
+   Admin, Glific_admin and every dynamic role receive an **identical** route tree.
+2. A user holding `Staff` *plus* a dynamic role gets the **Staff menu** (`role.ts:60-63` runs after
+   the Dynamic block and last-write-wins) but the **admin route tree**. Menus and routes disagree by
+   construction.
+3. A user whose only role is `None` matches neither branch — `route` stays `undefined` and renders a
+   blank page rather than redirecting.
+
+**The menu is the only thing that distinguishes Manager from Glific_admin.** `getMenus`
+(`menu.ts:350-356`) filters by `roles.includes(role)`, and `menu.ts:294,301` restrict Organizations
+and Consulting to `['Glific_admin']`. But filtering a menu does not unregister a route.
+
+### F1. The core finding — SaaS-operator pages render for Managers and dynamic roles
+
+Every row: the route is registered for the role, the menu link is hidden, and typing the URL mounts
+the container and fires its queries. The backend gate is the **only** control.
+
+| Route | Menu says | Actually reachable by | Operations fired | Backend gate | Net |
+|---|---|---|---|---|---|
+| `/organizations` | Glific_admin only (`menu.ts:294`) | Manager, Admin, **dynamic** | `q:organizations`, `q:countOrganizations`, `m:deleteOrganization`, `m:updateOrganizationStatus` | `:glific_admin` (`organization_types.ex:284,292,390,396`) | **Backend holds.** Page renders, data calls fail |
+| `/consulting-hours/` | Glific_admin only (`:301`) | Manager, Admin, **dynamic** | `q:consultingHours`, `m:create/update/deleteConsultingHour` | `:glific_admin` (`consulting_hour_types.ex:78-121`) | **Backend holds** |
+| `/organizations/:id/extensions` | no entry at all | Manager, Admin, **dynamic** | `m:createExtension`, `m:deleteExtension`, `q:getOrganizationExtension` | `:glific_admin` (`extension_types.ex:45-80`) | **Backend holds** |
+| `/organizations/:id/customer` | no entry | Manager, Admin, **dynamic** | `m:createBilling`, `m:updateBilling`, `q:getOrganizationBilling` | `:admin` (`billing_types.ex:77-115`) | **Gap for dynamic roles** — see F2 |
+| `/settings/billing` | adminLevel (`:318`) | **Manager**, dynamic | `m:createBillingSubscription`, `m:updatePaymentMethod`, `q:customerPortal` | `:admin` (`billing_types.ex:64-121`) | Backend holds |
+| `/settings/:type` (providers) | adminLevel | **Manager**, dynamic | `m:createCredential`, `m:updateCredential`, `q:credential` | `:admin` (`credential_types.ex:41-55`) | Backend holds |
+| `/settings/organization` | adminLevel | **Manager**, dynamic | `m:updateOrganization`, `q:organization` | `:admin` / `:staff` | Backend holds on write |
+| `/contact-management` | adminLevel (`:258`) | **Manager**, dynamic | `m:ImportContacts`, `m:MoveContacts` | `:manager` (`contact_types.ex:302,309`) | **REAL GAP — manager passes** |
+| `/staff-management` | Manager+ but **dynamic excluded** (`:256`) | **dynamic roles** | `q:users`, `m:deleteUser`, `m:updateUser` | `:staff` / `:manager` | **REAL GAP — see F2** |
+| `/role`, `/role/add` | Manager+ but **dynamic excluded** (`:292`) | **dynamic roles** | `m:createAccessRole`, `m:updateAccessRole`, `m:deleteAccessRole` | `:manager` (`role_types.ex:68-81`) | **REAL GAP — see F2** |
+
+**The reassuring half:** for genuinely SaaS-operator-scoped data (organizations, consulting,
+extensions), the backend gate is `:glific_admin` and holds. These rows are UX bugs — a Manager sees
+a page that then errors — not privilege escalation.
+
+**The dangerous half:** `contact-management`, `staff-management` and `role` are gated `:manager` or
+lower on the backend, and the frontend hides them from a population the backend admits.
+
+### F2. Dynamic roles are the systematic hole
+
+`checkDynamicRole()` (`role.ts:33-44`) returns `true` for **any** role label outside
+`['Admin','Manager','Staff','None','Glific_admin']`, which routes it into the full admin tree
+(`AuthenticatedRoute.tsx:242`). Meanwhile `menu.ts` deliberately excludes `'Dynamic'` from Staff
+management (`:256`) and Roles (`:292`) — the two pages that edit authorization itself.
+
+Chained with backend finding **C1** (`users.ex:163`: any unrecognized role label falls through to
+`["manager"]`), a custom role gets:
+
+- the **full admin UI** (frontend, via `checkDynamicRole`),
+- **`:manager` backend rights** (via the `check_access_role` fallback),
+- reaching `/staff-management` and `/role` — pages the menu says dynamic roles must not see,
+- where `updateUser` is gated `:manager` and, per **finding 1**, does not validate the requested role.
+
+That is a complete escalation chain from "custom role with no permissions defined" to `:glific_admin`,
+using only pages the UI renders.
+
+### F3. The client-side escalation guard is broken by a string literal
+
+`StaffManagement.tsx:147-155` filters the assignable-role dropdown:
+
+```js
+if (isManager) rolesList = rolesList.filter((i) => i.label !== 'Admin' && i.label !== 'Glific admin');
+if (isAdmin)   rolesList = rolesList.filter((i) => i.label !== 'Glific admin');
+```
+
+`rolesList` is built from the server's `accessRoles` (`:140-145`), where the seeded label is
+**`"Glific_admin"`** with an underscore (`seeds_dev.ex:1804`). `'Glific admin'` with a space never
+matches. **The Glific_admin option remains in the dropdown for both Manager and Admin.**
+
+The sibling check in `StaffManagementList.tsx:82` uses `'Glific_admin'` correctly, so the *list*
+hides edit/delete on Glific_admin rows while the *form* offers the role. Two files, same concept,
+different literal.
+
+Combined with reported finding 1, this means the escalation does not require a crafted GraphQL
+mutation — **a Manager can select "Glific_admin" from a dropdown in the normal staff-edit UI.**
+This materially raises finding 1's exploitability from "attacker with API knowledge" to "any manager
+who opens the staff page."
+
+### F4. Where the frontend hides a control the backend would allow
+
+These are real authorization decisions made **only** in the client. The mutation is gated at or
+below the user's role, so a direct API call succeeds:
+
+| Control hidden | Where | Hidden from | Mutation | Backend gate |
+|---|---|---|---|---|
+| Collection create/edit/delete buttons | `CollectionList.tsx:150,158`; `List.tsx:600` | Staff, **and Manager** (`manageCollections` is Admin-only, `role.ts:72`) | `createGroup`/`updateGroup`/`deleteGroup` | `:manager` — **a Manager can call these** |
+| Saved-search save/update | `ChatConversations.tsx:210` | Staff, Manager | `createSavedSearch`/`updateSavedSearch` | `:manager` |
+| Simulator panel | `ChatInterface.tsx:72-74` | Staff | `simulatorGet`/`simulatorRelease` | `:staff` — **staff can call these directly** |
+| "Make primary" phone | `PhonesPanel.tsx:36,89` | non-Admin | `setPrimaryPhone` | `:admin` — backend holds |
+| Reconnect / sync phone | `PhoneManagement.tsx:50,119` | non-Manager | `reconnectWaManagedPhone` | `:admin` / `:manager` |
+| Roles multi-select on every form | `FormLayout.tsx:533-546` | non-Admin — and **Glific_admin too**, since `.includes('Admin')` doesn't match `'Glific_admin'` | `addRoleIds`/`deleteRoleIds` on many mutations | varies |
+
+The `simulatorGet` and collections rows are the notable ones: the UI is the *only* thing preventing
+a staff/manager user from performing an action the API permits.
+
+### F5. Client-side role state is fully attacker-controlled and never refreshed
+
+Verified (`AuthService.tsx:108-122`, `role.ts:4-24`): roles come from a `GET_CURRENT_USER` response
+at login, are written to **`localStorage.glific_user`** as plaintext JSON, and are memoized into a
+module-level `role` array on first read.
+
+Editing that key to `{"roles":[{"label":"Glific_admin"}]}` and reloading yields the full admin tree
+and the Glific_admin menu **with the original, legitimately-issued token still attached**. This is
+expected for any SPA and is *not itself* the finding — it is the reason every row in F1/F4 must be
+judged solely on its backend gate.
+
+**No role refresh exists.** `setUserSession` is called from exactly one place (`Login.tsx:68`).
+`MyAccount.tsx:286` re-reads the current user but writes only to the Apollo cache. So when an admin
+changes a user's role, that user keeps their old route tree and menus **until they log out and back
+in** — which compounds backend finding B (the server-side session cache also isn't invalidated on a
+bare `roles` write). Demotion is not enforced on either side until the user voluntarily re-logs in.
+
+### F6. Feature flags are not authorization
+
+`/ticket`, `/certificates`, `/whatsapp-forms/*`, `/group/*`, `/ai-evaluations` are hidden from the
+menu by `getOrganizationServices(...)` flags but remain **registered routes**. `organizationServices`
+is likewise localStorage-backed with a one-write lifecycle (`Login.tsx:53`). Only
+`/ai-evaluation-v2` has an actual element-level guard (`AIEvaluationGuard.tsx:12`) — the single
+route in the app that guards itself.
+
+Backend-side, `RequireFeatureFlag` gates ~13 fields (`ai_evaluation_types.ex`,
+`session_template_type.ex:218`, `prompt_generator_types.ex:72`). These are toggles layered *on top
+of* an `Authorize` gate, not a substitute — correct as used, worth stating because the frontend
+treats flags and roles interchangeably.
+
+### F7. Summary — where page and API disagree
+
+| Category | Count | Risk |
+|---|---|---|
+| Pages reachable by a role the backend rejects | 8 routes | Low — UX bug; backend holds (`:glific_admin`/`:admin`) |
+| **Pages reachable by a role the backend *accepts*, hidden only by menu** | **3** (`contact-management`, `staff-management`, `role`) | **High — real bypass for Manager/dynamic** |
+| Controls hidden client-side but permitted by API | 6 classes | Medium — `simulatorGet`, collections CRUD |
+| Client-side escalation guards that don't work | 1 (`StaffManagement.tsx:150`) | **High — raises finding 1's exploitability** |
+| Routes with element-level guards | **1 of ~70** | Structural |
+
+**The one-line answer to "if the API blocks staff, is the page also hidden?"** — mostly yes for
+`staff`, because staff get a physically different 8-route tree. But the question doesn't generalize:
+there is no per-page role declaration anywhere, so for the ~70 admin-tree routes the frontend makes
+**no distinction at all** between Manager, Admin, Glific_admin, and arbitrary dynamic roles. Menu
+filtering is the only differentiator, and it is cosmetic.

--- a/plans/rbac-audit/03-architecture.md
+++ b/plans/rbac-audit/03-architecture.md
@@ -1,0 +1,342 @@
+# Report 3 — RBAC architecture: assessment and recommendations
+
+**Constraint honoured:** the five roles (`glific_admin > admin > manager > staff > none`) stay
+exactly as they are. Nothing here proposes new roles or renames existing ones. Everything is about
+*how* roles are represented, stored, enforced, and tested.
+
+---
+
+## Part 1 — Diagnosis: why these bugs are structural, not incidental
+
+Every finding in Reports 1 and 2 traces to one of six architectural properties. None is a
+"someone forgot" bug; each is the predictable output of the design.
+
+### 1.1 Authorization is opt-in, and forgetting it fails open
+
+`lib/glific_web/schema.ex:265` applies `AddOrganization`, `SafeResolution` and the error middlewares
+to every query and mutation — **but no `Authorize`**. A field with no middleware line is reachable by
+any authenticated user.
+
+The same property holds at the row level: `Repo.add_permission/3` is a call you remember to make
+(15 sites), and `AccessControl.check_access/2` likewise (3 sites). Code that omits them is
+indistinguishable from code that never needed them.
+
+> **Findings explained:** 5 (`export_collection`, `export_data`), G1 (`bspbalance`), G2 (17
+> subscriptions), H (Messages/Profiles have no `add_permission` at all).
+
+### 1.2 There are two enforcement surfaces and only one enforces roles
+
+| Surface | Gate | Fields/routes |
+|---|---|---|
+| GraphQL (Absinthe) | per-field `middleware(Authorize, role)` | 325 gated |
+| REST (Phoenix router) | `Pow.Plug.RequireAuthenticated` — presence only | **29, none role-gated** |
+
+`:api_protected` (`router.ex:50-53`) halts only when `current_user == nil`. `ContextPlug`
+(`context_plug.ex:22-40`) then populates the process dictionary without consulting roles. The
+`/flow-editor` scope reaches flows, contact fields and collections that GraphQL gates at `:manager`.
+
+> **Findings explained:** 4, and the whole of Report 2 §A.
+
+### 1.3 Roles are stringly-typed at every boundary
+
+There is no single source of truth for a role name. The same concept appears as:
+
+| Representation | Where |
+|---|---|
+| `:glific_admin` atom | `user_roles_enum` (`ecto_enums.ex:96-100`) |
+| `"Glific_admin"` string | seeded `roles.label` (`seeds_dev.ex:1804`) |
+| `"Glific Admin"` string | `check_access_role/2` (`users.ex:162`) — **never matches** |
+| `'Glific admin'` string | `StaffManagement.tsx:150,153` — **never matches** |
+| `'Glific_admin'` string | `StaffManagementList.tsx:82`, `role.ts:28` — matches |
+| free-form `:role_label` scalar | GraphQL input (`generic_types.ex:124-149`) |
+
+Three of six spellings are wrong, in three different files, written by different people. This is the
+signature of stringly-typed authorization: **the compiler cannot help, and a typo silently disables
+a security control.**
+
+> **Findings explained:** C1/C2 (backend fallback to `:manager`), F3 (frontend dropdown guard
+> broken), and finding 1's parsing step (`:role_label` accepts any existing atom).
+
+### 1.4 Two role systems write to one column
+
+The legacy enum (`users.roles`) and the dynamic-role tables (`roles`, `user_roles`) are not
+alternatives — they are two writers to the same field. `Users.update_user/2` derives the enum from
+`add_role_ids` via `check_access_role/2` **only when `add_role_ids` is present and non-empty**
+(`users.ex:146-166`). Omit that key and the client's raw `roles` list flows into the changeset.
+
+The dynamic system is also far narrower than it appears: `check_access/2` is called from 3 list
+queries only, no-ops unless the default-off `roles_and_permission` flag is set, and additionally
+requires the user to hold *none* of Admin/Manager/Staff (`access_control.ex:270-274`). For every
+standard-role user it is inert.
+
+> **Findings explained:** 1 (the bypass path), C3, C4, F2.
+
+### 1.5 Authorization asks the wrong question in the one place it is relational
+
+`Authorize.valid_role?/2` answers "does the caller out-rank threshold X?" — correct for gating an
+operation. `Resolvers.Users.update_user/3` reuses it as
+`valid_role?(current_user.roles, hd(target.roles))` — "does the caller out-rank this *person*?"
+
+That is a different question, and it protects the target's **current** identity while ignoring the
+**requested** one. There is no framework concept of "authorize the contents of this input", so the
+only such check in the codebase was hand-rolled, and hand-rolled it wrong. `hd/1` also silently
+ignores every role after the first, which is why role-stacking (`["staff","glific_admin"]`) defeats it.
+
+> **Findings explained:** 1, 2 (the same check simply absent).
+
+### 1.6 Identity is a 30-minute snapshot with no revocation
+
+`APIAuthPlug.create/3` stores the **entire `%User{}` struct, roles included**, in `CredentialsCache`
+(`api_auth_plug.ex:79-83`); `get_credentials/3` returns it verbatim with no DB reload, TTL 30 min.
+Invalidation is conditional (`users.ex:116-122`) and **skips bare `roles` writes**.
+
+There is no user-level `is_active`/`suspended` column at all (`user.ex:82-111`); login checks only
+org status and password. "Revoking" a user means demoting them to `:none` — after which they can
+still log in and still satisfy `:api_protected`.
+
+The frontend mirrors this exactly: roles are written to `localStorage` once at login
+(`Login.tsx:68`) and never refreshed.
+
+> **Findings explained:** B, F5, and the "after re-login" caveat in finding 1.
+
+---
+
+## Part 2 — Recommended architecture
+
+Ordered by (security value ÷ disruption). Items 1–3 are small and close real holes; 4–6 are the
+structural work; 7 is the thing that prevents regression.
+
+### Fix 0 — Immediate patches — ✅ IMPLEMENTED
+
+All nine shipped. Full suite green; `mix format`, Credo `--strict`, and `tsc --noEmit` clean.
+
+| # | Fix | Where | Status |
+|---|---|---|---|
+| 0.1 | `collection_stats` now ignores the client `organization_id` and uses `user.organization_id` | `resolvers/searches.ex:48-50` | ✅ |
+| 0.2 | `update_user` validates the **requested** roles via `can_grant_roles?/2`, covering both `roles` and `add_role_ids` | `resolvers/users.ex:79-110` | ✅ |
+| 0.3 | `delete_user` gained the target-role check | `resolvers/users.ex:141-151` | ✅ |
+| 0.4 | Language create/update/delete → `:glific_admin` | `language_types.ex:70-92` | ✅ |
+| 0.5 | `export_collection` enforces `has_permission?/1`; the three `organization_export_*` fields → `:admin` | `groups.ex:177-180`, `organization_types.ex:324-346` | ✅ |
+| 0.6 | Role literals centralised in `Glific.Users.Roles`; frontend compares separator/case-insensitively | `users/roles.ex`, `StaffManagement.tsx:147-158` | ✅ |
+| 0.7 | `bspbalance` gated | `provider_types.ex:62-66` | ✅ |
+| 0.8 | Inverted phone redaction corrected | `contact_types.ex:50-56` | ✅ |
+| 0.9 | Sessions invalidate on **any** role change, including a bare `roles` write | `users.ex:117-125` | ✅ |
+
+**Two deviations from the original recommendation, both deliberate:**
+
+- **0.7 gated at `:staff`, not `:admin`.** The wallet-balance banner (`WalletBalance.tsx`, rendered
+  from `SideDrawer.tsx:71`) and `StatusBar.tsx` query `bspbalance` for **every** role. `:admin`
+  would have broken the UI for staff and managers. `:staff` closes the `:none` hole — the actual
+  finding — without regression.
+- **`can_manage_user?/2` uses `>=`, not `>`.** Strict `>` would stop an admin editing a peer admin,
+  which the previous code allowed and which the suite depends on. Escalation is blocked by
+  `can_grant_roles?/2` instead; `can_manage_user?/2` only prevents reaching *up* the hierarchy.
+
+**Beyond the nine, delivered in the same pass:**
+
+- Root-caused **C1/C2** properly rather than patching the literal: `check_access_role/2` no longer
+  falls through to `["manager"]` for an unrecognised label — an unmatched custom role now yields
+  `["none"]` (fails closed), and label→role mapping lives in one place.
+- **Role stacking is fixed.** `highest_rank/1` replaces `hd/1`, so `["staff", "glific_admin"]` can
+  no longer hide a high-privilege role behind a low-privilege first element.
+- New `Glific.Users.Roles` module — single source of truth for the hierarchy, with the middleware
+  delegating to it. This is the first slice of **Fix 1**, kept in `lib/glific/` to respect the
+  layering rule that business logic must not depend on the web layer.
+
+**Regression tests added (12), all verified to fail against the unpatched code:**
+
+| Test | Asserts |
+|---|---|
+| `roles_test.exs` (14 cases) | hierarchy, fail-closed unknown roles, role stacking, grant/manage rules |
+| `user_test.exs` — "manager cannot grant a role above their own" | `["glific_admin"]`, `["Admin"]`, `["Staff","Admin"]` all rejected; DB unchanged |
+| `user_test.exs` — "manager cannot escalate their own role" | self-escalation rejected |
+| `user_test.exs` — "manager cannot delete a user of a higher role" | admin survives |
+| `language_test.exs` — "a manager cannot create, update or delete a language" | all three return `Unauthorized` |
+| `groups_test.exs` — "export_collection raises when not assigned" | restricted staff blocked |
+| `StaffManagment.test.tsx` (2 cases) | Glific_admin absent from the dropdown for Admin **and** Manager |
+
+The pre-existing test that **pinned the vulnerability** (`user_test.exs:209`, a manager setting
+`roles: ["Staff","Admin"]` and asserting success) was rewritten to use a grantable role. The
+frontend mocks never contained a Glific_admin row at all, so the old "Admin should not see Glific
+admin" test passed vacuously; a new mock (`getRoleNamesWithGlificAdminMock`) makes it meaningful.
+
+**Every new test was verified to fail against the unpatched code.** This mattered: the first draft
+of the frontend test passed both before *and* after the fix, and the first draft of the
+`export_collection` test silently ran as an admin. Both would have been worthless as regression
+tests. Two lessons worth carrying into phase 2:
+
+- **A security test that has never failed proves nothing.** Assert the negative case against the
+  old code before trusting it. Half of my first-draft tests were vacuous.
+- **`with` and no `else` fails open — the same shape as the bugs being fixed.** The
+  `export_collection` test copied a pattern from `contacts_test.exs` that resolves a seeded user;
+  in `groups_test.exs` that describe block has no `setup`, so the fetch failed, the
+  `put_current_user` never ran, and the test passed as an admin. Fixed by constructing the
+  restricted user explicitly with `Fixtures.user_fixture/1` rather than depending on ambient seed
+  state. This is worth a lint: **a test that establishes a security precondition must assert that
+  the precondition took effect.**
+
+### Verification performed
+
+| Gate | Result |
+|---|---|
+| `mix compile --warnings-as-errors` | clean (it caught the now-unreachable `do_update_user(false, …)` clause) |
+| Full backend suite | 3001 tests, 0 failures on an uncontended run |
+| Targeted suites (users, groups, language, contacts, roles) | 90 tests, 0 failures |
+| `mix format --check-formatted` | clean |
+| `mix credo --strict` | clean (one pre-existing TODO elsewhere) |
+| `mix dialyzer` | passed — 34 errors, all 34 pre-existing skips, none new |
+| Frontend `vitest` (StaffManagement) | 57 tests, 0 failures |
+| Frontend `tsc --noEmit` | clean |
+
+Note on flakiness: intermediate full-suite runs reported 12/22/35 failures while Dialyzer or a
+second suite ran concurrently. Those were `:eaddrinuse` (port contention on `GlificWeb.Endpoint`)
+and `DBConnection.ConnectionError` (pool exhaustion) — infrastructure, not logic. Confirmed by
+re-running uncontended.
+
+### Fix 1 — Make roles a type, not a string
+
+Introduce one module that owns the role vocabulary and the hierarchy:
+
+```elixir
+defmodule Glific.Roles.Role do
+  @roles [:glific_admin, :admin, :manager, :staff, :none]
+  @rank  %{glific_admin: 4, admin: 3, manager: 2, staff: 1, none: 0}
+
+  def all, do: @roles
+  def rank(role), do: Map.fetch!(@rank, role)
+  def parse("Glific_admin"), do: {:ok, :glific_admin}   # every spelling, one place
+  ...
+  def at_least?(user_roles, threshold),
+    do: Enum.any?(user_roles, &(rank(&1) >= rank(threshold)))
+  def highest(user_roles), do: Enum.max_by(user_roles, &rank/1)
+end
+```
+
+Then:
+- Replace `:role_label`'s free-form `safe_string_to_atom` parse with an **Absinthe enum**
+  (`enum_types.ex`), so `roles: ["glific_admin"]` is rejected at the schema boundary unless the value
+  is legal *and* the caller is authorized. This alone blocks finding 1's input vector.
+- Replace `hd(user.roles)` with `Role.highest/1` — kills the role-stacking bypass.
+- Delete `check_access_role/2`'s string `cond` and its `true -> ["manager"]` fallback. **Fail closed**
+  (`:none`) when a label doesn't resolve.
+- Export the same vocabulary to the frontend (generated constants file or a `roles` query) so no
+  `.tsx` file ever writes a role literal again.
+
+### Fix 2 — Make the gate mandatory, not opt-in
+
+Invert the default in `schema.ex`'s `middleware/3` callback:
+
+```elixir
+def middleware(middleware, field, %{identifier: type}) when type in [:query, :mutation] do
+  unless has_authorize?(middleware), do: raise "no Authorize gate on #{field.identifier}"
+  ...
+end
+```
+
+This is a **compile-time** check — a new field without a gate fails the build. Cheap, and it makes
+1.1 structurally impossible going forward. Apply the same to subscriptions, where all 17 are
+currently ungated (G2).
+
+If a hard raise is too disruptive initially, the same callback can inject a `:glific_admin` default
+for ungated fields — fail closed rather than open — and let the 18 known cases be fixed forward.
+
+### Fix 3 — Give REST the same gate
+
+Two options; recommend (a).
+
+**(a) A `RequireRole` plug**, used per-scope in the router:
+
+```elixir
+scope "/flow-editor", GlificWeb.Flows do
+  pipe_through([:api, :api_protected, {RequireRole, :manager}])
+```
+
+This puts REST and GraphQL on one hierarchy and one `Role` module. `/flow-editor` should be
+`:manager` — matching `update_flow`/`publish_flow` — with read-only actions at `:staff` if the
+editor needs them.
+
+**(b)** Move flow-editor operations to GraphQL. Correct long-term, but large; the embedded
+`@glific/flow-editor` library dictates the REST shape.
+
+Separately, and regardless: fix `get_flow_revision/2` to actually use its `flow_uuid` argument
+(`flows.ex:455`), validate the `save_revisions` payload, and add signature verification to the BSP
+webhooks (Stripe at `plugs/stripe_webhook.ex` is the in-repo model).
+
+### Fix 4 — Authorize *inputs*, not just operations
+
+The missing concept behind findings 1 and 2. Add an explicit rule for privilege-bearing fields:
+
+```elixir
+defmodule Glific.Users.Policy do
+  # may the actor assign this role?
+  def can_grant?(actor, requested), do: Role.at_least?(actor.roles, requested)
+  # may the actor act on this target at all?
+  def can_manage?(actor, target),
+    do: Role.rank(Role.highest(actor.roles)) > Role.rank(Role.highest(target.roles))
+end
+```
+
+`update_user` must satisfy **both**; `delete_user` must satisfy `can_manage?`. Note `can_manage?` uses
+strict `>`, which also fixes the self-escalation case that `valid_role?`'s `>=` semantics permit today.
+
+### Fix 5 — One row-level mechanism, applied at the context boundary
+
+Today five mechanisms coexist (`add_permission`, `AccessControl.check_access`, per-field resolvers,
+resolver-level `valid_role?`, the `upload_contacts` boolean). Consolidate:
+
+- Extend `add_permission` coverage to **Messages** and **Profiles** (currently zero), and to by-id
+  accessors — `get_flow!/1`, `get_trigger!/1`, `get_profile!/1` are bare `Repo.get!`.
+- Decide whether `AccessControl` replaces or supplements `add_permission`, then apply the winner to
+  reads **and** by-id fetches, not just list queries.
+- Apply row-level filtering to the **subscription** path, which currently bypasses it entirely (G2).
+- Route all reads through context functions; forbid `Repo.fetch_by` on resources in resolvers, where
+  it silently skips the context's permission logic (`resolvers/contacts.ex:58,119,131`).
+
+### Fix 6 — Make identity live, and make revocation real
+
+- **Re-read roles per request**, or store only `user_id` in the token and load the user. If the
+  30-minute cache must stay for performance, key it so any `users` row update busts it.
+- **Add a user-level `is_active` flag**, checked at login *and* per request. Today there is no way to
+  disable an account without deleting it.
+- **Client-side:** re-fetch `currentUser` on navigation or subscription reconnect and update
+  `localStorage`, so a demoted user's UI collapses without a manual logout.
+
+### Fix 7 — Test the policy, not the examples
+
+This is what would have caught all five findings, and it is the highest-leverage item in the report.
+
+There are currently **zero** tests asserting schema-wide gate coverage, and the existing user tests
+actively **pin the vulnerable behaviour** (`user_test.exs:209-236` asserts a manager can set
+`roles: ["Staff","Admin"]`). Those assertions must be inverted as part of fix 0.2.
+
+Add three mechanical tests:
+
+1. **Gate coverage** — walk the Absinthe schema via `__absinthe_type__(:query)` /`(:mutation)`
+   /`(:subscription)`; assert every field has an `Authorize` middleware. Maintain an explicit
+   allow-list so an intentional exception is a visible, reviewed line of code.
+2. **Gate snapshot** — assert the full `operation → role` map against a checked-in fixture. Any gate
+   change then shows up in a diff and must be justified in review. This is how `create_language`
+   sitting at `:manager` becomes visible.
+3. **Escalation matrix** — for each role pair (actor, target) × each of `updateUser`/`deleteUser`,
+   assert allow/deny. ~20 cases, table-driven.
+
+Plus a router test asserting every route in an authenticated scope pipes through a role plug.
+
+---
+
+## Part 3 — What to do, in order
+
+| Phase | Work | Why this order |
+|---|---|---|
+| **1. ✅ DONE** | Fix 0.1–0.9 + C1/C2 root cause + `Users.Roles` + 12 regression tests | Self-contained patches closing verified holes. 0.1 was a genuine cross-tenant leak |
+| **2. Next** | Fix 7 (tests 1 + 2) | Freezes the current gate map before refactoring, so later phases can't regress silently |
+| **3.** | Fix 2 (mandatory gate) + Fix 3 (REST plug) | Removes the two fail-open surfaces. Both are additive and low-risk |
+| **4.** | Fix 1 (`Role` module + GraphQL enum) + Fix 4 (input policy) | The typed-role refactor; enables deleting the string `cond`s |
+| **5.** | Fix 6 (live identity, `is_active`) | Touches auth and caching — do it with tests in place |
+| **6.** | Fix 5 (unify row-level) | Largest and least urgent; only affects restricted staff |
+
+**One-line summary:** the five roles are fine. The problems are that authorization is *optional*
+(nothing forces a gate), *stringly-typed* (typos silently disable it), *split across two surfaces*
+(REST has none), *operation-scoped only* (inputs are never authorized), and *snapshotted* (revocation
+doesn't take effect). Fixes 2, 1, 3, 4 and 6 address exactly those five properties — and fix 7 is
+what keeps them addressed.

--- a/test/glific/groups_test.exs
+++ b/test/glific/groups_test.exs
@@ -168,6 +168,23 @@ defmodule Glific.GroupsTest do
              }
     end
 
+    test "export_collection/1 raises when the user is not assigned to the collection", attrs do
+      group = group_fixture(attrs)
+      admin_user = Repo.get_current_user()
+
+      {:ok, restricted_user} =
+        Fixtures.user_fixture(%{roles: ["staff"]})
+        |> Users.update_user(%{is_restricted: true})
+
+      Repo.put_current_user(restricted_user)
+
+      assert_raise RuntimeError, fn ->
+        Groups.export_collection(group.id)
+      end
+
+      Repo.put_current_user(admin_user)
+    end
+
     test "load_group_by_label", attrs do
       group_fixture(attrs)
 

--- a/test/glific/users/roles_test.exs
+++ b/test/glific/users/roles_test.exs
@@ -1,0 +1,108 @@
+defmodule Glific.Users.RolesTest do
+  use ExUnit.Case, async: true
+
+  alias Glific.Users.Roles
+
+  describe "rank/1" do
+    test "orders the hierarchy" do
+      assert Roles.rank(:glific_admin) > Roles.rank(:admin)
+      assert Roles.rank(:admin) > Roles.rank(:manager)
+      assert Roles.rank(:manager) > Roles.rank(:staff)
+      assert Roles.rank(:staff) > Roles.rank(:none)
+    end
+
+    test "an unknown role ranks lowest so comparisons fail closed" do
+      assert Roles.rank(:not_a_role) == 0
+      assert Roles.rank("Custom Role") == 0
+      assert Roles.rank(nil) == 0
+    end
+
+    test "accepts the seeded labels, whatever the separator or case" do
+      for label <- ["Glific_admin", "Glific admin", "glific_admin", "GLIFIC ADMIN"] do
+        assert Roles.rank(label) == Roles.rank(:glific_admin)
+      end
+
+      assert Roles.rank("No access") == Roles.rank(:none)
+    end
+
+    # the :role_label scalar turns GraphQL input into a downcased atom, so an aliased
+    # spelling reaches us as :"glific admin" rather than :glific_admin
+    test "resolves aliased atoms, not just aliased strings" do
+      for role <- [:"glific admin", :glific_admin, :"GLIFIC ADMIN"] do
+        assert Roles.rank(role) == Roles.rank(:glific_admin)
+      end
+
+      assert Roles.rank(:"no access") == Roles.rank(:none)
+      refute Roles.can_grant_roles?([:manager], [:"glific admin"])
+      refute Roles.can_grant_roles?([:admin], [:"glific admin"])
+    end
+  end
+
+  describe "highest_rank/1" do
+    test "uses the maximum, not the first element" do
+      assert Roles.highest_rank([:staff, :glific_admin]) == Roles.rank(:glific_admin)
+      assert Roles.highest_rank([:glific_admin, :staff]) == Roles.rank(:glific_admin)
+    end
+
+    test "an empty or unexpected list ranks lowest" do
+      assert Roles.highest_rank([]) == 0
+      assert Roles.highest_rank(nil) == 0
+    end
+  end
+
+  describe "can_manage_user?/2" do
+    test "cannot reach up the hierarchy" do
+      refute Roles.can_manage_user?([:manager], [:admin])
+      refute Roles.can_manage_user?([:manager], [:glific_admin])
+      refute Roles.can_manage_user?([:staff], [:manager])
+    end
+
+    test "peers and lower ranks are manageable" do
+      assert Roles.can_manage_user?([:admin], [:admin])
+      assert Roles.can_manage_user?([:manager], [:staff])
+      assert Roles.can_manage_user?([:glific_admin], [:admin])
+    end
+
+    test "role stacking does not hide a high-ranked target" do
+      refute Roles.can_manage_user?([:manager], [:staff, :glific_admin])
+    end
+  end
+
+  describe "can_grant_roles?/2" do
+    test "nobody may grant a role above their own" do
+      refute Roles.can_grant_roles?([:manager], [:glific_admin])
+      refute Roles.can_grant_roles?([:manager], [:admin])
+      refute Roles.can_grant_roles?([:admin], [:glific_admin])
+    end
+
+    test "role stacking cannot smuggle a higher role past the check" do
+      refute Roles.can_grant_roles?([:manager], [:staff, :glific_admin])
+      refute Roles.can_grant_roles?([:manager], ["Staff", "Glific_admin"])
+    end
+
+    test "granting at or below your own rank is allowed" do
+      assert Roles.can_grant_roles?([:manager], [:staff])
+      assert Roles.can_grant_roles?([:manager], [:manager])
+      assert Roles.can_grant_roles?([:glific_admin], [:glific_admin])
+    end
+
+    test "an empty request is a no-op" do
+      assert Roles.can_grant_roles?([:staff], [])
+    end
+  end
+
+  describe "reserved/1" do
+    test "maps every seeded label to its legacy role" do
+      assert Roles.reserved("Admin") == :admin
+      assert Roles.reserved("Manager") == :manager
+      assert Roles.reserved("Staff") == :staff
+      assert Roles.reserved("No access") == :none
+      assert Roles.reserved("Glific_admin") == :glific_admin
+    end
+
+    test "a custom role is not reserved, so it grants no legacy privilege" do
+      assert Roles.reserved("Content Reviewer") == nil
+      assert Roles.reserved(nil) == nil
+    end
+  end
+end

--- a/test/glific_web/schema/contact_test.exs
+++ b/test/glific_web/schema/contact_test.exs
@@ -151,6 +151,13 @@ defmodule GlificWeb.Schema.ContactTest do
     assert fetched_contact["phone"] == ""
     assert fetched_contact["maskedPhone"] != contact.phone
 
+    # a restricted staff user is more limited, so it must not see more
+    {:ok, restricted_user} = Glific.Users.update_user(user, %{is_restricted: true})
+
+    result = auth_query_gql_by(:by_id, restricted_user, variables: %{"id" => contact.id})
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:data, "contact", "contact", "phone"]) == ""
+
     result = auth_query_gql_by(:by_id, user, variables: %{"id" => 123_456})
     assert {:ok, query_data} = result
 

--- a/test/glific_web/schema/language_test.exs
+++ b/test/glific_web/schema/language_test.exs
@@ -43,7 +43,7 @@ defmodule GlificWeb.Schema.LanguageTest do
     assert message == "Resource not found"
   end
 
-  test "create a language and test possible scenarios and errors", %{manager: user} do
+  test "create a language and test possible scenarios and errors", %{glific_admin: user} do
     result =
       auth_query_gql_by(:create, user,
         variables: %{
@@ -75,7 +75,7 @@ defmodule GlificWeb.Schema.LanguageTest do
     assert message =~ "has already been taken"
   end
 
-  test "update a language and test possible scenarios and errors", %{manager: user} do
+  test "update a language and test possible scenarios and errors", %{glific_admin: user} do
     label = "Klingon"
 
     result =
@@ -118,7 +118,7 @@ defmodule GlificWeb.Schema.LanguageTest do
     assert message =~ "has already been taken"
   end
 
-  test "delete a language", %{manager: user} do
+  test "delete a language", %{glific_admin: user} do
     # first create a language
     result =
       auth_query_gql_by(:create, user,
@@ -142,5 +142,36 @@ defmodule GlificWeb.Schema.LanguageTest do
 
     message = get_in(query_data, [:data, "deleteLanguage", "errors", Access.at(0), "message"])
     assert message == "Resource not found"
+  end
+
+  # languages is a global-prefix table shared by every tenant, so writes must not be
+  # reachable below :glific_admin
+  test "a manager cannot create, update or delete a language", %{manager: user} do
+    result =
+      auth_query_gql_by(:create, user,
+        variables: %{
+          "input" => %{"label" => "Klingon", "labelLocale" => "Klingon", "locale" => "kl_KL"}
+        }
+      )
+
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:errors, Access.at(0), :message]) == "Unauthorized"
+
+    {:ok, lang} = Glific.Repo.fetch_by(Glific.Settings.Language, %{label: "English"})
+
+    result =
+      auth_query_gql_by(:update, user,
+        variables: %{
+          "id" => lang.id,
+          "input" => %{"label" => "Pirate", "labelLocale" => "Pirate", "locale" => "pi_PI"}
+        }
+      )
+
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:errors, Access.at(0), :message]) == "Unauthorized"
+
+    result = auth_query_gql_by(:delete, user, variables: %{"id" => lang.id})
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:errors, Access.at(0), :message]) == "Unauthorized"
   end
 end

--- a/test/glific_web/schema/search_test.exs
+++ b/test/glific_web/schema/search_test.exs
@@ -41,12 +41,36 @@ defmodule GlificWeb.Schema.SearchTest do
   load_gql(:search_multi, GlificWeb.Schema, "assets/gql/searches/search_multi.gql")
   load_gql(:wa_search_multi, GlificWeb.Schema, "assets/gql/searches/wa_search_multi.gql")
 
+  load_gql(
+    :collection_stats,
+    GlificWeb.Schema,
+    "assets/gql/searches/collection_stats.gql"
+  )
+
   defp get_saved_search_list(org_id) do
     Searches.list_saved_searches(%{filter: %{organization_id: org_id}})
   end
 
   defp get_contacts_count(org_id) do
     Contacts.count_contacts(%{filter: %{organization_id: org_id}})
+  end
+
+  test "collectionStats is scoped to the session, not to the organization_id argument", %{
+    staff: user
+  } do
+    other_org =
+      Fixtures.organization_fixture(%{shortcode: "other_org", email: "other@org.test"})
+
+    Fixtures.contact_fixture(%{organization_id: other_org.id})
+
+    {:ok, query_data} =
+      auth_query_gql_by(:collection_stats, user,
+        variables: %{"organizationId" => "#{other_org.id}"}
+      )
+
+    stats = Jason.decode!(get_in(query_data, [:data, "collectionStats"]))
+    assert Map.keys(stats) == ["#{user.organization_id}"]
+    refute Map.has_key?(stats, "#{other_org.id}")
   end
 
   test "savedSearches field returns list of searches", %{staff: user} do

--- a/test/glific_web/schema/user_test.exs
+++ b/test/glific_web/schema/user_test.exs
@@ -206,12 +206,25 @@ defmodule GlificWeb.Schema.UserTest do
     assert message == "Resource not found"
   end
 
+  test "a manager cannot delete a user of a higher role", %{manager: user_auth} do
+    {:ok, admin} =
+      Repo.fetch_by(User, %{name: "NGO Admin", organization_id: user_auth.organization_id})
+
+    result = auth_query_gql_by(:delete, user_auth, variables: %{"id" => admin.id})
+    assert {:ok, query_data} = result
+
+    assert get_in(query_data, [:errors, Access.at(0), :message]) ==
+             "Does not have access to the user"
+
+    assert {:ok, _still_there} = Repo.fetch_by(User, %{id: admin.id})
+  end
+
   test "update a user and test possible scenarios and errors", %{manager: user_auth} do
     {:ok, user} =
       Repo.fetch_by(User, %{name: "NGO Staff", organization_id: user_auth.organization_id})
 
     name = "User Test Name New"
-    roles = ["Staff", "Admin"]
+    roles = ["Staff"]
 
     group = Fixtures.group_fixture()
 
@@ -239,7 +252,6 @@ defmodule GlificWeb.Schema.UserTest do
 
     # update user groups
     group_2 = Fixtures.group_fixture(%{label: "new group"})
-    roles = ["admin"]
 
     result =
       auth_query_gql_by(:update, user_auth,
@@ -258,6 +270,62 @@ defmodule GlificWeb.Schema.UserTest do
     user_result = get_in(query_data, [:data, "updateUser", "user"])
 
     assert user_result["groups"] == [%{"id" => "#{group_2.id}"}]
+  end
+
+  test "a manager cannot grant a role above their own", %{manager: user_auth} do
+    {:ok, user} =
+      Repo.fetch_by(User, %{name: "NGO Staff", organization_id: user_auth.organization_id})
+
+    for requested <- [["glific_admin"], ["Admin"], ["Staff", "Admin"], ["Glific admin"]] do
+      result =
+        auth_query_gql_by(:update, user_auth,
+          variables: %{"id" => user.id, "input" => %{"roles" => requested}}
+        )
+
+      assert {:ok, query_data} = result
+
+      assert get_in(query_data, [:errors, Access.at(0), :message]) ==
+               "Does not have access to assign this role"
+    end
+
+    {:ok, db_user} = Repo.fetch_by(User, %{id: user.id})
+    assert db_user.roles == [:staff]
+  end
+
+  # a role id that does not resolve used to fall through to an empty label list, which
+  # check_access_role maps to the lowest role - so a bogus id silently demoted the target
+  test "an unresolvable add_role_id is refused rather than demoting the user", %{
+    manager: user_auth
+  } do
+    {:ok, user} =
+      Repo.fetch_by(User, %{name: "NGO Staff", organization_id: user_auth.organization_id})
+
+    for role_ids <- [["999999"], ["999999", "1000000"]] do
+      result =
+        auth_query_gql_by(:update, user_auth,
+          variables: %{"id" => user.id, "input" => %{"addRoleIds" => role_ids}}
+        )
+
+      assert {:ok, query_data} = result
+      assert get_in(query_data, [:errors, Access.at(0), :message]) == "Resource not found"
+    end
+
+    {:ok, db_user} = Repo.fetch_by(User, %{id: user.id})
+    assert db_user.roles == [:staff]
+    refute db_user.roles == [:none]
+  end
+
+  test "a manager cannot escalate their own role", %{manager: user_auth} do
+    result =
+      auth_query_gql_by(:update, user_auth,
+        variables: %{"id" => user_auth.id, "input" => %{"roles" => ["glific_admin"]}}
+      )
+
+    assert {:ok, query_data} = result
+    assert get_in(query_data, [:errors, Access.at(0), :message]) != nil
+
+    {:ok, db_user} = Repo.fetch_by(User, %{id: user_auth.id})
+    refute :glific_admin in db_user.roles
   end
 
   test "update a user of higher role should give an errors", %{manager: user_auth} do


### PR DESCRIPTION
## Summary

A security audit reported five RBAC findings. Verifying them from source surfaced **three shared structural causes** rather than five isolated bugs, plus **one critical cross-tenant read that was not reported**. This PR closes ten issues; the roles themselves (`glific_admin > admin > manager > staff > none`) are unchanged — only how they are represented, stored, enforced and tested.

Full reviewer notes are in `fixes.md`; the underlying analysis is in `plans/rbac-audit/`.

### Root cause

The hierarchy had **no single owner** — `Authorize`, `Users.check_access_role` and the frontend each re-derived it, with three different spellings of `glific_admin`. And `updateUser` checked the target's *current* role instead of the *requested* one: a "may I touch this row" check answering "may I write this value".

`Glific.Users.Roles` is now the single source of truth. It fails closed (unknown label ranks 0; it previously fell back to `manager`) and splits the decision into `can_manage_user?/2` (whose row) and `can_grant_roles?/2` (which value). That split is what makes the fix stricter while still letting an admin edit a peer admin.

### Fixes

| Sev | What | Where |
|---|---|---|
| **CRIT** | `collectionStats` took `organization_id` **from query args** at `:staff` → any staff user read any tenant's data. Now pinned to the session. *(Found during the scan, not reported.)* | `resolvers/searches.ex` |
| **CRIT** | `updateUser` let a manager set `roles: ["Admin"]` / `["glific_admin"]`, including on themselves. Requested roles now validated from **both** `roles` and `add_role_ids`. | `resolvers/users.ex` |
| **HIGH** | `Roles.rank/1`'s atom clause never consulted the alias map. The `:role_label` scalar downcases input to an atom, so `"Glific Admin"` arrived as `:"glific admin"` → rank 0 → a manager passed the escalation check. Only the Ecto enum stopped the write, as a MatchError 500. | `users/roles.ex` |
| HIGH | `deleteUser` had no role check — a manager could delete their org's admins. | `resolvers/users.ex` |
| HIGH | `languages` is a `global`-prefix table (writes hit **every tenant**) but was writable at `:manager`. | `schema/language_types.ex` |
| HIGH | Three org exports at `:staff` use **raw SQL**, so neither `prepare_query` nor `add_permission` applies. | `schema/organization_types.ex` |
| HIGH | `check_access_role` fell back to `["manager"]` for any unrecognised label, and its `"Glific Admin"` clause was dead code (seeded label is `Glific_admin`). | `glific/users.ex` |
| MED | A bare `roles` write did not invalidate sessions. Cached credentials embed roles with a 30-min TTL, so **demoting a compromised account left it privileged for 30 minutes**. | `glific/users.ex` |
| MED | An unresolvable `add_role_ids` (another org's role, or nonexistent) produced `[]`, which `can_grant_roles?` permits and `check_access_role` maps to the lowest role — a manager could **silently demote** anyone to `none`, and a cross-org `user_roles` row was written. | `resolvers/users.ex` |
| MED | `export_collection` skipped `Repo.add_permission` — restricted staff exported unassigned collections. | `glific/groups.ex` |
| MED | Contact phone redaction ran **backwards** (`staff && !is_restricted`): restricted users saw *more*. | `schema/contact_types.ex` |
| LOW | `bspbalance` had no gate at all. | `schema/provider_types.ex` |

**Two hunks are chained:** fixing the `Glific_admin` typo turns dead code into a live escalation path via `add_role_ids`, which the `updateUser` change closes. Please review them together.

### Judgement calls worth a reviewer's eye

- Managers **and admins** can no longer manage languages. If admins should be able to, the right answer is per-org languages, not a lower gate — a product call.
- `bspbalance` is gated `:staff`, not the `:admin` originally proposed: `WalletBalance` renders in the side drawer for every role. Tightest gate that doesn't regress the UI; still closes `:none`.
- `can_manage_user?` uses `>=`, not `>` — strict `>` would block an admin editing a peer admin, which existing behaviour and tests rely on.
- `skip_organization_id: true` is **deliberately left** in `CollectionCount.make_result/3`: `MinuteWorker` aggregates all orgs in one grouped query with no org in the process dict, so auto-scoping there would raise and kill the 5-minute cron.

### Not fixed — remaining risk

- **Audit finding 4** (`/flow-editor/*` unauthorized) needs a `RequireRole` plug: `Pow.Plug.RequireAuthenticated` is presence-only, so *every* REST route is role-blind. Its two claimed exploit chains were **not reproduced**; reported as a route-level gap only.
- `AddOrganization` uses `Map.put_new`, so a client-supplied `organization_id` still wins wherever a resolver reads it from args.
- 17 fields remain ungated (all subscriptions). Nothing makes a missing gate fail to compile — that is how `bspbalance` happened.
- `createAccessRole` sits at `:manager` and accepts `is_reserved`, letting a manager write to the table that drives role assignment. The label mapping neutralises the escalation, but it deserves a look.

Corrections to the audit's ratings: finding 2 is intra-org, not platform-wide; finding 5 is intra-tenant, not cross-tenant; finding 1 was **understated**.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. — _no new API; one `.gql` asset added for the previously untested `collectionStats` field_
- [x] Coding standard and conventions are followed.

## Notes

**Verification**

| Gate | Result |
|---|---|
| `mix test` | **41 doctests, 3004 tests, 0 failures**, 7 skipped |
| `mix credo --strict` | clean |
| `mix format` (changed files) | clean |
| **E2E against a live server** | all 10 fixes exercised over real HTTP + GraphQL — **all pass** |

16 regression tests added, **each verified to fail before its fix**.

**Please read the deletions in `user_test.exs`.** An assertion that a manager *can* set `roles: ["Staff", "Admin"]` was passing — the suite was green *because* the escalation worked. Any RBAC change requiring no test edits deserves suspicion.

**E2E highlights** (more trustworthy than the unit tests here):
- `collectionStats(organizationId: "2")` as org-1 staff, with org 2 holding 7 contacts, returned keys `['1']` only.
- Session invalidation: with a raw-SQL demotion the old token still returned `roles:["Admin"]` and 200 on the admin-gated export — the stale-privilege window is real. Through `updateUser`, `fetchUserSessions` went 2→0 and the old token got **401 immediately**. A name-only write does not purge, so there is no over-invalidation.

**Trap for future tests here:** a 401 has no GraphQL `errors` array, so a naive harness reads it as success — and any `updateUser` purges that user's sessions, which can kill a token mid-test and make later assertions "pass" against `data: null`. Assert on HTTP status, not just `errors`.

**Two pre-existing master failures that will show red on this PR**

Neither is caused by this branch; both are deliberately left out to keep the diff scoped.

1. **`mix dialyzer`** — 1 unskipped error at `lib/glific/assistants.ex:528:exact_eq` (`do_update_assistant_config/3`, the `evaluationv2` code from #5544/#5513). This branch does not touch that file, and `assistants.ex` contains no reference to `Users`, `Roles`, `Authorize` or roles at all, so there is no path from these changes to that warning. It is not in `.dialyzer_ignore.exs`. A full PLT rebuild also reported `Unnecessary Skips: 16`, so the ignore file has drifted and could use a separate cleanup. Everything this PR changed is clean.
2. **`mix format --check-formatted`** — fails on `test/glific_web/schema/session_template_test.exs` and `test/glific/flows/message_vars_parser_test.exs`. Both are unformatted on `master`; running bare `mix format` reformats them and pulls unrelated noise into any diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
