### PR TITLE
fix(evaluationv2): cap golden QA upload at 100 unique questions

### DIFF
--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -57,7 +57,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
 
   # 1MB
   @max_golden_qa_file_size 1 * 1024 * 1024
-  @max_golden_qa_evaluations 80
+  @max_golden_qa_unique_items 100
   @create_golden_qa_success_metric "Golden QA Create Success"
   @create_golden_qa_failure_metric "Golden QA Create Failure"
   @ai_evaluation_create_success_metric "AI Evaluation Created"
@@ -119,7 +119,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
          :ok <- validate_duplication_factor(factor),
          :ok <- validate_golden_qa_file_size(file, user),
          {:ok, row_count} <- validate_csv_structure(file),
-         :ok <- validate_golden_qa_question_limit(row_count, factor),
+         :ok <- validate_golden_qa_question_limit(row_count),
          {:ok, kaapi_dataset} <- upload_dataset(dataset, user.organization_id) do
       create_golden_qa_record(kaapi_dataset, name, file, factor, user)
     else
@@ -263,18 +263,15 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
-  @spec validate_golden_qa_question_limit(non_neg_integer(), integer()) ::
-          :ok | {:error, String.t()}
-  defp validate_golden_qa_question_limit(count, factor) do
-    total = count * factor
-
-    if total <= @max_golden_qa_evaluations do
+  @spec validate_golden_qa_question_limit(non_neg_integer()) :: :ok | {:error, String.t()}
+  defp validate_golden_qa_question_limit(count) do
+    if count <= @max_golden_qa_unique_items do
       :ok
     else
       {:error,
-       "The total number of evaluations (#{count} questions × #{factor} duplication factor = #{total}) " <>
-         "exceeds the maximum allowed limit of #{@max_golden_qa_evaluations}. " <>
-         "Please reduce the number of questions in the CSV or the duplication factor."}
+       "The CSV contains #{count} questions, which exceeds the maximum allowed limit of " <>
+         "#{@max_golden_qa_unique_items} unique questions. Please reduce the number of " <>
+         "questions in the CSV."}
     end
   end
 

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -525,8 +525,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert reason == "Timeout occurred, please try again."
     end
 
-    test "returns error when questions × duplication_factor exceeds 80", %{staff: user} do
-      csv_path = create_csv_with_rows(41)
+    test "returns error when unique question count exceeds 100", %{staff: user} do
+      csv_path = create_csv_with_rows(101)
       on_exit(fn -> File.rm(csv_path) end)
 
       upload = %Plug.Upload{
@@ -549,12 +549,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
         assert {:ok, %{errors: [%{message: msg}]}} =
                  AIEvaluations.create_golden_qa(nil, args, resolution)
 
-        assert msg =~
-                 "exceeds the maximum allowed limit of 80"
-
-        assert msg =~ "41 questions"
-        assert msg =~ "2 duplication factor"
-        assert msg =~ "82"
+        assert msg =~ "101 questions"
+        assert msg =~ "exceeds the maximum allowed limit of 100 unique questions"
 
         assert called(
                  Glific.Metrics.increment(
@@ -565,10 +561,10 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       end
     end
 
-    test "succeeds when questions × duplication_factor equals exactly 80 (boundary)", %{
+    test "succeeds when unique question count equals exactly 100 (boundary)", %{
       staff: user
     } do
-      csv_path = create_csv_with_rows(40)
+      csv_path = create_csv_with_rows(100)
       on_exit(fn -> File.rm(csv_path) end)
 
       upload = %Plug.Upload{
@@ -589,7 +585,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
         input: %{
           name: "valid_name",
           file: upload,
-          duplication_factor: 2
+          duplication_factor: 5
         }
       }
 
@@ -601,7 +597,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert golden_qa.name == "valid_name"
     end
 
-    test "succeeds when questions × duplication_factor is well under 80", %{staff: user} do
+    test "succeeds when unique question count is well under 100", %{staff: user} do
       csv_path = create_csv_with_rows(5)
       on_exit(fn -> File.rm(csv_path) end)
 


### PR DESCRIPTION
## Summary
Target Issue: #5616

Golden QA CSV upload rejected valid datasets once `row_count × duplication_factor > 80` —
a combined cap, not a per-item limit as the error implied. At the max allowed
`duplication_factor` of 5, this meant only 16 unique questions could be uploaded, not 80.
Need to support up to 100 unique questions with duplication factor up to 5 (500 total
evaluations).

## Changes

- `Resolvers.AIEvaluations.validate_golden_qa_question_limit/1` now caps unique question
  count directly at 100 (`@max_golden_qa_unique_items`), independent of
  `duplication_factor`.
- Since `duplication_factor` stays bounded to `1..5`, total evaluations is automatically
  `<= 500` — the old combined `count * factor` check is removed.
- Error message now reports the unique question count against the 100 limit instead of the
  misleading combined total.
- Users are expected to upload a dataset of unique questions only — `duplication_factor` is
  set separately at evaluation run time, so the CSV itself should not contain repeated
  questions.

## Testing

- Updated `ai_evaluations_test.exs` cases: >100 unique questions fails with the new
  message, exactly 100 questions with `duplication_factor: 5` succeeds (500 total), and a
  small row count still succeeds.
- `mix test test/glific_web/resolvers/ai_evaluations_test.exs`, `mix format` pass on the
  touched files.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] Fixed a bug and added test cases covering it.
- [ ] N/A — no new API added.
- [x] Coding standard and conventions followed.
