### PR TITLE
feat(ai_evaluations): support duplication_factor on evaluation run creation

### DIFF
--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -291,6 +291,10 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   defp validate_duplication_factor(_factor),
     do: {:error, "Duplication factor must be between 1 and 5"}
 
+  @spec validate_evaluation_duplication_factor(integer() | nil) :: :ok | {:error, String.t()}
+  defp validate_evaluation_duplication_factor(nil), do: :ok
+  defp validate_evaluation_duplication_factor(factor), do: validate_duplication_factor(factor)
+
   @spec validate_golden_qa_file_size(struct(), map()) :: :ok | {:error, String.t()}
   defp validate_golden_qa_file_size(%{path: path}, %{id: id, organization_id: organization_id}) do
     case File.stat(path) do
@@ -411,7 +415,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec create_evaluation(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}
   def create_evaluation(_, %{input: input}, %{context: %{current_user: user}}) do
-    with {:name, {:error, _}} <-
+    with :ok <- validate_evaluation_duplication_factor(Map.get(input, :duplication_factor)),
+         {:name, {:error, _}} <-
            {:name,
             Repo.fetch_by(AIEvaluation, %{
               name: input.evaluation_name,
@@ -436,7 +441,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         {:ok, kaapi_response} <- run_kaapi_evaluation(kaapi_input, user.organization_id),
+         duplication_factor = Map.get(input, :duplication_factor),
+         {:ok, kaapi_response} <-
+           run_kaapi_evaluation(kaapi_input, duplication_factor, user.organization_id),
          {:kaapi_response, {:ok, data}} <-
            {:kaapi_response, validate_kaapi_evaluation_response(kaapi_response)},
          {:status, {:ok, status}} <- {:status, parse_ai_evaluation_status(data.status)},
@@ -489,16 +496,25 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
-  @spec run_kaapi_evaluation(map(), non_neg_integer()) :: {:ok, map()} | {:error, any()}
-  defp run_kaapi_evaluation(kaapi_input, organization_id) do
+  @spec run_kaapi_evaluation(map(), integer() | nil, non_neg_integer()) ::
+          {:ok, map()} | {:error, any()}
+  defp run_kaapi_evaluation(kaapi_input, duplication_factor, organization_id) do
     organization = Partners.organization(organization_id)
 
     if Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization) do
-      Kaapi.create_evaluation_v2(kaapi_input, organization_id)
+      kaapi_input
+      |> maybe_put_duplication_factor(duplication_factor)
+      |> Kaapi.create_evaluation_v2(organization_id)
     else
       Kaapi.create_evaluation(kaapi_input, organization_id)
     end
   end
+
+  @spec maybe_put_duplication_factor(map(), integer() | nil) :: map()
+  defp maybe_put_duplication_factor(kaapi_input, nil), do: kaapi_input
+
+  defp maybe_put_duplication_factor(kaapi_input, duplication_factor),
+    do: Map.put(kaapi_input, :duplication_factor, duplication_factor)
 
   @spec parse_ai_evaluation_status(String.t()) :: {:ok, atom()} | {:error, String.t()}
   defp parse_ai_evaluation_status(status) when status in @known_ai_evaluation_statuses,

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -291,10 +291,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   defp validate_duplication_factor(_factor),
     do: {:error, "Duplication factor must be between 1 and 5"}
 
-  @spec validate_evaluation_duplication_factor(integer() | nil) :: :ok | {:error, String.t()}
-  defp validate_evaluation_duplication_factor(nil), do: :ok
-  defp validate_evaluation_duplication_factor(factor), do: validate_duplication_factor(factor)
-
   @spec validate_golden_qa_file_size(struct(), map()) :: :ok | {:error, String.t()}
   defp validate_golden_qa_file_size(%{path: path}, %{id: id, organization_id: organization_id}) do
     case File.stat(path) do
@@ -415,7 +411,9 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec create_evaluation(map(), map(), map()) :: {:ok, map()} | {:error, String.t()}
   def create_evaluation(_, %{input: input}, %{context: %{current_user: user}}) do
-    with :ok <- validate_evaluation_duplication_factor(Map.get(input, :duplication_factor)),
+    duplication_factor = Map.get(input, :duplication_factor) || 1
+
+    with :ok <- validate_duplication_factor(duplication_factor),
          {:name, {:error, _}} <-
            {:name,
             Repo.fetch_by(AIEvaluation, %{
@@ -441,7 +439,6 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         duplication_factor = Map.get(input, :duplication_factor) || 1,
          {:ok, kaapi_response} <-
            run_kaapi_evaluation(kaapi_input, duplication_factor, user.organization_id),
          {:kaapi_response, {:ok, data}} <-

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -441,7 +441,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            config_version: config_version.kaapi_version_number,
            dataset_id: golden_qa.dataset_id
          },
-         duplication_factor = Map.get(input, :duplication_factor),
+         duplication_factor = Map.get(input, :duplication_factor) || 1,
          {:ok, kaapi_response} <-
            run_kaapi_evaluation(kaapi_input, duplication_factor, user.organization_id),
          {:kaapi_response, {:ok, data}} <-
@@ -496,25 +496,19 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
-  @spec run_kaapi_evaluation(map(), integer() | nil, non_neg_integer()) ::
+  @spec run_kaapi_evaluation(map(), integer(), non_neg_integer()) ::
           {:ok, map()} | {:error, any()}
   defp run_kaapi_evaluation(kaapi_input, duplication_factor, organization_id) do
     organization = Partners.organization(organization_id)
 
     if Flags.get_flag_enabled(:is_ai_evaluation_enabled, organization) do
       kaapi_input
-      |> maybe_put_duplication_factor(duplication_factor)
+      |> Map.put(:duplication_factor, duplication_factor)
       |> Kaapi.create_evaluation_v2(organization_id)
     else
       Kaapi.create_evaluation(kaapi_input, organization_id)
     end
   end
-
-  @spec maybe_put_duplication_factor(map(), integer() | nil) :: map()
-  defp maybe_put_duplication_factor(kaapi_input, nil), do: kaapi_input
-
-  defp maybe_put_duplication_factor(kaapi_input, duplication_factor),
-    do: Map.put(kaapi_input, :duplication_factor, duplication_factor)
 
   @spec parse_ai_evaluation_status(String.t()) :: {:ok, atom()} | {:error, String.t()}
   defp parse_ai_evaluation_status(status) when status in @known_ai_evaluation_statuses,

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -94,7 +94,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :golden_qa_id, non_null(:id)
     field :evaluation_name, non_null(:string)
     field :config_id, non_null(:id)
-    field :duplication_factor, :integer
+    field :duplication_factor, :integer, default_value: 1
   end
 
   object :evaluation_scores_result do

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -94,6 +94,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :golden_qa_id, non_null(:id)
     field :evaluation_name, non_null(:string)
     field :config_id, non_null(:id)
+    field :duplication_factor, :integer
   end
 
   object :evaluation_scores_result do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1768,6 +1768,46 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       )
     end
 
+    test "v2 path: defaults duplication_factor to 1 when not passed", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url, body: body} ->
+          assert url =~ "/api/v2/evaluations"
+          assert body =~ ~s("duplication_factor":1)
+
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              data: %{id: 780, run_name: "test_experiment_default_dup", status: "processing"}
+            }
+          }
+      end)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "test_experiment_default_dup",
+          config_id: assistant_config_version.id
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{evaluation: _evaluation}} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
     test "v2 path: forwards duplication_factor to the Kaapi request body", %{
       staff: user,
       assistant_config_version: assistant_config_version,

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1768,6 +1768,73 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       )
     end
 
