### PR TITLE
Bump version from 8.10.0 to 8.10.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Glific.MixProject do
   def project do
     [
       app: :glific,
-      version: "8.10.0",
+      version: "8.10.1",
       elixir: "~> 1.18.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [


### PR DESCRIPTION
Version bump 8.10.0 -> 8.10.1, opened by bin/gigalixir-release.sh.