### PR TITLE
fix(bigquery): stop invalid-credential crash loop and tag org on failures

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -249,21 +249,37 @@ defmodule Glific.BigQuery do
         org_contact,
         organization_id
       ) do
-    case Jason.decode(credentials.secrets["service_account"]) do
-      {:ok, service_account} ->
-        project_id = service_account["project_id"]
-        token = Partners.get_goth_token(organization_id, "bigquery")
+    service_account_json = credentials.secrets["service_account"]
 
-        if is_nil(token) do
-          {:error, "Error fetching token with Service Account JSON"}
-        else
-          conn = Connection.new(token.token)
-          {:ok, %{conn: conn, project_id: project_id, dataset_id: org_contact.phone}}
-        end
+    if is_binary(service_account_json) and service_account_json != "" do
+      case Jason.decode(service_account_json) do
+        {:ok, service_account} ->
+          project_id = service_account["project_id"]
+          token = Partners.get_goth_token(organization_id, "bigquery")
 
-      {:error, _error} ->
-        {:error, "Invalid Service Account JSON"}
+          if is_nil(token) do
+            {:error, "Error fetching token with Service Account JSON"}
+          else
+            conn = Connection.new(token.token)
+            {:ok, %{conn: conn, project_id: project_id, dataset_id: org_contact.phone}}
+          end
+
+        {:error, _error} ->
+          log_bigquery_credential_error(organization_id, "invalid")
+          {:error, "Invalid Service Account JSON"}
+      end
+    else
+      log_bigquery_credential_error(organization_id, "missing")
+      {:error, "Missing Service Account JSON"}
     end
+  end
+
+  @spec log_bigquery_credential_error(non_neg_integer(), String.t()) :: :ok
+  defp log_bigquery_credential_error(organization_id, reason) do
+    Glific.log_exception(
+      %RuntimeError{message: "BigQuery service account JSON #{reason}"},
+      tags: %{organization_id: organization_id, shortcode: "bigquery"}
+    )
   end
 
   @table_lookup %{
@@ -888,18 +904,29 @@ defmodule Glific.BigQuery do
       "Insert data to bigquery for org_id: #{organization_id}, table: #{table}, rows_count: #{Enum.count(data)}"
     )
 
-    fetch_bigquery_credentials(organization_id)
-    |> do_make_insert_query(organization_id, data,
-      table: table,
-      max_id: max_id,
-      last_updated_at: last_updated_at
-    )
-    |> handle_insert_query_response(organization_id,
-      table: table,
-      max_id: max_id,
-      last_updated_at: last_updated_at,
-      action: Keyword.get(attrs, :action)
-    )
+    case fetch_bigquery_credentials(organization_id) do
+      {:ok, %{conn: _conn, project_id: _project_id, dataset_id: _dataset_id}} = credentials ->
+        credentials
+        |> do_make_insert_query(organization_id, data,
+          table: table,
+          max_id: max_id,
+          last_updated_at: last_updated_at
+        )
+        |> handle_insert_query_response(organization_id,
+          table: table,
+          max_id: max_id,
+          last_updated_at: last_updated_at,
+          action: Keyword.get(attrs, :action)
+        )
+
+      {:error, _reason} ->
+        Instrumentation.record(table, :error, Keyword.get(attrs, :action), organization_id)
+
+      {:ok, message} ->
+        Logger.info(
+          "Skipping bigquery insert for org_id: #{organization_id}, table: #{table}: #{message}"
+        )
+    end
 
     :ok
   end

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -249,28 +249,26 @@ defmodule Glific.BigQuery do
         org_contact,
         organization_id
       ) do
-    service_account_json = credentials.secrets["service_account"]
-
-    if is_binary(service_account_json) and service_account_json != "" do
-      case Jason.decode(service_account_json) do
-        {:ok, service_account} ->
-          project_id = service_account["project_id"]
-          token = Partners.get_goth_token(organization_id, "bigquery")
-
-          if is_nil(token) do
-            {:error, "Error fetching token with Service Account JSON"}
-          else
-            conn = Connection.new(token.token)
-            {:ok, %{conn: conn, project_id: project_id, dataset_id: org_contact.phone}}
-          end
-
-        {:error, _error} ->
-          log_bigquery_credential_error(organization_id, "invalid")
-          {:error, "Invalid Service Account JSON"}
-      end
+    with {:secrets, service_account_json}
+         when is_binary(service_account_json) and service_account_json != "" <-
+           {:secrets, credentials.secrets["service_account"]},
+         {:ok, %{"project_id" => project_id}}
+         when is_binary(project_id) and project_id != "" <- Jason.decode(service_account_json),
+         {:token, token} when not is_nil(token) <-
+           {:token, Partners.get_goth_token(organization_id, "bigquery")} do
+      conn = Connection.new(token.token)
+      {:ok, %{conn: conn, project_id: project_id, dataset_id: org_contact.phone}}
     else
