### PR TITLE
feat(webhooks): flow-webhook smoke tests + sentinel-tagged callbacks (#5383)

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -79,6 +79,9 @@ oban_crontab = [
   {"58 23 * * *", Glific.Jobs.MinuteWorker, args: %{job: :daily_tasks}},
   {"0 3 * * *", Glific.Jobs.MinuteWorker, args: %{job: :tracker_tasks}},
   {"*/5 * * * *", Glific.Jobs.MinuteWorker, args: %{job: :five_minute_tasks}},
+  # Flow-webhook uptime probe. No-op unless a canary org is configured (staging only) — see
+  # Glific.Flows.Webhooks.Core.SmokeTest.run_scheduled/0.
+  {"*/15 * * * *", Glific.Jobs.MinuteWorker, args: %{job: :webhook_smoke}},
   {"0 0 * * *", Glific.Jobs.MinuteWorker, args: %{job: :update_hsms}},
   # 21:00 Sat UTC is  02:30 SAT IST, running the msg purging a day before other DB purges
   # to test this in isolation

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -492,6 +492,11 @@ defmodule Glific.Flows.Webhook do
   end
 
   @spec resume(non_neg_integer(), map(), map(), Contact.t()) :: :ok
+  # A smoke-test probe has no parked flow to resume: the outbound {:ok, ack} already proved the
+  # node is alive, so drop the callback here — after signature validation — before Dispatcher.callback
+  # (which would count it against `flow_webhook_count`), the flow resume, or any resume-error report.
+  defp resume(_organization_id, _result, %{"smoke_test" => true}, _contact), do: :ok
+
   defp resume(organization_id, result, response, contact) do
     maybe_update_log(response["webhook_log_id"], callback_log_message(result, response))
 
@@ -588,6 +593,9 @@ defmodule Glific.Flows.Webhook do
   copied into the supervised resume task.
   """
   @spec maybe_upload_tts_audio(map()) :: map()
+  # Smoke-test callbacks are dropped in resume/4, so never spend a GCS upload on their audio.
+  def maybe_upload_tts_audio(%{"smoke_test" => true} = response), do: response
+
   def maybe_upload_tts_audio(%{"output_type" => "audio", "message" => base64_audio} = response) do
     {:ok, organization_id} = response["organization_id"] |> Glific.parse_maybe_integer()
 

--- a/lib/glific/flows/webhooks/core/smoke_test.ex
+++ b/lib/glific/flows/webhooks/core/smoke_test.ex
@@ -1,0 +1,181 @@
+defmodule Glific.Flows.Webhooks.Core.SmokeTest do
+  @moduledoc """
+  Active uptime probe for the flow-webhook nodes. Calls each of the five current implementations'
+  `call/2` with fixture input against a sandbox/staging org and reports whether the node's external
+  dependencies are alive. This complements — it does not replace — the passive per-node alerting on
+  the `"flow_webhook_count"` AppSignal distribution:
+
+    * this probe catches "dependency down but no live traffic" (a silent outage),
+    * the `"flow_webhook_count"` alerts catch elevated error rates in real traffic.
+
+  Async nodes (STT, TTS, filesearch-gpt, voice-filesearch-gpt) dispatch to Kaapi and return
+  `{:ok, ack}` once the request is accepted; the callback that Kaapi POSTs back carries a
+  `smoke_test` sentinel so the flow-resume path drops it before it counts against
+  `"flow_webhook_count"` (see `Glific.Flows.Webhooks.Kaapi.build_flow_resume_metadata/6` and
+  `Glific.Flows.Webhook.resume/4`). So a probe run never pollutes the production metric.
+
+  ## Running
+
+  From a `mix` shell / CI against a staging DB:
+
+      mix glific.webhooks.smoke_test --org 1
+
+  From a Gigalixir `remote_console` against the running staging app:
+
+      Glific.Flows.Webhooks.Core.SmokeTest.run_all(1)
+      Glific.Flows.Webhooks.Core.SmokeTest.run_all(1, %{assistant_id: "asst_123", audio_url: "https://.../sample.ogg"})
+
+  ## Fixtures
+
+  `geolocation` uses static coordinates. The async nodes need org-specific fixtures — a reachable
+  `audio_url`, a configured `assistant_id`, and a `flow_id`/`contact_id` to sign the callback with.
+  Supply them via the `overrides` map or `config :glific, #{inspect(__MODULE__)}, ...`; a node whose
+  fixture is missing surfaces the node's own typed error rather than crashing the run.
+
+  ## Alerting (ops-side)
+
+  The `"flow_webhook_count"` distribution is already tagged `%{webhook_name, status}`. Configure a
+  per-`webhook_name` AppSignal trigger that alerts when
+  `sum(status: "failure") / sum(all) > X%` over an N-minute window (X TBD with ops). No code change
+  is needed — the metric dimensions already exist.
+  """
+
+  alias Glific.Flows.Webhooks.{
+    FilesearchGpt,
+    Geolocation,
+    SpeechToText,
+    TextToSpeech,
+    VoiceFilesearchGpt
+  }
+
+  alias Glific.Repo
+  alias Glific.SafeLog
+
+  # Ordered so the printed summary reads sync-first, then the Kaapi async nodes.
+  @webhooks [
+    {"geolocation", Geolocation},
+    {"speech_to_text", SpeechToText},
+    {"text_to_speech", TextToSpeech},
+    {"filesearch-gpt", FilesearchGpt},
+    {"voice-filesearch-gpt", VoiceFilesearchGpt}
+  ]
+
+  # Bengaluru — a stable coordinate that reverse-geocodes to a real address.
+  @default_lat "12.9716"
+  @default_long "77.5946"
+  @default_text "Glific webhook smoke test."
+  @default_question "What is Glific?"
+  @default_source_language "english"
+  @default_target_language "english"
+
+  @type outcome :: :ok | {:error, term()}
+
+  @doc """
+  Run every flow-webhook smoke check for `org_id`, returning `%{node_name => :ok | {:error, reason}}`.
+
+  `overrides` (atom-keyed) supplies the org-specific fixtures — `:assistant_id`, `:audio_url`,
+  `:flow_id`, `:contact_id`, and optionally `:lat`/`:long`/`:text`/`:question`/`:source_language`/
+  `:target_language` — falling back to `config :glific, #{inspect(__MODULE__)}` and then to defaults.
+  """
+  @spec run_all(non_neg_integer(), map()) :: %{String.t() => outcome()}
+  def run_all(org_id, overrides \\ %{}) when is_integer(org_id) do
+    Repo.put_organization_id(org_id)
+    config = build_config(org_id, overrides)
+    ctx = %{organization_id: org_id}
+
+    results =
+      Map.new(@webhooks, fn {name, module} ->
+        {name, run_one(module, fixtures(name, config), ctx)}
+      end)
+
+    print_summary(org_id, results)
+    results
+  end
+
+  @spec run_one(module(), map(), map()) :: outcome()
+  defp run_one(module, fields, ctx) do
+    case module.call(fields, ctx) do
+      {:ok, _value} -> :ok
+      {:error, _type, reason} -> {:error, reason}
+      {:snooze, seconds} -> {:error, "snoozed (#{seconds}s) — rate limited or transient"}
+      other -> {:error, SafeLog.safe_inspect(other)}
+    end
+  rescue
+    exception -> {:error, Exception.message(exception)}
+  end
+
+  @spec fixtures(String.t(), map()) :: map()
+  defp fixtures("geolocation", config), do: %{"lat" => config.lat, "long" => config.long}
+
+  defp fixtures("speech_to_text", config),
+    do: Map.put(flow_fields(config), "speech", config.audio_url)
+
+  defp fixtures("text_to_speech", config),
+    do: Map.put(flow_fields(config), "text", config.text)
+
+  defp fixtures("filesearch-gpt", config) do
+    Map.merge(flow_fields(config), %{
+      "assistant_id" => config.assistant_id,
+      "question" => config.question
+    })
+  end
+
+  defp fixtures("voice-filesearch-gpt", config) do
+    Map.merge(flow_fields(config), %{
+      "speech" => config.audio_url,
+      "assistant_id" => config.assistant_id,
+      "question" => config.question,
+      "source_language" => config.source_language,
+      "target_language" => config.target_language
+    })
+  end
+
+  # Mirrors a real flow-webhook payload: string keys, ids as strings. The `smoke_test` sentinel
+  # rides through to the Kaapi callback so it is dropped before counting.
+  @spec flow_fields(map()) :: map()
+  defp flow_fields(config) do
+    %{
+      "organization_id" => to_string(config.org_id),
+      "flow_id" => to_string(config.flow_id),
+      "contact_id" => to_string(config.contact_id),
+      "smoke_test" => true
+    }
+  end
+
+  @spec build_config(non_neg_integer(), map()) :: map()
+  defp build_config(org_id, overrides) do
+    env = Application.get_env(:glific, __MODULE__, [])
+
+    %{
+      org_id: org_id,
+      lat: fetch(overrides, env, :lat, @default_lat),
+      long: fetch(overrides, env, :long, @default_long),
+      text: fetch(overrides, env, :text, @default_text),
+      question: fetch(overrides, env, :question, @default_question),
+      source_language: fetch(overrides, env, :source_language, @default_source_language),
+      target_language: fetch(overrides, env, :target_language, @default_target_language),
+      audio_url: fetch(overrides, env, :audio_url, nil),
+      assistant_id: fetch(overrides, env, :assistant_id, nil),
+      flow_id: fetch(overrides, env, :flow_id, nil),
+      contact_id: fetch(overrides, env, :contact_id, nil)
+    }
+  end
+
+  @spec fetch(map(), keyword(), atom(), term()) :: term()
+  defp fetch(overrides, env, key, default),
+    do: Map.get(overrides, key) || Keyword.get(env, key) || default
+
+  @spec print_summary(non_neg_integer(), %{String.t() => outcome()}) :: :ok
+  defp print_summary(org_id, results) do
+    IO.puts("\nFlow-webhook smoke test  org_id=#{org_id}")
+
+    Enum.each(@webhooks, fn {name, _module} ->
+      case Map.fetch!(results, name) do
+        :ok -> IO.puts("  ✓ #{name}")
+        {:error, reason} -> IO.puts("  ✗ #{name}  —  #{reason}")
+      end
+    end)
+
+    :ok
+  end
+end

--- a/lib/glific/flows/webhooks/core/smoke_test.ex
+++ b/lib/glific/flows/webhooks/core/smoke_test.ex
@@ -25,12 +25,28 @@ defmodule Glific.Flows.Webhooks.Core.SmokeTest do
       Glific.Flows.Webhooks.Core.SmokeTest.run_all(1)
       Glific.Flows.Webhooks.Core.SmokeTest.run_all(1, %{assistant_id: "asst_123", audio_url: "https://.../sample.ogg"})
 
-  ## Fixtures
+  Recurringly, via the `Glific.Jobs.MinuteWorker` cron fan-out (a `"webhook_smoke"` branch wrapped in
+  `Appsignal.CheckIn.cron/2`). `run_scheduled/0` is config-gated: it runs only where a canary org is
+  configured, so it is a no-op on environments (e.g. production) that don't set it. The check-in
+  heartbeat alerts if the job stops running; each failed node is reported to AppSignal via
+  `Glific.log_error/1`.
+
+  ## Fixtures / config
 
   `geolocation` uses static coordinates. The async nodes need org-specific fixtures — a reachable
   `audio_url`, a configured `assistant_id`, and a `flow_id`/`contact_id` to sign the callback with.
-  Supply them via the `overrides` map or `config :glific, #{inspect(__MODULE__)}, ...`; a node whose
-  fixture is missing surfaces the node's own typed error rather than crashing the run.
+  Supply them via the `overrides` map or, for the scheduled run, via application config on the
+  staging deployment (a node whose fixture is missing surfaces its own typed error rather than
+  crashing the run):
+
+      config :glific, #{inspect(__MODULE__)},
+        org_id: 1,
+        assistant_id: "asst_123",
+        audio_url: "https://.../sample.ogg",
+        flow_id: 42,
+        contact_id: 99
+
+  `org_id` is what gates the scheduled run: absent (the default), `run_scheduled/0` does nothing.
 
   ## Alerting (ops-side)
 
@@ -90,6 +106,32 @@ defmodule Glific.Flows.Webhooks.Core.SmokeTest do
 
     print_summary(org_id, results)
     results
+  end
+
+  @doc """
+  Config-gated scheduled entry point for the `Glific.Jobs.MinuteWorker` cron branch. Runs the probe
+  only when a canary org is configured (`config :glific, #{inspect(__MODULE__)}, org_id: N, ...`) — a
+  no-op otherwise — reporting each failed node to AppSignal via `Glific.log_error/1`.
+  """
+  @spec run_scheduled() :: :ok
+  def run_scheduled do
+    env = Application.get_env(:glific, __MODULE__, [])
+
+    case Keyword.get(env, :org_id) do
+      nil -> :ok
+      org_id -> org_id |> run_all(Map.new(env)) |> report_failures()
+    end
+  end
+
+  @spec report_failures(%{String.t() => outcome()}) :: :ok
+  defp report_failures(results) do
+    Enum.each(results, fn
+      {name, {:error, reason}} ->
+        Glific.log_error("Flow-webhook smoke test failed for #{name}: #{reason}")
+
+      {_name, :ok} ->
+        :ok
+    end)
   end
 
   @spec run_one(module(), map(), map()) :: outcome()

--- a/lib/glific/flows/webhooks/kaapi.ex
+++ b/lib/glific/flows/webhooks/kaapi.ex
@@ -68,18 +68,28 @@ defmodule Glific.Flows.Webhooks.Kaapi do
 
     callback_url = Glific.api_callback_base(organization.shortcode) <> callback_path
 
-    request_metadata = %{
-      organization_id: organization_id,
-      flow_id: flow_id,
-      contact_id: contact_id,
-      timestamp: timestamp,
-      signature: signature,
-      webhook_log_id: fields["webhook_log_id"],
-      result_name: fields["result_name"]
-    }
+    request_metadata =
+      %{
+        organization_id: organization_id,
+        flow_id: flow_id,
+        contact_id: contact_id,
+        timestamp: timestamp,
+        signature: signature,
+        webhook_log_id: fields["webhook_log_id"],
+        result_name: fields["result_name"]
+      }
+      |> maybe_put_smoke_test(fields)
 
     {callback_url, request_metadata}
   end
+
+  # Rides the smoke-test sentinel back in the echoed metadata so the flow-resume path can drop the
+  # callback before it counts against `flow_webhook_count`. Absent on real traffic.
+  @spec maybe_put_smoke_test(map(), map()) :: map()
+  defp maybe_put_smoke_test(request_metadata, %{"smoke_test" => true}),
+    do: Map.put(request_metadata, :smoke_test, true)
+
+  defp maybe_put_smoke_test(request_metadata, _fields), do: request_metadata
 
   @doc """
   Dispatches the async unified LLM call to Kaapi (`/api/v1/llm/call`). Returns the normalised

--- a/lib/glific/jobs/minute_worker.ex
+++ b/lib/glific/jobs/minute_worker.ex
@@ -20,6 +20,7 @@ defmodule Glific.Jobs.MinuteWorker do
     Flags,
     Flows.BroadcastWorker,
     Flows.FlowContext,
+    Flows.Webhooks.Core.SmokeTest,
     GCS.GcsWorker,
     Jobs.BSPBalanceWorker,
     Jobs.UserJobWorker,
@@ -192,6 +193,14 @@ defmodule Glific.Jobs.MinuteWorker do
           only_recent: true
         )
     end
+
+    :ok
+  end
+
+  defp perform(%Oban.Job{args: %{"job" => "webhook_smoke"}} = _args, _services) do
+    Appsignal.CheckIn.cron("webhook_smoke", fn ->
+      SmokeTest.run_scheduled()
+    end)
 
     :ok
   end

--- a/lib/mix/tasks/glific.webhooks.smoke_test.ex
+++ b/lib/mix/tasks/glific.webhooks.smoke_test.ex
@@ -1,0 +1,69 @@
+defmodule Mix.Tasks.Glific.Webhooks.SmokeTest do
+  @shortdoc "Runs the flow-webhook smoke test against an org"
+
+  @moduledoc """
+  Calls each flow-webhook node's `call/2` with fixture input against a sandbox/staging org and
+  prints a per-node `:ok | {:error, reason}` summary. Exits non-zero if any node errored, so it
+  can gate a CI/staging check.
+
+      mix glific.webhooks.smoke_test --org 1
+      mix glific.webhooks.smoke_test --org 1 --assistant asst_123 --audio-url https://example.com/sample.ogg
+
+  ## Options
+
+    * `--org` (required) — organization id to probe
+    * `--assistant` — assistant display id for the filesearch/voice nodes
+    * `--audio-url` — reachable https audio URL for the STT/voice nodes
+    * `--flow` / `--contact` — flow and contact ids used to sign the async callbacks
+
+  The same probe runs on the live app from a Gigalixir `remote_console`:
+  `Glific.Flows.Webhooks.Core.SmokeTest.run_all(org_id)`.
+  """
+
+  use Mix.Task
+
+  alias Glific.Flows.Webhooks.Core.SmokeTest
+
+  @switches [
+    org: :integer,
+    assistant: :string,
+    audio_url: :string,
+    flow: :integer,
+    contact: :integer
+  ]
+
+  @impl Mix.Task
+  @spec run([String.t()]) :: :ok
+  def run(args) do
+    Mix.Task.run("app.start")
+
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: @switches)
+
+    org_id = opts[:org] || Mix.raise("--org <id> is required")
+
+    org_id
+    |> SmokeTest.run_all(overrides(opts))
+    |> exit_status()
+  end
+
+  @spec overrides(keyword()) :: map()
+  defp overrides(opts) do
+    %{
+      assistant_id: opts[:assistant],
+      audio_url: opts[:audio_url],
+      flow_id: opts[:flow],
+      contact_id: opts[:contact]
+    }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
+  end
+
+  @spec exit_status(%{String.t() => SmokeTest.outcome()}) :: :ok
+  defp exit_status(results) do
+    if Enum.any?(results, fn {_name, outcome} -> match?({:error, _reason}, outcome) end) do
+      exit({:shutdown, 1})
+    end
+
+    :ok
+  end
+end

