### PR TITLE
fix(webhooks): restrict BSP webhooks to provider source IPs and add an authenticated simulator endpoint

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -200,6 +200,16 @@ config :glific,
 
 # :inet rather than the CIDR library the plug matches with, because config runs before any
 # dependency is started.
+# The CIDR library the plug matches with rejects a block whose host bits are set, so
+# accepting one here would leave a list that looks configured but never matches, and the
+# whole range would be answered with 403.
+network_address? = fn parsed, prefix_length ->
+  {bits, group} = if tuple_size(parsed) == 4, do: {32, 256}, else: {128, 65_536}
+  address = parsed |> Tuple.to_list() |> Enum.reduce(0, fn part, acc -> acc * group + part end)
+
+  rem(address, Integer.pow(2, bits - prefix_length)) == 0
+end
+
 valid_webhook_ip? = fn entry ->
   [address | prefix] = String.split(entry, "/", parts: 2)
 
@@ -215,7 +225,13 @@ valid_webhook_ip? = fn entry ->
           true
 
         [length] ->
-          match?({value, ""} when value >= 0 and value <= max_length, Integer.parse(length))
+          case Integer.parse(length) do
+            {prefix_length, ""} when prefix_length >= 0 and prefix_length <= max_length ->
+              network_address?.(parsed, prefix_length)
+
+            _invalid ->
+              false
+          end
       end
   end
 end