-      log_bigquery_credential_error(organization_id, "missing")
-      {:error, "Missing Service Account JSON"}
+      {:secrets, _missing} ->
+        log_bigquery_credential_error(organization_id, "missing")
+        {:error, "Missing Service Account JSON"}
+
+      {:token, nil} ->
+        {:error, "Error fetching token with Service Account JSON"}
+
+      _invalid ->
+        log_bigquery_credential_error(organization_id, "invalid")
+        {:error, "Invalid Service Account JSON"}
     end
   end
 
@@ -539,15 +537,17 @@ defmodule Glific.BigQuery do
   @spec validate_bigquery_credentials(map(), non_neg_integer() | nil) ::
           {:ok, :valid} | {:error, String.t()}
   def validate_bigquery_credentials(service_account, organization_id \\ nil) do
-    project_id = service_account["project_id"]
-
-    case Goth.Token.fetch(source: {:service_account, service_account, []}) do
-      {:ok, token} ->
-        conn = Connection.new(token.token)
-        validate_bigquery_permissions(conn, project_id, organization_id)
-
+    with %{"project_id" => project_id} when is_binary(project_id) and project_id != "" <-
+           service_account,
+         {:ok, token} <- Goth.Token.fetch(source: {:service_account, service_account, []}) do
+      conn = Connection.new(token.token)
+      validate_bigquery_permissions(conn, project_id, organization_id)
+    else
       {:error, reason} ->
         {:error, "Error fetching token from service account: #{safe_inspect(reason)}"}
+
+      _invalid ->
+        {:error, "Invalid Service Account JSON"}
     end
   end
 

--- a/lib/glific/third_party/bigquery/instrumentation.ex
+++ b/lib/glific/third_party/bigquery/instrumentation.ex
@@ -87,21 +87,6 @@ defmodule Glific.BigQuery.Instrumentation do
   rescue
     exception ->
       record(table, :exception, action, organization_id)
-      tag_exception_with_org(table, organization_id)
       reraise exception, __STACKTRACE__
-  end
-
-  @spec tag_exception_with_org(String.t() | atom(), non_neg_integer() | nil) :: :ok
-  defp tag_exception_with_org(table, organization_id) do
-    Appsignal.Tracer.root_span()
-    |> Appsignal.Span.set_sample_data("tags", %{
-      organization_id: organization_id,
-      table: to_string(table)
-    })
-
-    :ok
-  rescue
-    # Enriching the span is best-effort: it must never mask the original exception.
-    _exception -> :ok
   end
 end

--- a/lib/glific/third_party/bigquery/instrumentation.ex
+++ b/lib/glific/third_party/bigquery/instrumentation.ex
@@ -87,6 +87,21 @@ defmodule Glific.BigQuery.Instrumentation do
   rescue
     exception ->
       record(table, :exception, action, organization_id)
+      tag_exception_with_org(table, organization_id)
       reraise exception, __STACKTRACE__
+  end
+
+  @spec tag_exception_with_org(String.t() | atom(), non_neg_integer() | nil) :: :ok
+  defp tag_exception_with_org(table, organization_id) do
+    Appsignal.Tracer.root_span()
+    |> Appsignal.Span.set_sample_data("tags", %{
+      organization_id: organization_id,
+      table: to_string(table)
+    })
+
+    :ok
+  rescue
+    # Enriching the span is best-effort: it must never mask the original exception.
+    _exception -> :ok
   end
 end

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -376,6 +376,33 @@ defmodule Glific.BigQueryTest do
     end
   end
 
