### PR TITLE
fix(ai_evaluations): persist per-run duplication factor on AiEvaluation

### DIFF
--- a/assets/gql/ai_evaluations/list_ai_evaluations.gql
+++ b/assets/gql/ai_evaluations/list_ai_evaluations.gql
@@ -5,6 +5,7 @@ query AiEvaluations($filter: AiEvaluationFilter, $opts: Opts) {
     status
     failureReason
     results
+    duplicationFactor
     goldenQa {
       id
       name

--- a/lib/glific/ai_evaluations/ai_evaluation.ex
+++ b/lib/glific/ai_evaluations/ai_evaluation.ex
@@ -22,6 +22,7 @@ defmodule Glific.AIEvaluations.AIEvaluation do
           failure_reason: String.t() | nil,
           results: map(),
           kaapi_evaluation_id: non_neg_integer() | nil,
+          duplication_factor: non_neg_integer() | nil,
           golden_qa_id: non_neg_integer() | nil,
           golden_qa: GoldenQA.t() | Ecto.Association.NotLoaded.t() | nil,
           organization_id: non_neg_integer() | nil,
@@ -44,7 +45,8 @@ defmodule Glific.AIEvaluations.AIEvaluation do
   @optional_fields [
     :failure_reason,
     :results,
-    :kaapi_evaluation_id
+    :kaapi_evaluation_id,
+    :duplication_factor
   ]
 
   schema "ai_evaluations" do
@@ -53,6 +55,7 @@ defmodule Glific.AIEvaluations.AIEvaluation do
     field(:failure_reason, :string)
     field(:results, :map, default: %{})
     field(:kaapi_evaluation_id, :integer)
+    field(:duplication_factor, :integer, default: 1)
     belongs_to(:golden_qa, GoldenQA)
     belongs_to(:assistant_config_version, AssistantConfigVersion)
     belongs_to(:organization, Organization)

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -450,6 +450,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
              status: status,
              failure_reason: (data.status == "failed" && Map.get(data, :error_message)) || nil,
              kaapi_evaluation_id: data.id,
+             duplication_factor: duplication_factor,
              golden_qa_id: input.golden_qa_id,
              assistant_config_version_id: input.config_id,
              organization_id: user.organization_id

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -34,6 +34,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :status, :ai_evaluation_status_enum
     field :failure_reason, :string
     field :results, :json
+    field :duplication_factor, :integer
     field :golden_qa, :ai_eval_golden_qa
     field :assistant_config_version, :ai_eval_config_version
     field :inserted_at, :datetime

--- a/priv/repo/migrations/20260821000000_add_duplication_factor_to_ai_evaluations.exs
+++ b/priv/repo/migrations/20260821000000_add_duplication_factor_to_ai_evaluations.exs
@@ -1,0 +1,12 @@
+defmodule Glific.Repo.Migrations.AddDuplicationFactorToAiEvaluations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:ai_evaluations) do
+      add :duplication_factor, :integer,
+        default: 1,
+        null: false,
+        comment: "Duplication factor used for this evaluation run"
+    end
+  end
+end

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1839,8 +1839,10 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       resolution = %{context: %{current_user: user}}
 
-      assert {:ok, %{evaluation: _evaluation}} =
+      assert {:ok, %{evaluation: evaluation}} =
                AIEvaluations.create_evaluation(nil, args, resolution)
+
+      assert evaluation.duplication_factor == 3
 
       FunWithFlags.disable(:is_ai_evaluation_enabled,
         for_actor: %{organization_id: user.organization_id}


### PR DESCRIPTION
## Summary
Running an AI evaluation with any `duplicationFactor` other than 1 always showed `1` in the `aiEvaluations` list response.

Root cause: `create_evaluation` forwarded `duplication_factor` to Kaapi for the run but never persisted it on the `AiEvaluation` record. The GraphQL type only exposed `goldenQa.duplicationFactor`, which is the golden QA dataset's upload-time value (defaults to 1) — unrelated to the factor used for a given evaluation run.

Fix:
- Migration adds `duplication_factor` (default 1) to `ai_evaluations`.
- `create_evaluation` resolver now stores the run's factor on the record.
- `AiEvaluation` GraphQL type exposes `duplicationFactor` directly.
- `list_ai_evaluations.gql` updated to select it.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] Fixed a bug; added a test case covering the persisted value (`test/glific_web/resolvers/ai_evaluations_test.exs`).
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.