@@ -235,6 +251,9 @@ webhook_ips = fn variable ->
           else:
             raise("""
             #{variable} contains "#{entry}", which is not an IP address or CIDR block.
+
+            A CIDR block must be given as its network address, so 192.0.2.0/24 rather than
+            192.0.2.10/24.
 
             Expected a comma separated list, for example:
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -195,6 +195,80 @@ config :glific,
   api_host_override: env!("GLIFIC_API_HOST_OVERRIDE", :string, nil),
   discord_webhook_url: env!("DISCORD_WEBHOOK_URL", :string, nil)
 
+# The BSP webhooks are unauthenticated, so callers are filtered on the source IPs the
+# provider publishes; anything else gets a 403.
+
+# :inet rather than the CIDR library the plug matches with, because config runs before any
+# dependency is started.
+valid_webhook_ip? = fn entry ->
+  [address | prefix] = String.split(entry, "/", parts: 2)
+
+  case :inet.parse_address(String.to_charlist(address)) do
+    {:error, _reason} ->
+      false
+
+    {:ok, parsed} ->
+      max_length = if tuple_size(parsed) == 4, do: 32, else: 128
+
+      case prefix do
+        [] ->
+          true
+
+        [length] ->
+          match?({value, ""} when value >= 0 and value <= max_length, Integer.parse(length))
+      end
+  end
+end
+
+webhook_ips = fn variable ->
+  case env!(variable, :string, nil) do
+    unset when unset in [nil, ""] ->
+      []
+
+    ips ->
+      ips
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.map(fn entry ->
+        if valid_webhook_ip?.(entry),
+          do: entry,
+          else:
+            raise("""
+            #{variable} contains "#{entry}", which is not an IP address or CIDR block.
+
+            Expected a comma separated list, for example:
+
+                gigalixir config:set #{variable}="a.b.c.d,e.f.g.h,w.x.y.z/24"
+            """)
+      end)
+  end
+end
+
+# Only :prod is configured. An unset list means the provider is not filtered, which keeps
+# dev and test working against localhost.
+if config_env() == :prod do
+  gupshup_webhook_ips = webhook_ips.("GUPSHUP_WEBHOOK_IPS")
+
+  # Booting without this list would leave the busiest webhook accepting forged messages
+  # from any caller, so refuse to start rather than come up unprotected.
+  if gupshup_webhook_ips == [],
+    do:
+      raise("""
+      GUPSHUP_WEBHOOK_IPS is not set.
+
+      The /gupshup webhook is unauthenticated and is guarded only by Gupshup's published
+      callback IPs, so Glific will not boot without them.
+
+      Set it to Gupshup's comma separated callback IPs, CIDR blocks allowed:
+
+          gigalixir config:set GUPSHUP_WEBHOOK_IPS="a.b.c.d,e.f.g.h,w.x.y.z/24"
+      """)
+
+  config :glific, :gupshup_webhook_ips, gupshup_webhook_ips
+  config :glific, :gupshup_enterprise_webhook_ips, webhook_ips.("GUPSHUP_ENTERPRISE_WEBHOOK_IPS")
+  config :glific, :maytapi_webhook_ips, webhook_ips.("MAYTAPI_WEBHOOK_IPS")
+end
+
 search_repo_module =
   if(env!("USE_REPLICA_DB", :boolean, false), do: Glific.RepoReplica, else: Glific.Repo)
 

--- a/lib/glific_web/controllers/api/v1/simulator_controller.ex
+++ b/lib/glific_web/controllers/api/v1/simulator_controller.ex
@@ -27,6 +27,9 @@ defmodule GlificWeb.API.V1.SimulatorController do
     %User{organization_id: organization_id} = conn.assigns[:current_user]
 
     if simulator_sender?(params) do
+      # SubdomainPlug has already resolved an organization from the host, but that only says
+      # which one the URL named. Taking the caller's own instead stops a valid token being
+      # pointed at another organization's simulator.
       Repo.put_organization_id(organization_id)
 
       conn

--- a/lib/glific_web/controllers/api/v1/simulator_controller.ex
+++ b/lib/glific_web/controllers/api/v1/simulator_controller.ex
@@ -1,0 +1,50 @@
+defmodule GlificWeb.API.V1.SimulatorController do
+  @moduledoc """
+  Authenticated entry point for messages typed into the simulator.
+
+  The simulator posts a message as though a contact had sent it. That used to go straight to
+  the BSP webhook, which meant an unauthenticated request deciding an organization from the
+  request host. Here the caller is authenticated and the organization comes from their token,
+  so a user can only ever drive the simulator belonging to their own organization.
+
+  Only simulator contacts are accepted; a payload naming any other sender is refused, so this
+  cannot be used to forge a message from a real beneficiary.
+
+  Beyond those checks the payload is handed to the usual Gupshup shunt, so every message type
+  the simulator produces is handled exactly as an inbound message is.
+  """
+
+  use GlificWeb, :controller
+
+  alias Glific.{Contacts, Repo, Users.User}
+  alias GlificWeb.Providers.Gupshup.Plugs.Shunt
+
+  @doc """
+  Injects a simulator message into the inbound pipeline for the caller's organization.
+  """
+  @spec message(Plug.Conn.t(), map()) :: Plug.Conn.t()
+  def message(conn, params) do
+    %User{organization_id: organization_id} = conn.assigns[:current_user]
+
+    if simulator_sender?(params) do
+      Repo.put_organization_id(organization_id)
+
+      conn
+      |> assign(:organization_id, organization_id)
+      |> Shunt.call(Shunt.init([]))
+    else
+      conn
+      |> put_status(:forbidden)
+      |> json(%{
+        error: %{status: 403, message: "Only simulator contacts can send simulator messages."}
+      })
+    end
+  end
+
+  @spec simulator_sender?(map()) :: boolean()
+  defp simulator_sender?(%{"payload" => %{"sender" => %{"phone" => phone}}})
+       when is_binary(phone),
+       do: Contacts.simulator_contact?(phone)
+
+  defp simulator_sender?(_params), do: false
+end

--- a/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
+++ b/lib/glific_web/plugs/bsp_webhook_ip_filter.ex
@@ -1,0 +1,138 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilter do
+  @moduledoc """
+  Restricts the BSP webhook endpoints to the source IPs published by each provider.
+
+  These endpoints are unauthenticated: the organization is resolved from the request
+  host and the shunt then runs the request as that organization's root user. Filtering
+  on the provider's published callback IPs is what stops an arbitrary caller from
+  posting a forged inbound message on behalf of any organization.
+
+  The provider is the first path segment (`/gupshup`, `/gupshup-enterprise`, `/maytapi`)
+  and each one carries its own config key, so a provider can be changed on its own:
+
+      config :glific, :gupshup_webhook_ips, ["192.0.2.10", "198.51.100.0/24"]
+
+  Entries are IPv4/IPv6 addresses or CIDR blocks. A caller outside its provider's list is
+  logged and answered with 403. That log line is the only warning that a provider has
+  started calling from an address we do not know about, so it is worth alerting on.
+
+  A provider whose list is empty is not filtered at all. That is what keeps a route
+  working before its IPs are known, and what leaves dev and test unfiltered, since
+  `config/runtime.exs` only populates the lists in `:prod`.
+
+  The lists come per provider from the environment (`GUPSHUP_WEBHOOK_IPS` and friends)
+  and are deliberately not held in this repository, so a provider adding an IP is a
+  `gigalixir config:set` and a restart rather than a deploy. Because an empty list means
+  no filtering, `runtime.exs` refuses to boot `:prod` when `GUPSHUP_WEBHOOK_IPS` is
+  missing rather than let the busiest webhook come up unguarded.
+
+  The caller is taken from `x-forwarded-for` alone, rather than from `conn.remote_ip`.
+  `GlificWeb.Endpoint` runs `RemoteIp` with its defaults, which also trust `forwarded`,
+  `x-client-ip` and `x-real-ip`; our proxy only rewrites `x-forwarded-for`, so a caller
+  that sends one of the other three can put an allowlisted address last in the chain and
+  have it win. Deciding here from the one header the proxy controls keeps that out of a
+  security decision, and leaves `conn.remote_ip` untouched for rate limiting and logging.
+
+  A request with no usable `x-forwarded-for` cannot be attributed to anyone and is
+  refused, with a distinct log line — in production every request arrives through the
+  proxy, so that means the proxy is not sending the header we expect.
+  """
+
+  require Logger
+
+  alias Plug.Conn
+
+  @behaviour Plug
+
+  @forwarding_headers ~w[x-forwarded-for]
+
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
+
+  @doc false
+  @spec init(Plug.opts()) :: Plug.opts()
+  def init(opts), do: opts
+
+  @doc false
+  @spec call(Conn.t(), Plug.opts()) :: Conn.t()
+  def call(%Conn{path_info: [provider | _]} = conn, _opts) do
+    case allowlist(provider) do
+      [] -> conn
+      allowlist -> filter(conn, provider, allowlist)
+    end
+  end
+
+  def call(conn, _opts), do: conn
+
+  @spec filter(Conn.t(), String.t(), [String.t()]) :: Conn.t()
+  defp filter(conn, provider, allowlist) do
+    case client_ip(conn) do
+      nil ->
+        reject(conn, "Request to the #{provider} webhook carried no usable x-forwarded-for")
+
+      client_ip ->
+        if allowed?(client_ip, allowlist),
+          do: conn,
+          else: reject(conn, "Unlisted IP #{format_ip(client_ip)} called the #{provider} webhook")
+    end
+  end
+
+  @spec reject(Conn.t(), String.t()) :: Conn.t()
+  defp reject(conn, message) do
+    Logger.warning(message)
+
+    conn
+    |> Conn.send_resp(403, "")
+    |> Conn.halt()
+  end
+
+  @spec client_ip(Conn.t()) :: :inet.ip_address() | nil
+  defp client_ip(conn), do: RemoteIp.from(conn.req_headers, headers: @forwarding_headers)
+
+  @spec format_ip(:inet.ip_address()) :: String.t()
+  defp format_ip(client_ip), do: client_ip |> :inet_parse.ntoa() |> to_string()
+
+  @spec allowed?(:inet.ip_address(), [String.t()]) :: boolean()
+  defp allowed?(remote_ip, allowlist) do
+    Enum.any?(allowlist, fn entry ->
+      case parse_cidr(entry) do
+        {:ok, cidr} -> InetCidr.contains?(cidr, remote_ip)
+        :error -> false
+      end
+    end)
+  end
+
+  @spec parse_cidr(String.t()) :: {:ok, tuple()} | :error
+  defp parse_cidr(entry) do
+    case InetCidr.parse_cidr(with_prefix_length(entry)) do
+      {:ok, cidr} ->
+        {:ok, cidr}
+
+      {:error, _reason} ->
+        Logger.warning("Ignoring invalid BSP webhook allowlist entry: #{entry}")
+        :error
+    end
+  end
+
+  @spec with_prefix_length(String.t()) :: String.t()
+  defp with_prefix_length(entry) do
+    cond do
+      String.contains?(entry, "/") -> entry
+      String.contains?(entry, ":") -> entry <> "/128"
+      true -> entry <> "/32"
+    end
+  end
+
+  @spec allowlist(String.t()) :: [String.t()]
+  defp allowlist(provider) do
+    with {:ok, key} <- Map.fetch(@allowlist_keys, provider),
+         ips when is_list(ips) <- Application.get_env(:glific, key) do
+      ips
+    else
+      _unconfigured -> []
+    end
+  end
+end

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -81,6 +81,7 @@ defmodule GlificWeb.Router do
     pipe_through([:api, :api_protected])
 
     post("/get-embed-token", SupersetController, :embed_token)
+    post("/simulator/message", SimulatorController, :message)
   end
 
   # Enables LiveDashboard only for development

--- a/lib/glific_web/router.ex
+++ b/lib/glific_web/router.ex
@@ -114,8 +114,14 @@ defmodule GlificWeb.Router do
     forward("/api", Absinthe.Plug, schema: GlificWeb.Schema)
   end
 
+  pipeline :bsp_webhook do
+    plug(GlificWeb.Plugs.BSPWebhookIPFilter)
+  end
+
   # BSP webhooks
   scope "/", GlificWeb do
+    pipe_through(:bsp_webhook)
+
     forward("/gupshup", Providers.Gupshup.Plugs.Shunt)
     forward("/gupshup-enterprise", Providers.Gupshup.Enterprise.Plugs.Shunt)
     forward("/maytapi", Providers.Maytapi.Plugs.Shunt)

--- a/mix.exs
+++ b/mix.exs
@@ -148,6 +148,7 @@ defmodule Glific.MixProject do
       {:csv, "~> 3.2"},
       {:observer_cli, "~> 1.7"},
       {:apiac_filter_ip_whitelist, "~> 1.0"},
+      {:inet_cidr, "~> 1.0"},
       {:ex_phone_number, "~> 0.3"},
       {:tzdata, "~> 1.1"},
       {:stripity_stripe, "~> 2.3"},

--- a/test/glific_web/controllers/api/v1/simulator_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/simulator_controller_test.exs
@@ -1,0 +1,85 @@
+defmodule GlificWeb.API.V1.SimulatorControllerTest do
+  use GlificWeb.ConnCase
+
+  alias Glific.{
+    Contacts,
+    Fixtures,
+    Messages.Message,
+    Repo,
+    Seeds.SeedsDev
+  }
+
+  import Ecto.Query
+
+  setup do
+    SeedsDev.seed_organizations()
+    SeedsDev.seed_contacts()
+    :ok
+  end
+
+  defp simulator_phone do
+    Contacts.simulator_phone_prefix() <> "_1"
+  end
+
+  defp payload(phone, text) do
+    %{
+      "type" => "message",
+      "payload" => %{
+        "id" => Ecto.UUID.generate(),
+        "type" => "text",
+        "payload" => %{"text" => text},
+        "sender" => %{"phone" => phone, "name" => "Glific Simulator One"}
+      }
+    }
+  end
+
+  defp last_message_body(text) do
+    Message
+    |> where([message], message.body == ^text)
+    |> Repo.all(skip_organization_id: true)
+  end
+
+  describe "POST /api/v1/simulator/message" do
+    test "accepts a simulator message and receives it into the organization", %{conn: conn} do
+      text = "hello from the simulator"
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response = post(authed_conn, "/api/v1/simulator/message", payload(simulator_phone(), text))
+
+      assert response.status == 200
+      assert [message] = last_message_body(text)
+      assert message.organization_id == 1
+    end
+
+    test "rejects a payload naming a contact that is not a simulator", %{conn: conn} do
+      text = "forged beneficiary message"
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response = post(authed_conn, "/api/v1/simulator/message", payload("919876543211", text))
+
+      assert json_response(response, 403)["error"]["status"] == 403
+      assert [] == last_message_body(text)
+    end
+
+    test "rejects a payload with no sender", %{conn: conn} do
+      authed_conn = api_auth_conn(conn, Fixtures.user_fixture(%{roles: ["staff"]}))
+
+      response =
+        post(authed_conn, "/api/v1/simulator/message", %{
+          "type" => "message",
+          "payload" => %{"type" => "text"}
+        })
+
+      assert json_response(response, 403)["error"]["status"] == 403
+    end
+
+    test "refuses an unauthenticated caller", %{conn: conn} do
+      text = "unauthenticated simulator message"
+
+      response = post(conn, "/api/v1/simulator/message", payload(simulator_phone(), text))
+
+      assert json_response(response, 401)["error"]["code"] == 401
+      assert [] == last_message_body(text)
+    end
+  end
+end

--- a/test/glific_web/controllers/api/v1/simulator_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/simulator_controller_test.exs
@@ -1,5 +1,11 @@
 defmodule GlificWeb.API.V1.SimulatorControllerTest do
+  @moduledoc """
+  Tests for the authenticated simulator endpoint: that a simulator payload is received into
+  the caller's organization, and that anything else is refused.
+  """
   use GlificWeb.ConnCase
+
+  import Ecto.Query
 
   alias Glific.{
     Contacts,
@@ -8,8 +14,6 @@ defmodule GlificWeb.API.V1.SimulatorControllerTest do
     Repo,
     Seeds.SeedsDev
   }
-
-  import Ecto.Query
 
   setup do
     SeedsDev.seed_organizations()

--- a/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
+++ b/test/glific_web/plugs/bsp_webhook_ip_filter_test.exs
@@ -1,0 +1,210 @@
+defmodule GlificWeb.Plugs.BSPWebhookIPFilterTest do
+  use ExUnit.Case, async: false
+
+  import Plug.Test
+
+  alias GlificWeb.Plugs.BSPWebhookIPFilter
+
+  # RFC 5737 documentation addresses, so no real provider IP is held in the repository.
+  @provider_ip "192.0.2.10"
+  @attacker_ip "203.0.113.5"
+
+  @allowlist_keys %{
+    "gupshup" => :gupshup_webhook_ips,
+    "gupshup-enterprise" => :gupshup_enterprise_webhook_ips,
+    "maytapi" => :maytapi_webhook_ips
+  }
+
+  setup do
+    original =
+      Map.new(@allowlist_keys, fn {_provider, key} -> {key, Application.get_env(:glific, key)} end)
+
+    on_exit(fn -> Enum.each(original, fn {key, ips} -> put_allowlist(key, ips) end) end)
+
+    :ok
+  end
+
+  defp configure(allowlist) do
+    Enum.each(@allowlist_keys, fn {provider, key} ->
+      put_allowlist(key, Map.get(allowlist, provider))
+    end)
+  end
+
+  defp put_allowlist(key, nil), do: Application.delete_env(:glific, key)
+  defp put_allowlist(key, ips), do: Application.put_env(:glific, key, ips)
+
+  defp build_conn(path, headers) do
+    Enum.reduce(headers, conn(:post, path, %{}), fn {header, value}, conn ->
+      Plug.Conn.put_req_header(conn, header, value)
+    end)
+  end
+
+  defp call(path, headers) when is_list(headers),
+    do: BSPWebhookIPFilter.call(build_conn(path, headers), BSPWebhookIPFilter.init([]))
+
+  defp call(path, client_ip), do: call(path, [{"x-forwarded-for", client_ip}])
+
+  describe "filtering" do
+    setup do
+      configure(%{"gupshup" => ["192.0.2.10", "192.0.2.11"], "maytapi" => []})
+    end
+
+    test "lets a request from an allowlisted provider IP through" do
+      conn = call("/gupshup", @provider_ip)
+
+      refute conn.halted
+      assert conn.status == nil
+    end
+
+    test "rejects a request from an IP the provider does not publish" do
+      conn = call("/gupshup", @attacker_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not filter a provider with an empty allowlist" do
+      conn = call("/maytapi", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "does not filter a provider that is not configured at all" do
+      conn = call("/gupshup-enterprise", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "keeps each provider's allowlist to itself" do
+      configure(%{"gupshup" => ["192.0.2.10"], "maytapi" => ["198.51.100.1"]})
+
+      conn = call("/maytapi", @provider_ip)
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "missing config leaves every request untouched" do
+      configure(%{})
+
+      conn = call("/gupshup", @attacker_ip)
+
+      refute conn.halted
+    end
+
+    test "a request without a path segment is left alone" do
+      conn = call("/", @attacker_ip)
+
+      refute conn.halted
+    end
+  end
+
+  describe "client IP is taken only from x-forwarded-for" do
+    setup do
+      configure(%{"gupshup" => ["192.0.2.10"]})
+    end
+
+    test "takes the last client address the proxy appended" do
+      conn = call("/gupshup", "#{@attacker_ip}, #{@provider_ip}")
+
+      refute conn.halted
+    end
+
+    test "ignores an allowlisted address supplied in x-real-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-real-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in x-client-ip" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"x-client-ip", @provider_ip}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "ignores an allowlisted address supplied in forwarded" do
+      conn =
+        call("/gupshup", [
+          {"x-forwarded-for", @attacker_ip},
+          {"forwarded", "for=#{@provider_ip}"}
+        ])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "refuses a request that carries no forwarding header" do
+      conn = call("/gupshup", [])
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+
+    test "does not fall back to the socket peer address" do
+      conn =
+        %{build_conn("/gupshup", []) | remote_ip: {192, 0, 2, 10}}
+        |> BSPWebhookIPFilter.call(BSPWebhookIPFilter.init([]))
+
+      assert conn.halted
+      assert conn.status == 403
+    end
+  end
+
+  describe "matching" do
+    test "matches an IP inside a CIDR block" do
+      configure(%{"gupshup" => ["198.51.100.0/24"]})
+
+      allowed = call("/gupshup", "198.51.100.7")
+      rejected = call("/gupshup", "198.51.101.7")
+
+      refute allowed.halted
+      assert rejected.halted
+    end
+
+    test "ignores an unparsable entry instead of failing the request" do
+      configure(%{"gupshup" => ["not-an-ip", "192.0.2.10"]})
+
+      conn = call("/gupshup", @provider_ip)
+
+      refute conn.halted
+    end
+
+    test "an IPv6 caller does not match an IPv4 allowlist" do
+      configure(%{"gupshup" => ["192.0.2.10"]})
+
+      conn = call("/gupshup", "2001:db8::1")
+
+      assert conn.halted
+    end
+
+    test "matches an IPv6 caller against an IPv6 allowlist" do
+      configure(%{"gupshup" => ["2001:db8::/32"]})
+
+      conn = call("/gupshup", "2001:db8::1")
+
+      refute conn.halted
+    end
+  end
+
+  test "the router runs the filter ahead of the gupshup shunt" do
+    configure(%{"gupshup" => ["192.0.2.10"]})
+
+    conn =
+      "/gupshup"
+      |> build_conn([{"x-forwarded-for", @attacker_ip}])
+      |> GlificWeb.Router.call(GlificWeb.Router.init([]))
+
+    assert conn.halted
+    assert conn.status == 403
+  end
+end


### PR DESCRIPTION
## Summary

Target issue is the internal security finding **GF-CVE-2026-08-5**.

Two changes that have to ship together: the IP filter that closes the finding, and the authenticated simulator endpoint that keeps the simulator working once `/gupshup` is closed to browsers.

Supersedes #5578 (same branch, closed when the branch was renamed; its review history is still readable there). Re-lands #5555, which was reverted in #5575.

## ⚠️ Before merging: set the environment variable

`#5555` was merged on 18 Aug and the deploy **failed** — the new replica never became healthy — because `GUPSHUP_WEBHOOK_IPS` did not exist in the environment. The release refuses to boot without it, by design: an empty list means "do not filter", so booting without one would bring the app up unprotected.

```bash
gigalixir config:set GUPSHUP_WEBHOOK_IPS="<Gupshup's callback IPs, comma separated>"
```

The list is in the Gupshup support thread and is deliberately not in this repository. Set it **first**, confirm with `gigalixir config`, then merge.

## What changed

### 1. BSP webhook IP filter (`GlificWeb.Plugs.BSPWebhookIPFilter`)

Unchanged from what was reviewed on #5555, including the follow-up feedback:

- A `:bsp_webhook` router pipeline on the three BSP routes only; nothing else is affected.
- The caller is taken from `x-forwarded-for` alone, not `conn.remote_ip`. `RemoteIp` also trusts `forwarded`, `x-client-ip` and `x-real-ip`, and our proxy only rewrites `x-forwarded-for`, so a caller could otherwise put an allowlisted address in one of the others and walk through.
- One config key per provider (`:gupshup_webhook_ips` and friends), fed by one environment variable each, so a provider can be widened with `config:set` and a restart rather than a deploy.
- Allowlist entries are validated at boot; a malformed entry refuses to start rather than silently matching nothing.
- No provider IPs in the repository. Test fixtures use RFC 5737 documentation addresses.
- Providers with an empty list are not filtered, which is why `gupshup-enterprise` and `maytapi` keep working — no published list exists for either yet.

### 2. Authenticated simulator endpoint (`POST /api/v1/simulator/message`)

The simulator posted to `/gupshup`, the same URL Gupshup itself calls, from the user's browser. That request is unauthenticated, picks its organization from the request host, and stops working the moment `/gupshup` is IP-restricted.

- Organization comes from the caller's token, not the host, so a user can only drive their own organization's simulator.
- Only simulator contacts are accepted; any other sender is refused with 403, so this cannot forge a message from a real beneficiary.
- Everything past those checks goes to the existing Gupshup shunt, so all message types are handled exactly as inbound messages are.

## Merge and deploy order

```
0. gigalixir config:set GUPSHUP_WEBHOOK_IPS=...   ← or the deploy fails, as it did on 18 Aug
1. this PR
2. glific-frontend#4148                            ← simulator moves off /gupshup
```

**There is a window between 1 and 2 where the simulator is broken**, because this PR closes `/gupshup` to browsers while the released frontend still posts there. That is the cost of carrying both changes on one branch. Deploy the frontend promptly after this, and expect a further short window where staff with a stale tab need to reload.

## Testing

- 18 tests for the filter: allowlisted IP passes, unlisted gets 403, CIDR matching, per-provider isolation, IPv6, unparsable entry ignored, and the router running the filter ahead of the shunt. Four cover the header bypass specifically: an allowlisted address in `x-real-ip`, `x-client-ip` or `forwarded` is ignored, and the socket peer is not used.
- 4 tests for the simulator endpoint: a simulator payload is received into the caller's organization; a non-simulator sender, a missing sender, and an unauthenticated caller are each refused and store nothing.
- The 89 existing BSP webhook controller tests pass unchanged.
- Config resolution checked in each environment including `:prod`, with the variable set, missing, and holding a malformed entry.
- Driven end to end in a browser against a local backend: the flow editor preview posts to `/api/v1/simulator/message`, the flow replies, and answering a prompt advances it. HSM and interactive-message previews render without posting.

## Checklist

- [x] Tests added and passing — 111 tests across the filter, simulator and provider suites, 0 failures.
- [x] Coding standard and conventions followed — `mix format`, `mix credo --strict`, `mix dialyzer` and `mix doctor` (100% doc and spec coverage) all clean, plus a warnings-as-errors compile.
- [ ] `mix setup` and the full suite were not run locally; verification was targeted at the affected areas. Leaving the full run to CI.
- [ ] No new GraphQL API, so no `.gql` asset.

## Notes

Still outstanding, and not addressed here:

- **Alerting.** The filter logs `Unlisted IP … called the … webhook` on every rejection and nothing watches that line. It is the only signal that a provider has started calling from an address we do not know about.
- **`plug(RemoteIp)` has no `:proxies` set.** Restricting the header closes the bypass this PR is concerned with, but pinning the trusted proxy CIDR would make it airtight. That needs Gigalixir's ingress range.
- **Payload to organization binding.** This narrows who can reach the endpoint; it does not by itself close the finding.