--- a/test/glific/flows/webhooks/core/smoke_test_test.exs
+++ b/test/glific/flows/webhooks/core/smoke_test_test.exs
@@ -1,0 +1,166 @@
+defmodule Glific.Flows.Webhooks.Core.SmokeTestTest do
+  use Glific.DataCase, async: false
+
+  import ExUnit.CaptureIO
+  import Mock
+
+  alias Glific.Fixtures
+
+  alias Glific.Flows.Webhook
+  alias Glific.Flows.Webhooks.Core.SmokeTest
+
+  alias Glific.Flows.Webhooks.{
+    FilesearchGpt,
+    Geolocation,
+    Kaapi,
+    SpeechToText,
+    TextToSpeech,
+    VoiceFilesearchGpt
+  }
+
+  @nodes [
+    "geolocation",
+    "speech_to_text",
+    "text_to_speech",
+    "filesearch-gpt",
+    "voice-filesearch-gpt"
+  ]
+
+  # Each entry stubs a module's call/2 with the given result.
+  defp mock_calls(results) do
+    [
+      {Geolocation, [], [call: fn _fields, _ctx -> results.geolocation end]},
+      {SpeechToText, [], [call: fn _fields, _ctx -> results.speech_to_text end]},
+      {TextToSpeech, [], [call: fn _fields, _ctx -> results.text_to_speech end]},
+      {FilesearchGpt, [], [call: fn _fields, _ctx -> results.filesearch end]},
+      {VoiceFilesearchGpt, [], [call: fn _fields, _ctx -> results.voice_filesearch end]}
+    ]
+  end
+
+  @all_ok %{
+    geolocation: {:ok, %{city: "Bengaluru"}},
+    speech_to_text: {:ok, %{success: true}},
+    text_to_speech: {:ok, %{success: true}},
+    filesearch: {:ok, %{success: true}},
+    voice_filesearch: {:ok, %{success: true}}
+  }
+
+  describe "run_all/2" do
+    test "returns :ok for every node when each call/2 succeeds" do
+      with_mocks(mock_calls(@all_ok)) do
+        results = capture_run(1)
+
+        assert Map.keys(results) |> Enum.sort() == Enum.sort(@nodes)
+        assert Enum.all?(@nodes, fn node -> results[node] == :ok end)
+      end
+    end
+
+    test "maps a typed error to {:error, reason} while the rest still run" do
+      results_stub = %{@all_ok | geolocation: {:error, :empty_input, "Missing lat or long field"}}
+
+      with_mocks(mock_calls(results_stub)) do
+        results = capture_run(1)
+
+        assert results["geolocation"] == {:error, "Missing lat or long field"}
+        assert results["speech_to_text"] == :ok
+        assert results["voice-filesearch-gpt"] == :ok
+      end
+    end
+
+    test "maps a {:snooze, seconds} result to an error" do
+      results_stub = %{@all_ok | speech_to_text: {:snooze, 5}}
+
+      with_mocks(mock_calls(results_stub)) do
+        results = capture_run(1)
+
+        assert {:error, reason} = results["speech_to_text"]
+        assert reason =~ "snoozed"
+      end
+    end
+
+    test "catches a raised exception and reports it without aborting the run" do
+      results_stub = %{@all_ok | filesearch: :__raise__}
+
+      raising = fn _fields, _ctx -> raise RuntimeError, "kaapi unreachable" end
+
+      with_mocks([
+        {Geolocation, [], [call: fn _f, _c -> results_stub.geolocation end]},
+        {SpeechToText, [], [call: fn _f, _c -> results_stub.speech_to_text end]},
+        {TextToSpeech, [], [call: fn _f, _c -> results_stub.text_to_speech end]},
+        {FilesearchGpt, [], [call: raising]},
+        {VoiceFilesearchGpt, [], [call: fn _f, _c -> results_stub.voice_filesearch end]}
+      ]) do
+        results = capture_run(1)
+
+        assert results["filesearch-gpt"] == {:error, "kaapi unreachable"}
+        assert results["geolocation"] == :ok
+      end
+    end
+
+    test "prints a per-node summary" do
+      with_mocks(mock_calls(@all_ok)) do
+        output = capture_io(fn -> SmokeTest.run_all(1) end)
+
+        assert output =~ "Flow-webhook smoke test  org_id=1"
+        assert output =~ "✓ geolocation"
+        assert output =~ "✓ voice-filesearch-gpt"
+      end
+    end
+  end
+
+  describe "smoke-test sentinel suppression" do
+    test "build_flow_resume_metadata/6 threads the sentinel from fields into request_metadata" do
+      fields = %{"webhook_log_id" => nil, "result_name" => nil, "smoke_test" => true}
+      {_url, metadata} = Kaapi.build_flow_resume_metadata(1, 10, 20, fields)
+      assert metadata.smoke_test == true
+
+      fields_without = %{"webhook_log_id" => nil, "result_name" => nil}
+      {_url, metadata_without} = Kaapi.build_flow_resume_metadata(1, 10, 20, fields_without)
+      refute Map.has_key?(metadata_without, :smoke_test)
+    end
+
+    test "maybe_upload_tts_audio/1 skips the GCS upload for a smoke callback" do
+      response = %{"smoke_test" => true, "output_type" => "audio", "message" => "base64audio"}
+      assert Webhook.maybe_upload_tts_audio(response) == response
+    end
+
+    test "resume/3 drops a signed smoke callback before Dispatcher.callback counts it" do
+      contact = Fixtures.contact_fixture(%{organization_id: 1})
+      timestamp = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+      signature =
+        Glific.signature(
+          1,
+          Jason.encode!(%{
+            "organization_id" => 1,
+            "flow_id" => 99,
+            "contact_id" => contact.id,
+            "timestamp" => timestamp
+          }),
+          timestamp
+        )
+
+      response = %{
+        "organization_id" => 1,
+        "flow_id" => 99,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp,
+        "signature" => signature,
+        "webhook_name" => "speech_to_text",
+        "smoke_test" => true
+      }
+
+      with_mock Glific.Flows.Webhooks.Dispatcher,
+        callback: fn _name, _result, _response -> %{} end do
+        assert :ok = Webhook.resume(1, %{"success" => true}, response)
+        assert_not_called(Glific.Flows.Webhooks.Dispatcher.callback(:_, :_, :_))
+      end
+    end
+  end
+
+  @spec capture_run(non_neg_integer()) :: %{String.t() => SmokeTest.outcome()}
+  defp capture_run(organization_id) do
+    {result, _io} = with_io(fn -> SmokeTest.run_all(organization_id) end)
+    result
+  end
+end

