### PR TITLE
fix: match verify_otp shortcode variants and pick the approved template

### DIFF
--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -438,7 +438,7 @@ defmodule Glific.Messages do
     |> then(&Map.merge(attrs, %{interactive_content: &1}))
   end
 
-  @doc false
+  @doc "Sends the OTP as a session message when possible, falling back to the HSM template."
   @spec create_and_send_otp_verification_message(Contact.t(), String.t()) ::
           {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_otp_verification_message(contact, otp) do
@@ -458,7 +458,7 @@ defmodule Glific.Messages do
     send_default_message(contact, body)
   end
 
-  @doc false
+  @doc "Sends the OTP using the organization's approved verify_otp HSM template."
   @spec create_and_send_otp_template_message(Contact.t(), String.t()) ::
           {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_otp_template_message(contact, otp) do

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -440,7 +440,7 @@ defmodule Glific.Messages do
 
   @doc false
   @spec create_and_send_otp_verification_message(Contact.t(), String.t()) ::
-          {:ok, Message.t()}
+          {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_otp_verification_message(contact, otp) do
     case Contacts.can_send_message_to?(contact, false) do
       {:ok, _} -> create_and_send_otp_session_message(contact, otp)
@@ -460,20 +460,22 @@ defmodule Glific.Messages do
 
   @doc false
   @spec create_and_send_otp_template_message(Contact.t(), String.t()) ::
-          {:ok, Message.t()}
+          {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_otp_template_message(contact, otp) do
-    # fetch session template by shortcode "verification"
-    {:ok, session_template} =
-      Repo.fetch_by(SessionTemplate, %{
-        shortcode: "verify_otp",
-        is_hsm: true,
-        organization_id: contact.organization_id
-      })
-
+    session_template = fetch_verify_otp_template(contact.organization_id)
     parameters = [otp]
 
     %{template_id: session_template.id, receiver_id: contact.id, parameters: parameters}
     |> create_and_send_hsm_message()
+  end
+
+  @spec fetch_verify_otp_template(non_neg_integer()) :: SessionTemplate.t() | nil
+  defp fetch_verify_otp_template(organization_id) do
+    SessionTemplate
+    |> where([st], ilike(st.shortcode, "verify_otp%"))
+    |> where([st], st.is_hsm and st.organization_id == ^organization_id)
+    |> Repo.all()
+    |> Enum.find(&(&1.status == "APPROVED" and &1.is_active))
   end
 
   @doc """

--- a/lib/glific/messages.ex
+++ b/lib/glific/messages.ex
@@ -462,20 +462,33 @@ defmodule Glific.Messages do
   @spec create_and_send_otp_template_message(Contact.t(), String.t()) ::
           {:ok, Message.t()} | {:error, String.t()}
   def create_and_send_otp_template_message(contact, otp) do
-    session_template = fetch_verify_otp_template(contact.organization_id)
-    parameters = [otp]
+    case fetch_verify_otp_template(contact.organization_id) do
+      {:ok, session_template} ->
+        parameters = [otp]
 
-    %{template_id: session_template.id, receiver_id: contact.id, parameters: parameters}
-    |> create_and_send_hsm_message()
+        %{template_id: session_template.id, receiver_id: contact.id, parameters: parameters}
+        |> create_and_send_hsm_message()
+
+      {:error, _} = error ->
+        error
+    end
   end
 
-  @spec fetch_verify_otp_template(non_neg_integer()) :: SessionTemplate.t() | nil
+  @spec fetch_verify_otp_template(non_neg_integer()) ::
+          {:ok, SessionTemplate.t()} | {:error, String.t()}
   defp fetch_verify_otp_template(organization_id) do
     SessionTemplate
-    |> where([st], ilike(st.shortcode, "verify_otp%"))
+    |> where([st], ilike(st.shortcode, "verify\\_otp%"))
     |> where([st], st.is_hsm and st.organization_id == ^organization_id)
-    |> Repo.all()
-    |> Enum.find(&(&1.status == "APPROVED" and &1.is_active))
+    |> where([st], st.category == "AUTHENTICATION")
+    |> where([st], st.status == "APPROVED" and st.is_active)
+    |> order_by([st], desc: st.updated_at, desc: st.id)
+    |> limit(1)
+    |> Repo.one()
+    |> case do
+      nil -> {:error, "No approved OTP template found"}
+      template -> {:ok, template}
+    end
   end
 
   @doc """

--- a/test/glific/messages_test.exs
+++ b/test/glific/messages_test.exs
@@ -1400,6 +1400,64 @@ defmodule Glific.MessagesTest do
       assert updated_hsm_template.body ==
                "Your OTP for param1 is param2. This is valid for param3."
     end
+
+    test "create_and_send_otp_template_message/2 picks the approved and active verify_otp template among multiple shortcode variants",
+         %{organization_id: organization_id, global_schema: global_schema} = attrs do
+      contact = Fixtures.contact_fixture(attrs)
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_pending",
+        shortcode: "verify_otp_pending",
+        type: :text,
+        body: "{{1}} is your pending verification code.",
+        is_hsm: true,
+        status: "PENDING",
+        is_active: false,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: organization_id
+      })
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_rejected",
+        shortcode: "verify_otp_rejected",
+        type: :text,
+        body: "{{1}} is your rejected verification code.",
+        is_hsm: true,
+        status: "REJECTED",
+        is_active: false,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: organization_id
+      })
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_approved",
+        shortcode: "verify_otp_approved",
+        type: :text,
+        body: "{{1}} is your verification code. For your security, do not share this code.",
+        is_hsm: true,
+        status: "APPROVED",
+        is_active: true,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: organization_id
+      })
+
+      assert {:ok, %Message{} = message} =
+               Messages.create_and_send_otp_template_message(contact, "445566")
+
+      assert_enqueued(worker: Worker, prefix: global_schema)
+      Oban.drain_queue(queue: :gupshup)
+
+      message = Messages.get_message!(message.id)
+
+      assert message.body ==
+               "445566 is your verification code. For your security, do not share this code."
+    end
   end
 
   describe "message_media" do

