### PR TITLE
feat(ai_evaluations): add GraphQL subscription for prompt-improve status

### DIFF
--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -204,6 +204,11 @@ defmodule Glific.AIEvaluations do
               updated_evaluation =
                 Repo.preload(evaluation, [:golden_qa, assistant_config_version: :assistant])
 
+              Logger.info(
+                "PUBLISH ai_evaluation_updated id=#{updated_evaluation.id} " <>
+                  "topic=#{updated_evaluation.organization_id} status=#{updated_evaluation.status}"
+              )
+
               Absinthe.Subscription.publish(
                 GlificWeb.Endpoint,
                 updated_evaluation,

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -316,34 +316,73 @@ defmodule Glific.AIEvaluations do
 
   @doc """
   Handles the async callback POSTed by Kaapi after v2 prompt-improvement completes.
+  Publishes `improve_prompt_updated` on a terminal (SUCCESS/FAILED) status; `organization_id`
+  is only required for the FAILED case since there's no config version to derive it from.
   """
-  @spec handle_improve_prompt_callback(map()) ::
+  @spec handle_improve_prompt_callback(map(), non_neg_integer() | nil) ::
           {:ok, AssistantConfigVersion.t() | :acknowledged} | {:error, String.t()}
-  def handle_improve_prompt_callback(%{"data" => %{"status" => "SUCCESS"} = data}),
-    do: create_improve_prompt_config_version(data["config_version"] || %{})
+  def handle_improve_prompt_callback(params, organization_id \\ nil)
 
-  def handle_improve_prompt_callback(%{"data" => %{"status" => "FAILED"} = data}) do
+  def handle_improve_prompt_callback(
+        %{"data" => %{"status" => "SUCCESS"} = data},
+        _organization_id
+      ) do
+    case create_improve_prompt_config_version(data["config_version"] || %{}) do
+      {:ok, config_version} = result ->
+        publish_improve_prompt_update(config_version.organization_id, %{
+          status: "success",
+          config_version: config_version,
+          error: nil
+        })
+
+        result
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  def handle_improve_prompt_callback(%{"data" => %{"status" => "FAILED"} = data}, organization_id) do
     Glific.log_exception(%Kaapi.Error{
       message: "Improve prompt failed",
       reason: safe_inspect(data)
     })
 
+    if organization_id do
+      publish_improve_prompt_update(organization_id, %{
+        status: "failed",
+        config_version: nil,
+        error: data["error_message"] || "Improve prompt failed"
+      })
+    end
+
     {:ok, :acknowledged}
   end
 
   # Non-terminal status (e.g. still PENDING) — nothing to do yet.
-  def handle_improve_prompt_callback(%{"data" => %{"status" => _}}),
+  def handle_improve_prompt_callback(%{"data" => %{"status" => _}}, _organization_id),
     do: {:ok, :acknowledged}
 
   # Defensive catch-all: the callback endpoint is public, so a malformed body must not
   # raise (the controller must still return 200).
-  def handle_improve_prompt_callback(params) do
+  def handle_improve_prompt_callback(params, _organization_id) do
     Glific.log_exception(%Kaapi.Error{
       message: "Unexpected improve prompt callback payload",
       reason: safe_inspect(params)
     })
 
     {:error, "Unexpected improve prompt callback payload"}
+  end
+
+  @spec publish_improve_prompt_update(non_neg_integer(), map()) :: :ok
+  defp publish_improve_prompt_update(organization_id, payload) do
+    Absinthe.Subscription.publish(
+      GlificWeb.Endpoint,
+      payload,
+      improve_prompt_updated: "#{organization_id}"
+    )
+
+    :ok
   end
 
   @spec build_improve_prompt_callback_url(non_neg_integer()) :: String.t()

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -379,7 +379,7 @@ defmodule Glific.AIEvaluations do
     Absinthe.Subscription.publish(
       GlificWeb.Endpoint,
       payload,
-      improve_prompt_updated: "#{organization_id}"
+      [{:improve_prompt_updated, "#{organization_id}"}]
     )
 
     :ok

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -207,7 +207,7 @@ defmodule Glific.AIEvaluations do
               Absinthe.Subscription.publish(
                 GlificWeb.Endpoint,
                 updated_evaluation,
-                ai_evaluation_updated: "#{updated_evaluation.organization_id}"
+                [{:ai_evaluation_updated, "#{updated_evaluation.organization_id}"}]
               )
 
               updated_evaluation
@@ -350,16 +350,14 @@ defmodule Glific.AIEvaluations do
 
   @doc """
   Handles the async callback POSTed by Kaapi after v2 prompt-improvement completes.
-  Publishes `improve_prompt_updated` on a terminal (SUCCESS/FAILED) status; `organization_id`
-  is only required for the FAILED case since there's no config version to derive it from.
+  Publishes `improve_prompt_updated` on a terminal (SUCCESS/FAILED) status; on SUCCESS the
+  topic's organization_id is derived from the new config version, not the `organization_id` arg.
   """
-  @spec handle_improve_prompt_callback(map(), non_neg_integer() | nil) ::
+  @spec handle_improve_prompt_callback(non_neg_integer(), map()) ::
           {:ok, AssistantConfigVersion.t() | :acknowledged} | {:error, String.t()}
-  def handle_improve_prompt_callback(params, organization_id \\ nil)
-
   def handle_improve_prompt_callback(
-        %{"data" => %{"status" => "SUCCESS"} = data},
-        _organization_id
+        _organization_id,
+        %{"data" => %{"status" => "SUCCESS"} = data}
       ) do
     case create_improve_prompt_config_version(data["config_version"] || %{}) do
       {:ok, config_version} = result ->
@@ -376,30 +374,28 @@ defmodule Glific.AIEvaluations do
     end
   end
 
-  def handle_improve_prompt_callback(%{"data" => %{"status" => "FAILED"} = data}, organization_id) do
+  def handle_improve_prompt_callback(organization_id, %{"data" => %{"status" => "FAILED"} = data}) do
     Glific.log_exception(%Kaapi.Error{
       message: "Improve prompt failed",
       reason: safe_inspect(data)
     })
 
-    if organization_id do
-      publish_improve_prompt_update(organization_id, %{
-        status: "failed",
-        config_version: nil,
-        error: data["error_message"] || "Improve prompt failed"
-      })
-    end
+    publish_improve_prompt_update(organization_id, %{
+      status: "failed",
+      config_version: nil,
+      error: data["error_message"] || "Improve prompt failed"
+    })
 
     {:ok, :acknowledged}
   end
 
   # Non-terminal status (e.g. still PENDING) — nothing to do yet.
-  def handle_improve_prompt_callback(%{"data" => %{"status" => _}}, _organization_id),
+  def handle_improve_prompt_callback(_organization_id, %{"data" => %{"status" => _}}),
     do: {:ok, :acknowledged}
 
   # Defensive catch-all: the callback endpoint is public, so a malformed body must not
   # raise (the controller must still return 200).
-  def handle_improve_prompt_callback(params, _organization_id) do
+  def handle_improve_prompt_callback(_organization_id, params) do
     Glific.log_exception(%Kaapi.Error{
       message: "Unexpected improve prompt callback payload",
       reason: safe_inspect(params)

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -204,11 +204,6 @@ defmodule Glific.AIEvaluations do
               updated_evaluation =
                 Repo.preload(evaluation, [:golden_qa, assistant_config_version: :assistant])
 
-              Logger.info(
-                "PUBLISH ai_evaluation_updated id=#{updated_evaluation.id} " <>
-                  "topic=#{updated_evaluation.organization_id} status=#{updated_evaluation.status}"
-              )
-
               Absinthe.Subscription.publish(
                 GlificWeb.Endpoint,
                 updated_evaluation,

--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -349,19 +349,17 @@ defmodule Glific.AIEvaluations do
   end
 
   @doc """
-  Handles the async callback POSTed by Kaapi after v2 prompt-improvement completes.
-  Publishes `improve_prompt_updated` on a terminal (SUCCESS/FAILED) status; on SUCCESS the
-  topic's organization_id is derived from the new config version, not the `organization_id` arg.
+  Handles the async callback POSTed by Kaapi after v2 prompt-improvement completes, publishing `improve_prompt_updated` on a terminal (SUCCESS/FAILED) status.
   """
   @spec handle_improve_prompt_callback(non_neg_integer(), map()) ::
-          {:ok, AssistantConfigVersion.t() | :acknowledged} | {:error, String.t()}
+          {:ok, AssistantConfigVersion.t() | :acknowledged} | {:error, any()}
   def handle_improve_prompt_callback(
-        _organization_id,
+        organization_id,
         %{"data" => %{"status" => "SUCCESS"} = data}
       ) do
-    case create_improve_prompt_config_version(data["config_version"] || %{}) do
+    case create_improve_prompt_config_version(data["config_version"] || %{}, organization_id) do
       {:ok, config_version} = result ->
-        publish_improve_prompt_update(config_version.organization_id, %{
+        publish_improve_prompt_update(organization_id, %{
           status: "success",
           config_version: config_version,
           error: nil
@@ -389,7 +387,6 @@ defmodule Glific.AIEvaluations do
     {:ok, :acknowledged}
   end
 
-  # Non-terminal status (e.g. still PENDING) — nothing to do yet.
   def handle_improve_prompt_callback(_organization_id, %{"data" => %{"status" => _}}),
     do: {:ok, :acknowledged}
 
@@ -464,11 +461,14 @@ defmodule Glific.AIEvaluations do
     :ok
   end
 
-  @spec create_improve_prompt_config_version(map()) ::
+  @spec create_improve_prompt_config_version(map(), non_neg_integer()) ::
           {:ok, AssistantConfigVersion.t()} | {:error, any()}
-  defp create_improve_prompt_config_version(config_version_data) do
+  defp create_improve_prompt_config_version(config_version_data, organization_id) do
     with {:ok, assistant} <-
-           Repo.fetch_by(Assistant, %{kaapi_uuid: config_version_data["config_id"]}) do
+           Repo.fetch_by(Assistant, %{
+             kaapi_uuid: config_version_data["config_id"],
+             organization_id: organization_id
+           }) do
       completion = get_in(config_version_data, ["config_blob", "completion"]) || %{}
       params = completion["params"] || %{}
 

--- a/lib/glific_web/controllers/kaapi_controller.ex
+++ b/lib/glific_web/controllers/kaapi_controller.ex
@@ -52,8 +52,11 @@ defmodule GlificWeb.KaapiController do
   unguessable token (matching the auth posture of the other Kaapi callbacks above).
   """
   @spec improve_prompt_callback(Plug.Conn.t(), map()) :: Plug.Conn.t()
-  def improve_prompt_callback(conn, params) do
-    AIEvaluations.handle_improve_prompt_callback(params)
+  def improve_prompt_callback(
+        %Plug.Conn{assigns: %{organization_id: organization_id}} = conn,
+        params
+      ) do
+    AIEvaluations.handle_improve_prompt_callback(params, organization_id)
     send_resp(conn, 200, "")
   end
 end

--- a/lib/glific_web/controllers/kaapi_controller.ex
+++ b/lib/glific_web/controllers/kaapi_controller.ex
@@ -56,7 +56,7 @@ defmodule GlificWeb.KaapiController do
         %Plug.Conn{assigns: %{organization_id: organization_id}} = conn,
         params
       ) do
-    AIEvaluations.handle_improve_prompt_callback(params, organization_id)
+    AIEvaluations.handle_improve_prompt_callback(organization_id, params)
     send_resp(conn, 200, "")
   end
 

--- a/lib/glific_web/schema.ex
+++ b/lib/glific_web/schema.ex
@@ -249,6 +249,8 @@ defmodule GlificWeb.Schema do
     import_fields(:ask_glific_subscriptions)
 
     import_fields(:assistant_chat_subscriptions)
+
+    import_fields(:ai_evaluation_subscriptions)
   end
 
   @doc """

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -249,6 +249,8 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
       config(fn _args, %{context: %{current_user: user}} ->
         {:ok, topic: "#{user.organization_id}"}
       end)
+
+      resolve(fn update, _args, _resolution -> {:ok, update} end)
     end
 
     @desc "Delivers an AI evaluation's status as it changes (e.g. once Kaapi's run completes)."
@@ -259,6 +261,8 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
       config(fn _args, %{context: %{current_user: user}} ->
         {:ok, topic: "#{user.organization_id}"}
       end)
+
+      resolve(fn evaluation, _args, _resolution -> {:ok, evaluation} end)
     end
   end
 end

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -122,6 +122,12 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :errors, list_of(:result_error)
   end
 
+  object :improve_prompt_update do
+    field :status, :string
+    field :config_version, :assistant_config_version
+    field :error, :string
+  end
+
   object :ai_evaluation_queries do
     @desc "List AI Evaluations"
     field :ai_evaluations, list_of(:ai_evaluation) do
@@ -229,6 +235,19 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
       middleware(RequireFeatureFlag, {:ai_evaluations, "AI Evaluations"})
       middleware(RequireFeatureFlag, {:is_ai_evaluation_enabled, "AI Evaluation V2"})
       resolve(&Resolvers.AIEvaluations.improve_evaluation_prompt/3)
+    end
+  end
+
+  object :ai_evaluation_subscriptions do
+    @desc "Delivers the result of a v2 prompt-improvement request once Kaapi's callback arrives."
+    field :improve_prompt_updated, :improve_prompt_update do
+      middleware(Authorize, :staff)
+      middleware(RequireFeatureFlag, {:ai_evaluations, "AI Evaluations"})
+      middleware(RequireFeatureFlag, {:is_ai_evaluation_enabled, "AI Evaluation V2"})
+
+      config(fn _args, %{context: %{current_user: user}} ->
+        {:ok, topic: "#{user.organization_id}"}
+      end)
     end
   end
 end

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -484,6 +484,7 @@ defmodule Glific.AIEvaluationsTest do
     end
 
     test "success callback builds a new :ready config version entirely from the payload", %{
+      organization_id: organization_id,
       assistant: assistant,
       config_version: config_version
     } do
@@ -520,7 +521,7 @@ defmodule Glific.AIEvaluationsTest do
       count_before = Repo.aggregate(AssistantConfigVersion, :count, :id)
 
       assert {:ok, new_config_version} =
-               AIEvaluations.handle_improve_prompt_callback(params)
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
       assert Repo.aggregate(AssistantConfigVersion, :count, :id) == count_before + 1
       refute new_config_version.id == config_version.id
@@ -539,6 +540,7 @@ defmodule Glific.AIEvaluationsTest do
     end
 
     test "success callback publishes improve_prompt_updated with the new config version", %{
+      organization_id: organization_id,
       assistant: assistant
     } do
       params = %{
@@ -569,7 +571,7 @@ defmodule Glific.AIEvaluationsTest do
          ]}
       ]) do
         assert {:ok, new_config_version} =
-                 AIEvaluations.handle_improve_prompt_callback(params)
+                 AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
         assert_receive {:published, payload, [{:improve_prompt_updated, topic}]}, 1000
         assert payload.status == "success"
@@ -580,6 +582,7 @@ defmodule Glific.AIEvaluationsTest do
     end
 
     test "success callback for a reasoning model carries effort, not temperature", %{
+      organization_id: organization_id,
       assistant: assistant
     } do
       params = %{
@@ -603,7 +606,7 @@ defmodule Glific.AIEvaluationsTest do
       }
 
       assert {:ok, new_config_version} =
-               AIEvaluations.handle_improve_prompt_callback(params)
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
       assert new_config_version.model == "gpt-5.6-luna"
       assert new_config_version.prompt == "You are a helpful assistant."
@@ -630,7 +633,7 @@ defmodule Glific.AIEvaluationsTest do
         Notifications.count_notifications(%{filter: %{organization_id: organization_id}})
 
       assert {:ok, :acknowledged} =
-               AIEvaluations.handle_improve_prompt_callback(params)
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
       assert Repo.aggregate(AssistantConfigVersion, :count, :id) == count_before
 
@@ -661,7 +664,7 @@ defmodule Glific.AIEvaluationsTest do
          ]}
       ]) do
         assert {:ok, :acknowledged} =
-                 AIEvaluations.handle_improve_prompt_callback(params, organization_id)
+                 AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
         assert_receive {:published, payload, [{:improve_prompt_updated, topic}]}, 1000
         assert payload.status == "failed"
@@ -671,32 +674,9 @@ defmodule Glific.AIEvaluationsTest do
       end
     end
 
-    test "failure callback without an organization_id just acknowledges, no publish" do
-      params = %{
-        "data" => %{
-          "status" => "FAILED",
-          "config_version" => nil,
-          "error_message" => "Judge scores unavailable"
-        }
-      }
-
-      test_pid = self()
-
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert {:ok, :acknowledged} = AIEvaluations.handle_improve_prompt_callback(params)
-        refute_receive {:published, _payload, _opts}, 200
-      end
-    end
-
-    test "returns error when config_id in the payload matches no assistant" do
+    test "returns error when config_id in the payload matches no assistant", %{
+      organization_id: organization_id
+    } do
       params = %{
         "data" => %{
           "status" => "SUCCESS",
@@ -710,20 +690,26 @@ defmodule Glific.AIEvaluationsTest do
       }
 
       assert {:error, [_, "Resource not found"]} =
-               AIEvaluations.handle_improve_prompt_callback(params)
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
     end
 
-    test "malformed payload is reported and does not crash" do
+    test "malformed payload is reported and does not crash", %{organization_id: organization_id} do
       assert {:error, _reason} =
-               AIEvaluations.handle_improve_prompt_callback(%{"unexpected" => "shape"})
+               AIEvaluations.handle_improve_prompt_callback(organization_id, %{
+                 "unexpected" => "shape"
+               })
     end
 
-    test "non-terminal status is acknowledged without creating a config version" do
+    test "non-terminal status is acknowledged without creating a config version", %{
+      organization_id: organization_id
+    } do
       params = %{"data" => %{"status" => "PENDING", "job_id" => "job-uuid-pending"}}
 
       count_before = Repo.aggregate(AssistantConfigVersion, :count, :id)
 
-      assert {:ok, :acknowledged} = AIEvaluations.handle_improve_prompt_callback(params)
+      assert {:ok, :acknowledged} =
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
+
       assert Repo.aggregate(AssistantConfigVersion, :count, :id) == count_before
     end
 
@@ -754,7 +740,8 @@ defmodule Glific.AIEvaluationsTest do
         }
       }
 
