### PR TITLE
autofix: send GET webhook body as a single data query param (incident #81)

### DIFF
--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -210,7 +210,7 @@ defmodule Glific.Flows.Webhook do
     do:
       Tesla.get(url,
         headers: headers,
-        query: Enum.into(Jason.decode!(body), []),
+        query: [data: body],
         opts: [adapter: [recv_timeout: 10_000]]
       )
 

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -164,6 +164,98 @@ defmodule Glific.Flows.WebhookTest do
       assert webhook_log.status == "Success"
     end
 
+    test "GET query string building does not crash when the interpolated body contains a nested map (regression for incident #81)",
+         attrs do
+      test_pid = self()
+
+      Tesla.Mock.mock(fn
+        %{method: :get} = env ->
+          send(test_pid, {:webhook_get_request, env.url, env.query})
+
+          %Tesla.Env{status: 200, body: Jason.encode!(@results)}
+      end)
+
+      attrs = %{
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        contact_id: Fixtures.contact_fixture(attrs).id,
+        organization_id: attrs.organization_id
+      }
+
+      {:ok, context} = FlowContext.create_flow_context(attrs)
+      context = Repo.preload(context, [:contact, :flow])
+
+      action = %Action{
+        headers: %{"Accept" => "application/json"},
+        method: "GET",
+        url: "some url",
+        # @action_body's `contact: "@contact"` interpolates to the nested contact map
+        # (id/name/phone/fields) that crashed the real query-string builder in incident #81.
+        body: Jason.encode!(@action_body)
+      }
+
+      assert Webhook.execute(action, context) == nil
+      assert_enqueued(worker: Webhook, prefix: "global")
+      Oban.drain_queue(queue: :webhook)
+
+      assert_received {:webhook_get_request, captured_url, captured_query}
+
+      # Tesla.Mock's adapter returns the canned response above without ever building the
+      # request URL, so the assertions above alone would not exercise `Tesla.build_url/2` -
+      # the exact call inside `Tesla.Adapter.Hackney.request/2` that raised
+      # `Protocol.UndefinedError` in production (String.Chars has no implementation for
+      # Map). Building it here for real, from the query the production code actually
+      # produced, is what makes this a genuine regression test.
+      built_url = Tesla.build_url(captured_url, captured_query)
+
+      assert [^captured_url, encoded_query] = String.split(built_url, "?", parts: 2)
+      decoded_query_params = URI.decode_query(encoded_query)
+
+      assert %{"data" => data_param} = decoded_query_params
+      assert {:ok, decoded_body_map} = Jason.decode(data_param)
+      assert %{"contact" => contact_fields_map} = decoded_body_map
+      assert is_map(contact_fields_map)
+      assert Map.has_key?(contact_fields_map, "id")
+    end
+
+    test "GET query string for a nil body encodes to a literal data=%7B%7D parameter",
+         attrs do
+      test_pid = self()
+
+      Tesla.Mock.mock(fn
+        %{method: :get} = env ->
+          send(test_pid, {:webhook_get_request, env.url, env.query})
+
+          %Tesla.Env{status: 200, body: Jason.encode!(@results)}
+      end)
+
+      attrs = %{
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        contact_id: Fixtures.contact_fixture(attrs).id,
+        organization_id: attrs.organization_id
+      }
+
+      {:ok, context} = FlowContext.create_flow_context(attrs)
+      context = Repo.preload(context, [:contact, :flow])
+
+      action = %Action{
+        headers: %{"Accept" => "application/json"},
+        method: "GET",
+        url: "url with no body",
+        body: nil
+      }
+
+      assert Webhook.execute(action, context) == nil
+      assert_enqueued(worker: Webhook, prefix: "global")
+      Oban.drain_queue(queue: :webhook)
+
+      assert_received {:webhook_get_request, captured_url, captured_query}
+
+      assert captured_query == [data: "{}"]
+      assert Tesla.build_url(captured_url, captured_query) == captured_url <> "?data=%7B%7D"
+    end
+
     test "execute a webhook for post method should not break and update the webhook log in case of error",
          attrs do
       Tesla.Mock.mock(fn


### PR DESCRIPTION
## Summary

## AppSignal incident

[#81](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/81) — `ErlangError` wrapping `Protocol.UndefinedError` (`String.Chars`), raised inside `Oban Glific.Flows.Webhook#perform`. 3 occurrences in the last 7 days, 16,111 total. Source: AppSignal.

## Root cause

`Glific.Flows.Webhook.do_action/4`'s `"get"` clause (`lib/glific/flows/webhook.ex`) re-decoded the already-JSON-encoded webhook body and spread every top-level key into the Tesla `query:` list:

```elixir
query: Enum.into(Jason.decode!(body), []),
```

Whenever a flow's webhook body template referenced `"@contact"`, the decoded `"contact"` key's value is itself a map (`%{"id" => ..., "name" => ..., "phone" => ..., "fields" => %{}}`). Tesla's `URI.encode_kv_pair/2` calls `to_string/1` on every query value while building the URL — `String.Chars` has no implementation for `Map`, so the request raised `Protocol.UndefinedError`, which Oban re-raised as `Oban.PerformError` on every attempt.

This also contradicted Glific's own documented webhook contract (`api.docs/includes/_webhook.md`): *"When you make a get request all this data will go as json string in a parameter called **data**"*.

## Fix

```elixir
query: [data: body],
```

`body` at this call site is always the JSON-encoded string produced by `Glific.Flows.Webhooks.Request.create_body/2` (traced through `do_action/4`'s callers — the `{:error, _}` case is filtered out before this point, so it's never a decoded map). Sending it verbatim under a single `data` key restores the documented contract and is a no-op for `to_string/1`.

**Blast radius checked:** grepped every `Tesla.get/post/put/patch/delete` and `query:`-building call site under `lib/glific/` (Kaapi, BigQuery, Google Sheets, Gupshup, Maytapi, AskGlific, assistants, prompt generator). All other sites build queries from fixed, known-scalar keys — none else decodes an arbitrary flow-author-controlled JSON body into query params. No other site needed the same fix.

**Known, intentional side effect:** an empty/nil webhook body now sends `?data=%7B%7D` instead of no query string at all (the old "no query string" behavior was an accidental byproduct of the buggy decode-and-spread, not a documented contract) — flagging this for reviewer awareness, it is not expected to be a problem since it's more consistent with the documented contract, not less.

## Regression tests

Added to `test/glific/flows/webhook_test.exs`:
- A test reusing the existing `contact: "@contact"` fixture (the exact incident shape) that captures the real Tesla `query` Tesla.Mock would send and calls `Tesla.build_url/2` on it directly — the actual call Tesla's real adapter performs and that `Tesla.Mock` normally bypasses. Verified by manual trace against Tesla 1.13.2 source: raises `Protocol.UndefinedError` under the old `Enum.into(Jason.decode!(body), [])` code, passes under the fix.
- A nil-body test locking in the new `data=%7B%7D` URL shape.

## Verification

⚠️ **This sandbox has no Elixir/Erlang toolchain** (no `mix`, no `erl`, no `deps/`, no working docker daemon — checked exhaustively) — `mix format`, `mix compile --warnings-as-errors`, and `mix test` could not be executed, and the `make-branch-ready-for-review` finalize skill is reserved for direct user/human invocation and could not be run in this session either. The fix and regression tests were produced by a `backend-engineer` agent and a `test-automator` agent, then adversarially reviewed by a `code-reviewer` agent, which independently re-derived the blast-radius grep, re-confirmed the documented webhook contract in `api.docs/includes/_webhook.md`, traced `do_action/4`'s callers to confirm `body` is always a JSON string at this call site, and hand-verified the test would fail on `master` and pass with the fix. Verdict: **CLEAR**, no blocking issues. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.** Opened as draft given the toolchain/finalize-step gap.

## Checklist

- [ ] Ran `mix setup` in the repository root and test. — not possible in this sandbox (no toolchain); relying on CI.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. — n/a, no new API.
- [x] Coding standard and conventions are followed.

## Notes

Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged — review-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjPHgk4S2nsMm1wnQon87Y)_