--- a/test/glific/messages_test.exs
+++ b/test/glific/messages_test.exs
@@ -1434,6 +1434,34 @@ defmodule Glific.MessagesTest do
       })
 
       Repo.insert!(%SessionTemplate{
+        label: "verify_otp_active_but_not_approved",
+        shortcode: "verify_otp_active_but_not_approved",
+        type: :text,
+        body: "{{1}} is your active but unapproved verification code.",
+        is_hsm: true,
+        status: "PENDING",
+        is_active: true,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: organization_id
+      })
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_approved_but_inactive",
+        shortcode: "verify_otp_approved_but_inactive",
+        type: :text,
+        body: "{{1}} is your approved but inactive verification code.",
+        is_hsm: true,
+        status: "APPROVED",
+        is_active: false,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: organization_id
+      })
+
+      Repo.insert!(%SessionTemplate{
         label: "verify_otp_approved",
         shortcode: "verify_otp_approved",
         type: :text,
@@ -1457,6 +1485,44 @@ defmodule Glific.MessagesTest do
 
       assert message.body ==
                "445566 is your verification code. For your security, do not share this code."
+    end
+
+    test "create_and_send_otp_template_message/2 returns an error when no verify_otp template is approved and active",
+         attrs do
+      contact = Fixtures.contact_fixture(attrs)
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_pending",
+        shortcode: "verify_otp_pending",
+        type: :text,
+        body: "{{1}} is your pending verification code.",
+        is_hsm: true,
+        status: "PENDING",
+        is_active: false,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: attrs.organization_id
+      })
+
+      Repo.insert!(%SessionTemplate{
+        label: "verify_otp_approved_but_inactive",
+        shortcode: "verify_otp_approved_but_inactive",
+        type: :text,
+        body: "{{1}} is your approved but inactive verification code.",
+        is_hsm: true,
+        status: "APPROVED",
+        is_active: false,
+        number_parameters: 1,
+        category: "AUTHENTICATION",
+        language_id: 1,
+        organization_id: attrs.organization_id
+      })
+
+      assert {:error, error_message} =
+               Messages.create_and_send_otp_template_message(contact, "445566")
+
+      assert error_message == "No approved OTP template found"
     end
   end
 


### PR DESCRIPTION
## Summary
- `create_and_send_otp_template_message/2` looked up the OTP HSM template with an exact-match `shortcode: "verify_otp"`, which raises `Ecto.MultipleResultsError` as soon as an org has more than one `verify_otp*` template row (e.g. re-submitted/duplicate BSP variants like `verify_otp_v1`).
- Replaced the exact match with a prefix match (`ilike(shortcode, "verify_otp%")`) scoped to `is_hsm`/`organization_id`, then pick the one that's actually usable: `status == "APPROVED" and is_active`.