### PR TITLE
chore: document ERP_ENDPOINT in the dev env template

### DIFF
--- a/config/.env.dev.txt
+++ b/config/.env.dev.txt
@@ -20,6 +20,7 @@ NOTION_SECRET=this_is_not_the_secret
 GOOGLE_MAPS_API_KEY=this_is_not_the_secret
 ERP_API_KEY=this_is_not_the_secret
 ERP_SECRET=this_is_not_the_secret
+ERP_ENDPOINT=https://your-erp-host/api/resource
 OPEN_AI_PROJECT=this_is_not_the_secret
 AVNI_PASSWORD=this_is_not_secret
 READ_REPLICA_DATABASE_URL=ecto://postgres:postgres@postgres:5432/glific_dev


### PR DESCRIPTION
`ERP_ENDPOINT` is read by `ERP.fetch_organization_detail/1`, which gates organisation setup for
every non-trial org — but it was missing from `config/.env.dev.txt`, so a fresh dev environment
never sets it.

When unset, `runtime.exs:147` falls back to the literal string `"This is not a secret"`:

```elixir
ERP_ENDPOINT: env!("ERP_ENDPOINT", :string, "This is not a secret")
```

which makes the request URL `This is not a secret/Customer/<org name>`. Onboarding then fails with

```
[error] Unexpected response: body: :timeout
%{messages: %{global: "\"Unexpected response from ERP due to :timeout\""}, is_valid: false}
```

after roughly 8 seconds — an opaque failure that points at the network rather than at config.
This cost real debugging time.

Uses a shaped placeholder (`https://your-erp-host/api/resource`) rather than the real host, so
the value is obviously a URL that needs filling in, and local dev doesn't default to hitting
production ERP for Customer lookups. An unresolved host also fails fast and legibly instead of
hanging.

Worth knowing: trial orgs skip the ERP lookup entirely (`if is_trial do {:ok, nil}` in
`Queries.organization/2`), so `"is_trial" => true` is a way to exercise onboarding locally
without configuring this at all.