--- a/test/glific/flows/webhooks/core/smoke_test_test.exs
+++ b/test/glific/flows/webhooks/core/smoke_test_test.exs
@@ -158,6 +158,47 @@ defmodule Glific.Flows.Webhooks.Core.SmokeTestTest do
     end
   end
 
+  describe "run_scheduled/0" do
+    setup do
+      previous = Application.get_env(:glific, SmokeTest)
+      on_exit(fn -> restore_env(previous) end)
+      :ok
+    end
+
+    test "is a no-op that reports nothing when no canary org is configured" do
+      Application.delete_env(:glific, SmokeTest)
+
+      with_mock Glific, [:passthrough], log_error: fn message -> {:error, message} end do
+        assert SmokeTest.run_scheduled() == :ok
+        assert_not_called(Glific.log_error(:_))
+      end
+    end
+
+    test "runs the probe and reports each failed node when a canary org is configured" do
+      Application.put_env(:glific, SmokeTest, org_id: 1)
+      results_stub = %{@all_ok | geolocation: {:error, :empty_input, "Missing lat or long field"}}
+
+      with_mocks(
+        mock_calls(results_stub) ++
+          [{Glific, [:passthrough], [log_error: fn message -> {:error, message} end]}]
+      ) do
+        capture_io(fn -> assert SmokeTest.run_scheduled() == :ok end)
+
+        assert_called(
+          Glific.log_error(
+            "Flow-webhook smoke test failed for geolocation: Missing lat or long field"
+          )
+        )
+
+        assert_called_exactly(Glific.log_error(:_), 1)
+      end
+    end
+  end
+
+  @spec restore_env(keyword() | nil) :: :ok
+  defp restore_env(nil), do: Application.delete_env(:glific, SmokeTest)
+  defp restore_env(previous), do: Application.put_env(:glific, SmokeTest, previous)
+
   @spec capture_run(non_neg_integer()) :: %{String.t() => SmokeTest.outcome()}
   defp capture_run(organization_id) do
     {result, _io} = with_io(fn -> SmokeTest.run_all(organization_id) end)