+    test "v2 path: forwards duplication_factor to the Kaapi request body", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      Tesla.Mock.mock(fn
+        %{method: :post, url: url, body: body} ->
+          assert url =~ "/api/v2/evaluations"
+          assert body =~ ~s("duplication_factor":3)
+
+          %Tesla.Env{
+            status: 200,
+            body: %{data: %{id: 779, run_name: "test_experiment_dup", status: "processing"}}
+          }
+      end)
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "test_experiment_dup",
+          config_id: assistant_config_version.id,
+          duplication_factor: 3
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:ok, %{evaluation: _evaluation}} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
+    test "v2 path: returns error when duplication_factor is out of range", %{
+      staff: user,
+      assistant_config_version: assistant_config_version,
+      golden_qa: golden_qa
+    } do
+      FunWithFlags.enable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+
+      args = %{
+        input: %{
+          golden_qa_id: golden_qa.id,
+          evaluation_name: "test_experiment_dup_invalid",
+          config_id: assistant_config_version.id,
+          duplication_factor: 8
+        }
+      }
+
+      resolution = %{context: %{current_user: user}}
+
+      assert {:error, "Duplication factor must be between 1 and 5"} =
+               AIEvaluations.create_evaluation(nil, args, resolution)
+
+      FunWithFlags.disable(:is_ai_evaluation_enabled,
+        for_actor: %{organization_id: user.organization_id}
+      )
+    end
+
     test "returns an error instead of crashing on an unrecognized status", %{
       staff: user,
       assistant_config_version: assistant_config_version,


### PR DESCRIPTION
## Summary
Kaapi's v2 evaluations endpoint recently added an optional `duplication_factor` param on evaluation run creation:

```bash
curl -X POST "http://localhost:8000/evaluations" \
  -H "Authorization: Bearer <your_token>" \
  -H "Content-Type: application/json" \
  -d '{
    "dataset_id": 123,
    "experiment_name": "my-eval-run",
    "config_id": "d468be6d-24c2-4315-b847-90221421d7fd",
    "config_version": 1,
    "duplication_factor": 3
  }'
```

This PR plumbs it through Glific's `createEvaluation` GraphQL mutation:

- Added optional `duplication_factor` field to the `evaluation_input` GraphQL type, defaulting to `1` (`default_value: 1`) so existing clients that don't pass it keep the current behavior.
- Resolver also falls back to `1` when the field is absent — covers direct/internal callers that bypass Absinthe's argument defaulting.
- Validates the value is in `1..5` (reuses the existing `validate_duplication_factor/1` used for Golden QA uploads).
- Forwarded only on the Kaapi **v2** request path (`create_evaluation_v2`) since it's a v2-only param — the v1 request body is unchanged.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] Added test cases (resolver tests: default of 1 when omitted, duplication_factor forwarded to v2 request body, and rejected when out of range).
- [ ] Postman request (n/a — no new REST API, existing GraphQL mutation extended).
- [x] Coding standard and conventions followed.

## Notes
`mix format` + `mix credo` clean on changed files. Full `test/glific_web/resolvers/ai_evaluations_test.exs` suite passes (81 tests).