### PR TITLE
feat(simulator): accept simulator messages on an authenticated endpoint

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -195,6 +195,80 @@ config :glific,
   api_host_override: env!("GLIFIC_API_HOST_OVERRIDE", :string, nil),
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
+# The BSP webhooks are unauthenticated, so callers are filtered on the source IPs the
+# provider publishes; anything else gets a 403.
+
+# :inet rather than the CIDR library the plug matches with, because config runs before any
+# dependency is started.
+valid_webhook_ip? = fn entry ->
+  [address | prefix] = String.split(entry, "/", parts: 2)
+
+  case :inet.parse_address(String.to_charlist(address)) do
+    {:error, _reason} ->
+      false
+
+    {:ok, parsed} ->
+      max_length = if tuple_size(parsed) == 4, do: 32, else: 128
+
+      case prefix do
+        [] ->
+          true
+
+        [length] ->
+          match?({value, ""} when value >= 0 and value <= max_length, Integer.parse(length))
+      end
+  end
+end
+
+webhook_ips = fn variable ->
+  case env!(variable, :string, nil) do
+    unset when unset in [nil, ""] ->
+      []
+
+    ips ->
+      ips
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.map(fn entry ->
+        if valid_webhook_ip?.(entry),
+          do: entry,
+          else:
+            raise("""
+            #{variable} contains "#{entry}", which is not an IP address or CIDR block.
+
+            Expected a comma separated list, for example:
+
+                gigalixir config:set #{variable}="a.b.c.d,e.f.g.h,w.x.y.z/24"
+            """)
+      end)
+  end
+end
+
+# Only :prod is configured. An unset list means the provider is not filtered, which keeps
+# dev and test working against localhost.
+if config_env() == :prod do
+  gupshup_webhook_ips = webhook_ips.("GUPSHUP_WEBHOOK_IPS")
+
+  # Booting without this list would leave the busiest webhook accepting forged messages
+  # from any caller, so refuse to start rather than come up unprotected.
+  if gupshup_webhook_ips == [],
+    do:
+      raise("""
+      GUPSHUP_WEBHOOK_IPS is not set.
+
+      The /gupshup webhook is unauthenticated and is guarded only by Gupshup's published
+      callback IPs, so Glific will not boot without them.
+
+      Set it to Gupshup's comma separated callback IPs, CIDR blocks allowed:
+
+          gigalixir config:set GUPSHUP_WEBHOOK_IPS="a.b.c.d,e.f.g.h,w.x.y.z/24"
+      """)
+
+  config :glific, :gupshup_webhook_ips, gupshup_webhook_ips
+  config :glific, :gupshup_enterprise_webhook_ips, webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS")
+  config :glific, :maytapi_webhook_ips, webhook_ips.("MAYTAPI_WEBHOOK_IPS")
+end
+
 search_repo_module =
   if(env!("USE_REPLICA_DB", :boolean, false), do: Glific.RepoReplica, else: Glific.Repo)
 