### PR DESCRIPTION
## What & why

Closes #5383 (part of #5293, Uptime Monitoring — Flow Webhooks).

Adds an **active uptime probe** for the flow-webhook nodes: a smoke-test module that calls each of the 5 current implementations' `call/2` with fixture input against a sandbox/staging org and reports whether the node's external dependencies are alive.

This **complements** — it does not replace — the passive per-node alerting on the existing `flow_webhook_count` AppSignal distribution:
- the probe catches "dependency down but no live traffic" (a silent outage),
- the `flow_webhook_count` alerts catch elevated error rates in real traffic.

## What's in this PR

- **`Glific.Flows.Webhooks.Core.SmokeTest.run_all/2`** — calls `geolocation`, `speech_to_text`, `text_to_speech`, `filesearch-gpt`, and `voice-filesearch-gpt`, returning `%{node_name => :ok | {:error, reason}}`. Fixtures are config/override-driven (async nodes need an org-specific `assistant_id`, `audio_url`, and a `flow_id`/`contact_id`); a node with a missing fixture surfaces its own typed error rather than crashing the run.
- **`mix glific.webhooks.smoke_test`** — thin trigger that prints a per-node summary and exits non-zero if any node errored (CI/staging gate friendly).
- **Scheduled recurring run** — `SmokeTest.run_scheduled/0` plus a `"webhook_smoke"` branch in `Glific.Jobs.MinuteWorker` (cron every 15 min), wrapped in `Appsignal.CheckIn.cron/2`. It's **config-gated on a canary org**, so it's a no-op wherever that config is absent (production included) and staging-only in practice. Two alert signals fall out: the **check-in heartbeat** fires if the job stops running, and each **failed node** is reported to AppSignal via `Glific.log_error/1`.
- **Sentinel-tagged async callbacks** — async smoke calls carry a `smoke_test` sentinel through the Kaapi `request_metadata`, which rides back in the echoed callback. The flow-resume path drops the smoke callback **after signature validation** but before `Dispatcher.callback`, so probe traffic **never counts against `flow_webhook_count`** (and the TTS GCS upload is skipped for smoke callbacks too). Real traffic is untouched.
- **Tests** — mocked `call/2` covering all-ok / typed-error / snooze / raised-exception / summary, the 3 sentinel-suppression cases, and the scheduled-run config gate + failure reporting.