+  test "decode_bigquery_credential/3 returns error for a missing service account without raising",
+       attrs do
+    credentials = %{secrets: %{}}
+    org_contact = %{phone: "919999999999"}
+
+    assert {:error, "Missing Service Account JSON"} =
+             BigQuery.decode_bigquery_credential(credentials, org_contact, attrs.organization_id)
+  end
+
+  test "decode_bigquery_credential/3 returns error for a nil service account without raising",
+       attrs do
+    credentials = %{secrets: %{"service_account" => nil}}
+    org_contact = %{phone: "919999999999"}
+
+    assert {:error, "Missing Service Account JSON"} =
+             BigQuery.decode_bigquery_credential(credentials, org_contact, attrs.organization_id)
+  end
+
+  test "decode_bigquery_credential/3 returns error for an invalid service account without raising",
+       attrs do
+    credentials = %{secrets: %{"service_account" => "not-a-json"}}
+    org_contact = %{phone: "919999999999"}
+
+    assert {:error, "Invalid Service Account JSON"} =
+             BigQuery.decode_bigquery_credential(credentials, org_contact, attrs.organization_id)
+  end
+
   test "handle_duplicate_removal_job_error/2 should log info on successful deletion",
        attrs do
     # we need to figure out how to check that this function did the right thing

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -403,6 +403,22 @@ defmodule Glific.BigQueryTest do
              BigQuery.decode_bigquery_credential(credentials, org_contact, attrs.organization_id)
   end
 
+  test "decode_bigquery_credential/3 returns error for non-object service account json without raising",
+       attrs do
+    org_contact = %{phone: "919999999999"}
+
+    for service_account_json <- ["[]", "null", "{}", ~s({"project_id": ""})] do
+      credentials = %{secrets: %{"service_account" => service_account_json}}
+
+      assert {:error, "Invalid Service Account JSON"} =
+               BigQuery.decode_bigquery_credential(
+                 credentials,
+                 org_contact,
+                 attrs.organization_id
+               )
+    end
+  end
+
   test "handle_duplicate_removal_job_error/2 should log info on successful deletion",
        attrs do
     # we need to figure out how to check that this function did the right thing


### PR DESCRIPTION
Closes #5571

## Problem

`Glific.BigQuery.BigQueryWorker#perform` has been throwing a `FunctionClauseError` on every BigQuery sync sweep for any org whose stored service-account JSON is missing or unparseable — the single largest source of `oban_job` exceptions in production (AppSignal exception incident #137, ~600–840/hr sustained, millions all-time), firing every 2 minutes and completely unattributable to an org.

### Root cause

`make_insert_query/4` piped `fetch_bigquery_credentials/1` straight into `do_make_insert_query/4`, which **only** matches `{:ok, %{conn, project_id, dataset_id}}`. Any other result crashed:

- `{:error, _}` — invalid/undecodable credential (the actual crasher)
- `{:ok, "BigQuery is not active"}` — the inactive/disabled case also had no clause

Separately, `decode_bigquery_credential/3` called `Jason.decode(secrets["service_account"])` directly, so a `nil` secret raised (`Jason.decode(nil)`) instead of returning a handled error.

The raised exception propagated through Oban to AppSignal **without an `organization_id` tag**, so the incident could not be traced to a tenant.

## Changes

- **`make_insert_query/4`** now matches all three `fetch_bigquery_credentials/1` outcomes: valid creds proceed to insert; `{:error, _}` records a `status=error` (org-tagged) metric on `bigquery_sync_count` and returns; the inactive string logs and returns. No more raise → the crash loop stops.
- **`decode_bigquery_credential/3`** guards for a non-empty binary `service_account` before decoding, and logs an **org-tagged** AppSignal exception via `Glific.log_exception/2` for both the **missing** and **invalid** cases (distinct messages so they group as separate, org-filterable incidents).
- **`Instrumentation.track/4`** tags the AppSignal span with `organization_id` and `table` before re-raising, so any BigQuery-worker exception is attributable to an org in the incident UI — not just on the `bigquery_sync_count` metric. Best-effort (rescued) so it can never mask the original exception.
- Tests for the missing / nil / invalid service-account paths.

## Effect

- Incident #137 stops: invalid-credential jobs no-op with a logged, org-tagged error instead of crashing.
- Failing orgs become identifiable straight from AppSignal — either the `bigquery_sync_count` metric (`status=error`, grouped by `organization_id`) or the new org-tagged "missing/invalid" incidents.

## Follow-up (intentionally not in this PR)

`Mails.SyncDisabledMail.send_if_any/0` **unconditionally re-enables** disabled BigQuery/GCS credentials every Monday without re-validating them, which revives broken orgs and restarts the storm. Gating that re-enable behind a validation check is a separate, behavior-changing fix worth doing knowingly.

## Testing

- `mix test test/glific/bigquery_test.exs test/glific/bigquery_instrumentation_test.exs` → 54 tests, 0 failures
- `mix format --check-formatted` and `mix credo` clean on changed files
- `mix compile --warnings-as-errors` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)