-      assert {:ok, new_config_version} = AIEvaluations.handle_improve_prompt_callback(params)
+      assert {:ok, new_config_version} =
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
 
       assert Repo.all(
                from(link in "assistant_config_version_knowledge_base_versions",
@@ -765,6 +752,7 @@ defmodule Glific.AIEvaluationsTest do
     end
 
     test "rolls back the config version when no knowledge base matches the llm_service_id", %{
+      organization_id: organization_id,
       assistant: assistant
     } do
       params = %{
@@ -788,12 +776,15 @@ defmodule Glific.AIEvaluationsTest do
 
       count_before = Repo.aggregate(AssistantConfigVersion, :count, :id)
 
-      assert {:error, reason} = AIEvaluations.handle_improve_prompt_callback(params)
+      assert {:error, reason} =
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
+
       assert reason =~ "No matching knowledge base found"
       assert Repo.aggregate(AssistantConfigVersion, :count, :id) == count_before
     end
 
     test "returns the changeset error when the config version data is invalid", %{
+      organization_id: organization_id,
       assistant: assistant
     } do
       params = %{
@@ -807,7 +798,8 @@ defmodule Glific.AIEvaluationsTest do
         }
       }
 
-      assert {:error, %Ecto.Changeset{}} = AIEvaluations.handle_improve_prompt_callback(params)
+      assert {:error, %Ecto.Changeset{}} =
+               AIEvaluations.handle_improve_prompt_callback(organization_id, params)
     end
   end
 

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -512,7 +512,7 @@ defmodule Glific.AIEvaluationsTest do
     end
   end
 
-  describe "handle_improve_prompt_callback/1" do
+  describe "handle_improve_prompt_callback/2" do
     setup %{organization_id: organization_id} do
       enable_kaapi(organization_id)
       config_version = create_config_version(organization_id)

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -577,8 +577,31 @@ defmodule Glific.AIEvaluationsTest do
         assert payload.status == "success"
         assert payload.config_version.id == new_config_version.id
         assert payload.error == nil
-        assert topic == "#{new_config_version.organization_id}"
+        assert topic == "#{organization_id}"
       end
+    end
+
+    test "returns an error and publishes nothing when config_id belongs to another organization",
+         %{organization_id: organization_id, assistant: assistant} do
+      params = %{
+        "data" => %{
+          "status" => "SUCCESS",
+          "config_version" => %{
+            "config_id" => assistant.kaapi_uuid,
+            "version" => 6,
+            "config_blob" => %{
+              "completion" => %{"params" => %{"instructions" => "Be helpful."}}
+            }
+          }
+        }
+      }
+
+      count_before = Repo.aggregate(AssistantConfigVersion, :count, :id)
+
+      assert {:error, _reason} =
+               AIEvaluations.handle_improve_prompt_callback(organization_id + 1, params)
+
+      assert Repo.aggregate(AssistantConfigVersion, :count, :id) == count_before
     end
 
     test "success callback for a reasoning model carries effort, not temperature", %{

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -3,6 +3,7 @@ defmodule Glific.AIEvaluationsTest do
   use Glific.DataCase, async: false
 
   import Ecto.Query
+  import Mock
 
   alias Glific.{
     AIEvaluations,
@@ -580,6 +581,47 @@ defmodule Glific.AIEvaluationsTest do
       assert new_config_version.settings == %{"temperature" => 0.4}
     end
 
+    test "success callback publishes improve_prompt_updated with the new config version", %{
+      assistant: assistant
+    } do
+      params = %{
+        "data" => %{
+          "status" => "SUCCESS",
+          "config_version" => %{
+            "config_id" => assistant.kaapi_uuid,
+            "version" => 6,
+            "config_blob" => %{
+              "completion" => %{
+                "provider" => "openai",
+                "params" => %{"model" => "gpt-5.6-luna", "instructions" => "Be helpful."}
+              }
+            }
+          }
+        }
+      }
+
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, new_config_version} =
+                 AIEvaluations.handle_improve_prompt_callback(params)
+
+        assert_receive {:published, payload, [{:improve_prompt_updated, topic}]}, 1000
+        assert payload.status == "success"
+        assert payload.config_version.id == new_config_version.id
+        assert payload.error == nil
+        assert topic == "#{new_config_version.organization_id}"
+      end
+    end
+
     test "success callback for a reasoning model carries effort, not temperature", %{
       assistant: assistant
     } do
@@ -637,6 +679,64 @@ defmodule Glific.AIEvaluationsTest do
 
       assert Notifications.count_notifications(%{filter: %{organization_id: organization_id}}) ==
                notification_count
+    end
+
+    test "failure callback publishes improve_prompt_updated when given an organization_id", %{
+      organization_id: organization_id
+    } do
+      params = %{
+        "data" => %{
+          "status" => "FAILED",
+          "config_version" => nil,
+          "error_message" => "Judge scores unavailable"
+        }
+      }
+
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, :acknowledged} =
+                 AIEvaluations.handle_improve_prompt_callback(params, organization_id)
+
+        assert_receive {:published, payload, [{:improve_prompt_updated, topic}]}, 1000
+        assert payload.status == "failed"
+        assert payload.config_version == nil
+        assert payload.error == "Judge scores unavailable"
+        assert topic == "#{organization_id}"
+      end
+    end
+
+    test "failure callback without an organization_id just acknowledges, no publish" do
+      params = %{
+        "data" => %{
+          "status" => "FAILED",
+          "config_version" => nil,
+          "error_message" => "Judge scores unavailable"
+        }
+      }
+
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, :acknowledged} = AIEvaluations.handle_improve_prompt_callback(params)
+        refute_receive {:published, _payload, _opts}, 200
+      end
     end
 
     test "returns error when config_id in the payload matches no assistant" do

--- a/test/glific/ai_evaluations_test.exs
+++ b/test/glific/ai_evaluations_test.exs
@@ -817,7 +817,7 @@ defmodule Glific.AIEvaluationsTest do
       %{evaluation: evaluation}
     end
 
-    test "completed status re-fetches full scores from Kaapi, updates the evaluation, and publishes ai_evaluation_updated",
+    test "completed status re-fetches full scores from Kaapi and updates the evaluation",
          %{organization_id: organization_id, evaluation: evaluation} do
       summary_scores = [
         %{name: "Cosine Similarity", avg: 0.74, std: 0.1, data_type: "NUMERIC", total_pairs: 25}
@@ -832,31 +832,14 @@ defmodule Glific.AIEvaluationsTest do
         }
       end)
 