## Out of scope

Webhook implementation logic, new nodes, load/perf testing, and new counters.

## Recommended setup

- **Recurring on staging, one canary org, every 15 min** (this PR's default). 15 min balances detection latency against the real Kaapi/Gemini/Maps spend and the shared per-org STT/TTS rate-limit budget.
- **Not on production** — prod already has the passive `flow_webhook_count` alerts on real traffic, so the active probe there mostly duplicates them at real cost. (A low-frequency prod canary to catch cred/config drift is a reasonable follow-up, not day one.)
- **Optionally as a post-deploy step** on staging (`mix glific.webhooks.smoke_test --org <canary>`) for fast feedback on config regressions; the cron is the safety net.

## AppSignal alerting (ops-side, no code — issue AC4)

The `flow_webhook_count` distribution is already tagged `%{webhook_name, status}`. Configure a per-`webhook_name` AppSignal trigger that alerts when `sum(status: "failure") / sum(all) > X%` over an N-minute window (X TBD with ops). No code change needed — the metric dimensions already exist. Also set up the `webhook_smoke` check-in monitor for the scheduled heartbeat. This is documented in the smoke module's `@moduledoc`.

## How to run

Against a staging DB from a `mix` shell / CI:

```bash
mix glific.webhooks.smoke_test --org 1
```

With org-specific fixtures for the async (Kaapi) nodes:

```bash
mix glific.webhooks.smoke_test --org 1 --assistant asst_123 --audio-url https://example.com/sample.ogg --flow 42 --contact 99
```

Against the running staging app (Gigalixir `remote_console`):

```elixir
Glific.Flows.Webhooks.Core.SmokeTest.run_all(1)
Glific.Flows.Webhooks.Core.SmokeTest.run_all(1, %{assistant_id: "asst_123", audio_url: "https://.../sample.ogg"})
```

To enable the **scheduled** run, configure the canary org on the staging deployment:

```elixir
config :glific, Glific.Flows.Webhooks.Core.SmokeTest,
  org_id: 1,
  assistant_id: "asst_123",
  audio_url: "https://.../sample.ogg",
  flow_id: 42,
  contact_id: 99
```

`org_id` is the gate: absent (the default), `run_scheduled/0` does nothing.

## Test plan

- [x] `mix test test/glific/flows/webhooks/core/smoke_test_test.exs` — 10 tests, 0 failures
- [x] `mix compile --warnings-as-errors`
- [x] `mix format`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