--- a/lib/glific_web/controllers/api/v1/simulator_controller.ex
+++ b/lib/glific_web/controllers/api/v1/simulator_controller.ex
@@ -1,0 +1,50 @@
+defmodule GlificWeb.API.V1.SimulatorController do
+  @moduledoc """
+  Authenticated entry point for messages typed into the simulator.
+
+  The simulator posts a message as though a contact had sent it. That used to go straight to
+  the BSP webhook, which meant an unauthenticated request deciding an organization from the
+  request host. Here the caller is authenticated and the organization comes from their token,
+  so a user can only ever drive the simulator belonging to their own organization.
+
+  Only simulator contacts are accepted; a payload naming any other sender is refused, so this
+  cannot be used to forge a message from a real beneficiary.
+
+  Beyond those checks the payload is handed to the usual Gupshup shunt, so every message type
+  the simulator produces is handled exactly as an inbound message is.
+  """
+
+  use GlificWeb, :controller
+
+  alias Glific.{Contacts, Repo, Users.User}
+  alias GlificWeb.Providers.Gupshup.Plugs.Shunt
+
+  @doc """
+  Injects a simulator message into the inbound pipeline for the caller's organization.
+  """
+  @spec message(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def message(conn, params) do
+    %User{organization_id: organization_id} = conn.assigns[:current_user]
+
+    if simulator_sender?(params) do
+      Repo.put_organization_id(organization_id)
+
+      conn
+      |> assign(:organization_id, organization_id)
+      |> Shunt.call(Shunt.init([]))
+    else
+      conn
+      |> put_status(:forbidden)
+      |> json(%{
+        error: %{status: 403, message: "Only simulator contacts can send simulator messages."}
+      })
+    end
+  end
+
+  @spec simulator_sender?(map()) :: boolean()
+  defp simulator_sender?(%{"payload" => %{"sender" => %{"phone" => phone}}})
+       when is_binary(phone),
+       do: Contacts.simulator_contact?(phone)
+
+  defp simulator_sender?(_params), do: false
+end

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -1,0 +1,138 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
+  @moduledoc """
+  Restricts the BSP webhook endpoints to the source IPs published by each provider.
+
+  These endpoints are unauthenticated: the organization is resolved from the request
+  host and the shunt then runs the request as that organization's root user. Filtering
+  on the provider's published callback IPs is what stops an arbitrary caller from
+  posting a forged inbound message on behalf of any organization.
+
+  The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`, `/maytapi`)
+  and each one carries its own config key, so a provider can be changed on its own:
+
+      config :glific, :gupshup_webhook_ips, ["192.0.2.10", "198.51.100.0/24"]
+
+  Entries are IPv4/IPv6 addresses or CIDR blocks. A caller outside its provider's list is
+  logged and answered with 403. That log line is the only warning that a provider has
+  started calling from an address we do not know about, so it is worth alerting on.
+
+  A provider whose list is empty is not filtered at all. That is what keeps a route
+  working before its IPs are known, and what leaves dev and test unfiltered, since
+  `config/runtime.exs` only populates the lists in `:prod`.
+
+  The lists come per provider from the environment (`GUPSHUP_WEBHOOK_IPS` and friends)
+  and are deliberately not held in this repository, so a provider adding an IP is a
+  `gigalixir config:set` and a restart rather than a deploy. Because an empty list means
+  no filtering, `runtime.exs` refuses to boot `:prod` when `GUPSHUP_WEBHOOK_IPS` is
+  missing rather than let the busiest webhook come up unguarded.
+
+  The caller is taken from `x-forwarded-for` alone, rather than from `conn.remote_ip`.
+  `GlificWeb.Endpoint` runs `RemoteIp` with its defaults, which also trust `forwarded`,
+  `x-client-ip` and `x-real-ip`; our proxy only rewrites `x-forwarded-for`, so a caller
+  that sends one of the other three can put an allowlisted address last in the chain and
+  have it win. Deciding here from the one header the proxy controls keeps that out of a
+  security decision, and leaves `conn.remote_ip` untouched for rate limiting and logging.
+
+  A request with no usable `x-forwarded-for` cannot be attributed to anyone and is
+  refused, with a distinct log line — in production every request arrives through the
+  proxy, so that means the proxy is not sending the header we expect.
+  """
+
+  require Logger
+
+  alias Plug.Conn
+
+  @behaviour Plug
+
+  @forwarding_headers ~w[x-forwarded-for]
+
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
+
+  @doc false
+  @spec init(Plug.opts()) :: Plug.opts()
+  def init(opts), do: opts
+
+  @doc false
+  @spec call(Conn.t(), Plug.opts()) :: Conn.t()
+  def call(%Conn{path_info: [provider | _]} = conn, _opts) do
+    case allowlist(provider) do
+      [] -> conn
+      allowlist -> filter(conn, provider, allowlist)
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  @spec filter(Conn.t(), String.t(), [String.t()]) :: Conn.t()
+  defp filter(conn, provider, allowlist) do
+    case client_ip(conn) do
+      nil ->
+        reject(conn, "Request to the #{provider} webhook carried no usable x-forwarded-for")
+
+      client_ip ->
+        if allowed?(client_ip, allowlist),
+          do: conn,
+          else: reject(conn, "Unlisted IP #{format_ip(client_ip)} called the #{provider} webhook")
+    end
+  end
+
+  @spec reject(Conn.t(), String.t()) :: Conn.t()
+  defp reject(conn, message) do
+    Logger.warning(message)
+
+    conn
+    |> Conn.send_resp(403, "")
+    |> Conn.halt()
+  end
+
+  @spec client_ip(Conn.t()) :: :inet.ip_address() | nil
+  defp client_ip(conn), do: RemoteIp.from(conn.req_headers, headers: @forwarding_headers)
+
+  @spec format_ip(:inet.ip_address()) :: String.t()
+  defp format_ip(client_ip), do: client_ip |> :inet_parse.ntoa() |> to_string()
+
+  @spec allowed?(:inet.ip_address(), [String.t()]) :: boolean()
+  defp allowed?(remote_ip, allowlist) do
+    Enum.any?(allowlist, fn entry ->
+      case parse_cidr(entry) do
+        {:ok, cidr} -> InetCidr.contains?(cidr, remote_ip)
+        :error -> false
+      end
+    end)
+  end
+
+  @spec parse_cidr(String.t()) :: {:ok, tuple()} | :error
+  defp parse_cidr(entry) do
+    case InetCidr.parse_cidr(with_prefix_length(entry)) do
+      {:ok, cidr} ->
+        {:ok, cidr}
+
+      {:error, _reason} ->
+        Logger.warning("Ignoring invalid BSP webhook allowlist entry: #{entry}")
+        :error
+    end
+  end
+
+  @spec with_prefix_length(String.t()) :: String.t()
+  defp with_prefix_length(entry) do
+    cond do
+      String.contains?(entry, "/") -> entry
+      String.contains?(entry, ":") -> entry <> "/128"
+      true -> entry <> "/32"
+    end
+  end
+
+  @spec allowlist(String.t()) :: [String.t()]
+  defp allowlist(provider) do
+    with {:ok, key} <- Map.fetch(@allowlist_keys, provider),
+         ips when is_list(ips) <- Application.get_env(:glific, key) do
+      ips
+    else
+      _unconfigured -> []
+    end
+  end
+end

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -81,6 +81,7 @@ defmodule GlificWeb.Router do
     pipe_through([:api, :api_protected])
 
     post("/get-embed-token", SupersetController, :embed_token)
+    post("/simulator/message", SimulatorController, :message)
   end
 
   # Enables LiveDashboard only for development

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -114,8 +114,14 @@ defmodule GlificWeb.Router do
     forward("/api", Absinthe.Plug, schema: GlificWeb.Schema)
   end
 
+  pipeline :bsp_webhook do
+    plug(GlificWeb.Plugs.BSPWebhookIPFilter)
+  end
+
   # BSP webhooks
   scope "/", GlificWeb do
+    pipe_through(:bsp_webhook)
+
     forward("/gupshup", Providers.Gupshup.Plugs.Shunt)
     forward("/gupshup-enterprise", Providers.Gupshup.Enterprise.Plugs.Shunt)
     forward("/maytapi", Providers.Maytapi.Plugs.Shunt)

--- a/mix.exs
+++ b/mix.exs
@@ -148,6 +148,7 @@ defmodule Glific.MixProject do
       {:csv, "~> 3.2"},
       {:observer_cli, "~> 1.7"},
       {:apiac_filter_ip_whitelist, "~> 1.0"},
+      {:inet_cidr, "~> 1.0"},
       {:ex_phone_number, "~> 0.3"},
       {:tzdata, "~> 1.1"},
       {:stripity_stripe, "~> 2.3"},

--- a/test/glific_web/controllers/api/v1/simulator_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/simulator_controller_test.exs
@@ -1,0 +1,85 @@
+defmodule GlificWeb.API.V1.SimulatorControllerTest do
+  use GlificWeb.ConnCase
+
+  alias Glific.{
+    Contacts,
+    Fixtures,
+    Messages.Message,
+    Repo,
+    Seeds.SeedsDev
+  }
+
+  import Ecto.Query
+
+  setup do
+    SeedsDev.seed_organizations()
+    SeedsDev.seed_contacts()
+    :ok
+  end
+
+  defp simulator_phone do
+    Contacts.simulator_phone_prefix() <> "_1"
+  end
+
+  defp payload(phone, text) do
+    %{
+      "type" => "message",
+      "payload" => %{
+        "id" => Ecto.UUID.generate(),
+        "type" => "text",
+        "payload" => %{"text" => text},
+        "sender" => %{"phone" => phone, "name" => "Glific Simulator One"}
+      }
+    }
+  end
+
+  defp last_message_body(text) do
+    Message
+    |> where([message], message.body == ^text)
+    |> Repo.all(skip_organization_id: true)
+  end
+
+  describe "POST /api/v1/simulator/message" do
+    test "accepts a simulator message and receives it into the organization", %{conn: conn} do
+      text = "hello from the simulator"
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response = post(authed_conn, "/api/v1/simulator/message", payload(simulator_phone(), text))
+
+      assert response.status == 200
+      assert [message] = last_message_body(text)
+      assert message.organization_id == 1
+    end
+
+    test "rejects a payload naming a contact that is not a simulator", %{conn: conn} do
+      text = "forged beneficiary message"
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response = post(authed_conn, "/api/v1/simulator/message", payload("919876543211", text))
+
+      assert json_response(response, 403)["error"]["status"] == 403
+      assert [] == last_message_body(text)
+    end
+
+    test "rejects a payload with no sender", %{conn: conn} do
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response =
+        post(authed_conn, "/api/v1/simulator/message", %{
+          "type" => "message",
+          "payload" => %{"type" => "text"}
+        })
+
+      assert json_response(response, 403)["error"]["status"] == 403
+    end
+
+    test "refuses an unauthenticated caller", %{conn: conn} do
+      text = "unauthenticated simulator message"
+
+      response = post(conn, "/api/v1/simulator/message", payload(simulator_phone(), text))
+
+      assert json_response(response, 401)["error"]["code"] == 401
+      assert [] == last_message_body(text)
+    end
+  end
+end

--- a/test/glific_web/controllers/api/v1/simulator_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/simulator_controller_test.exs
@@ -1,5 +1,11 @@
 defmodule GlificWeb.API.V1.SimulatorControllerTest do
+  @moduledoc """
+  Tests for the authenticated simulator endpoint: that a simulator payload is received into
+  the caller's organization, and that anything else is refused.
+  """
   use GlificWeb.ConnCase
+
+  import Ecto.Query
 
   alias Glific.{
     Contacts,
@@ -8,8 +14,6 @@ defmodule GlificWeb.API.V1.SimulatorControllerTest do
     Repo,
     Seeds.SeedsDev
   }
-
-  import Ecto.Query
 
   setup do
     SeedsDev.seed_organizations()

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -1,0 +1,210 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias GlificWeb.Plugs.BSPWebhookIPFilter
+
+  # RFC 5737 documentation addresses, so no real provider IP is held in the repository.
+  @provider_ip "192.0.2.10"
+  @attacker_ip "203.0.113.5"
+
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
+
+  setup do
+    original =
+      Map.new(@allowlist_keys, fn {_provider, key} -> {key, Application.get_env(:glific, key)} end)
+
+    on_exit(fn -> Enum.each(original, fn {key, ips} -> put_allowlist(key, ips) end) end)
+
+    :ok
+  end
+
+  defp configure(allowlist) do
+    Enum.each(@allowlist_keys, fn {provider, key} ->
+      put_allowlist(key, Map.get(allowlist, provider))
+    end)
+  end
+
+  defp put_allowlist(key, nil), do: Application.delete_env(:glific, key)
+  defp put_allowlist(key, ips), do: Application.put_env(:glific, key, ips)
+
+  defp build_conn(path, headers) do
+    Enum.reduce(headers, conn(:post, path, %{}), fn {header, value}, conn ->
+      Plug.Conn.put_req_header(conn, header, value)
+    end)
+  end
+
+  defp call(path, headers) when is_list(headers),
+    do: BSPWebhookIPFilter.call(build_conn(path, headers), BSPWebhookIPFilter.init([]))
+
+  defp call(path, client_ip), do: call(path, [{"x-forwarded-for", client_ip}])
+
+  describe "filtering" do
+    setup do
+      configure(%{"gupshup" => ["192.0.2.10", "192.0.2.11"], "maytapi" => []})
+    end
+
+    test "lets a request from an allowlisted provider IP through" do
+      conn = call("/gupshup", @provider_ip)
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+
+    test "rejects a request from an IP the provider does not publish" do
+      conn = call("/gupshup", @attacker_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not filter a provider with an empty allowlist" do
+      conn = call("/maytapi", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "does not filter a provider that is not configured at all" do
+      conn = call("/gupshup-enterprise", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "keeps each provider's allowlist to itself" do
+      configure(%{"gupshup" => ["192.0.2.10"], "maytapi" => ["198.51.100.1"]})
+
+      conn = call("/maytapi", @provider_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "missing config leaves every request untouched" do
+      configure(%{})
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "a request without a path segment is left alone" do
+      conn = call("/", @attacker_ip)
+
+      refute conn.halted
+    end
+  end
+
+  describe "client IP is taken only from x-forwarded-for" do
+    setup do
+      configure(%{"gupshup" => ["192.0.2.10"]})
+    end
+
+    test "takes the last client address the proxy appended" do
+      conn = call("/gupshup", "#{@attacker_ip}, #{@provider_ip}")
+
+      refute conn.halted
+    end
+
+    test "ignores an allowlisted address supplied in x-real-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-real-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in x-client-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-client-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in forwarded" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"forwarded", "for=#{@provider_ip}"}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "refuses a request that carries no forwarding header" do
+      conn = call("/gupshup", [])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not fall back to the socket peer address" do
+      conn =
+        %{build_conn("/gupshup", []) | remote_ip: {192, 0, 2, 10}}
+        |> BSPWebhookIPFilter.call(BSPWebhookIPFilter.init([]))
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
+  describe "matching" do
+    test "matches an IP inside a CIDR block" do
+      configure(%{"gupshup" => ["198.51.100.0/24"]})
+
+      allowed = call("/gupshup", "198.51.100.7")
+      rejected = call("/gupshup", "198.51.101.7")
+
+      refute allowed.halted
+      assert rejected.halted
+    end
+
+    test "ignores an unparsable entry instead of failing the request" do
+      configure(%{"gupshup" => ["not-an-ip", "192.0.2.10"]})
+
+      conn = call("/gupshup", @provider_ip)
+
+      refute conn.halted
+    end
+
+    test "an IPv6 caller does not match an IPv4 allowlist" do
+      configure(%{"gupshup" => ["192.0.2.10"]})
+
+      conn = call("/gupshup", "2001:db8::1")
+
+      assert conn.halted
+    end
+
+    test "matches an IPv6 caller against an IPv6 allowlist" do
+      configure(%{"gupshup" => ["2001:db8::/32"]})
+
+      conn = call("/gupshup", "2001:db8::1")
+
+      refute conn.halted
+    end
+  end
+
+  test "the router runs the filter ahead of the gupshup shunt" do
+    configure(%{"gupshup" => ["192.0.2.10"]})
+
+    conn =
+      "/gupshup"
+      |> build_conn([{"x-forwarded-for", @attacker_ip}])
+      |> GlificWeb.Router.call(GlificWeb.Router.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+end


### PR DESCRIPTION
## Summary

Follow-up to #5555. That PR restricts `/gupshup` to Gupshup's published source IPs — which breaks the simulator, because the simulator is not Gupshup.

`glific-frontend` posts simulator messages straight to the BSP webhook, from the browser:

```ts
// src/config/index.ts
export const GUPSHUP_CALLBACK_URL = `${GLIFIC_BACKEND_URL}/gupshup`;

// src/components/simulator/Simulator.tsx
axios.post(GUPSHUP_CALLBACK_URL, { type: 'message', payload: {...} })
```

That request comes from the staff member's laptop, carries no authentication, and picks its organization from the request host. So it is both the thing the IP filter is designed to reject, and an example of the weakness #5555 exists to close.

### What changed

Adds `POST /api/v1/simulator/message` behind the existing authenticated pipeline (`:api`, `:api_protected`):

- **Organization comes from the caller's token, not the host.** A user can only ever drive their own organization's simulator.
- **Only simulator contacts are accepted.** A payload naming any other sender is refused with 403, so this cannot be used to forge a message from a real beneficiary.
- **Everything past those checks is handed to the existing Gupshup shunt**, so every message type the simulator produces — text, media, location, interactive replies — is handled exactly as an inbound message is, with no duplicated payload handling.

### ⚠️ Needs the matching frontend change

This endpoint is inert until `glific-frontend` posts here instead of `/gupshup`, with the auth token attached. Merge order that avoids a broken simulator:

1. This PR (adds the endpoint; nothing else changes behaviour).
2. The frontend PR (switches the URL).
3. #5555 (starts rejecting unlisted IPs on `/gupshup`).

If #5555 lands before the frontend change, the simulator is broken in the gap.

### Testing

Four tests in `test/glific_web/controllers/api/v1/simulator_controller_test.exs`:

- an authenticated simulator payload is received and the message is stored against the caller's organization
- a payload naming a non-simulator phone is refused with 403 and stores nothing
- a payload with no sender is refused
- an unauthenticated caller gets 401 and stores nothing

Also ran the provider and controller suites (136 tests, 0 failures) to confirm the existing webhook path is untouched.

## Checklist

- [x] Tests added and passing.
- [x] Coding standard and conventions followed — `mix format`, `mix credo --strict`, `mix dialyzer` and `mix doctor` (100% doc and spec coverage) all clean, plus a warnings-as-errors compile.
- [ ] `mix setup` and the full suite were not run locally; verification was targeted at the affected areas. Leaving the full run to CI.
- [ ] New endpoint is REST rather than GraphQL, matching the existing `/api/v1` controllers, so there is no `.gql` asset. Happy to add a Postman/Bruno entry if wanted.

## Notes

The endpoint deliberately reuses `GlificWeb.Providers.Gupshup.Plugs.Shunt` rather than reimplementing dispatch. That keeps simulator behaviour identical to inbound behaviour by construction — including running as the organization's root user, which is what the simulator does today — so message types cannot drift apart between the two paths.