-      test_pid = self()
+      assert :ok =
+               AIEvaluations.handle_evaluation_run_callback(organization_id, %{
+                 "data" => %{"id" => 767, "status" => "completed"}
+               })
 
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert :ok =
-                 AIEvaluations.handle_evaluation_run_callback(organization_id, %{
-                   "data" => %{"id" => 767, "status" => "completed"}
-                 })
-
-        {:ok, updated} = Repo.fetch_by(AIEvaluation, %{id: evaluation.id})
-        assert updated.status == :completed
-        assert hd(updated.results["summary_scores"])["name"] == "Cosine Similarity"
-
-        assert_receive {:published, payload, [{:ai_evaluation_updated, topic}]}, 1000
-        assert payload.id == evaluation.id
-        assert payload.status == :completed
-        assert topic == "#{organization_id}"
-      end
+      {:ok, updated} = Repo.fetch_by(AIEvaluation, %{id: evaluation.id})
+      assert updated.status == :completed
+      assert hd(updated.results["summary_scores"])["name"] == "Cosine Similarity"
     end
 
     test "failed status re-fetches from Kaapi and updates the evaluation to failed", %{

--- a/test/glific_web/schema/ai_evaluation_improve_prompt_test.exs
+++ b/test/glific_web/schema/ai_evaluation_improve_prompt_test.exs
@@ -166,6 +166,7 @@ defmodule GlificWeb.Schema.AIEvaluationImprovePromptTest do
 
     test "improve -> callback creates a new :ready config version", %{
       staff: user,
+      organization_id: organization_id,
       evaluation: evaluation,
       assistant: assistant
     } do
@@ -182,7 +183,7 @@ defmodule GlificWeb.Schema.AIEvaluationImprovePromptTest do
              ]) == "pending"
 
       {:ok, new_config_version} =
-        AIEvaluations.handle_improve_prompt_callback(%{
+        AIEvaluations.handle_improve_prompt_callback(organization_id, %{
           "success" => true,
           "data" => %{
             "job_id" => "job_schema_test",


### PR DESCRIPTION
## Summary
Target issue is #5602

Adds a GraphQL subscription so clients get notified when a v2 prompt-improvement job finishes, instead of polling.

- New `improve_prompt_updated` subscription (`ai_evaluation_subscriptions` object, imported in `schema.ex`), topic scoped by `organization_id`, gated behind `staff` auth + `ai_evaluations`/`is_ai_evaluation_enabled` feature flags.
- `AIEvaluations.handle_improve_prompt_callback/2` now takes `organization_id` and publishes on both terminal states: SUCCESS (org id derived from the created config version) and FAILED (org id passed in, since there's no config version to derive it from).
- `KaapiController.improve_prompt_callback/2` passes `conn.assigns.organization_id` through to the handler.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] Added/updated tests (`test/glific/ai_evaluations_test.exs`).
- [ ] Postman request (n/a — subscription, not REST).
- [x] Coding standard and conventions followed.

## Notes
No frontend consumer wired up yet — this is the backend subscription plumbing only.
