### PR TITLE
[glific-ai]: Store all Glific AI data

### DIFF
--- a/lib/glific/ai/conversation.ex
+++ b/lib/glific/ai/conversation.ex
@@ -1,0 +1,50 @@
+defmodule Glific.AI.Conversation do
+  @moduledoc """
+  A Glific AI chat thread, owned by one user within one organization.
+
+  A conversation groups many `Glific.AI.Request`s, which in turn hold the
+  individual `Glific.AI.Event`s. It carries only what identifies the thread; the
+  columns a thread list would need arrive with the interface that needs them.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Glific.{
+    Partners.Organization,
+    Users.User
+  }
+
+  @required_fields [:user_id, :organization_id]
+  @optional_fields [:title]
+
+  @type t() :: %__MODULE__{
+          __meta__: Ecto.Schema.Metadata.t(),
+          id: non_neg_integer | nil,
+          title: String.t() | nil,
+          user_id: non_neg_integer | nil,
+          user: User.t() | Ecto.Association.NotLoaded.t() | nil,
+          organization_id: non_neg_integer | nil,
+          organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: :utc_datetime | nil,
+          updated_at: :utc_datetime | nil
+        }
+
+  schema "glific_ai_conversations" do
+    field :title, :string
+    belongs_to :user, User
+    belongs_to :organization, Organization
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(conversation, attrs) do
+    conversation
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:organization_id)
+  end
+end

--- a/lib/glific/ai/conversation.ex
+++ b/lib/glific/ai/conversation.ex
@@ -2,7 +2,7 @@ defmodule Glific.AI.Conversation do
   @moduledoc """
   A Glific AI chat thread, owned by one user within one organization.
 
-  A conversation groups many `Glific.AI.Request`s, which in turn hold the
+  A conversation groups many `Glific.AI.Message`s, which in turn hold the
   individual `Glific.AI.Event`s. It carries only what identifies the thread; the
   columns a thread list would need arrive with the interface that needs them.
   """

--- a/lib/glific/ai/conversation.ex
+++ b/lib/glific/ai/conversation.ex
@@ -25,8 +25,8 @@ defmodule Glific.AI.Conversation do
           user: User.t() | Ecto.Association.NotLoaded.t() | nil,
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
-          inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
 
   schema "glific_ai_conversations" do
@@ -37,12 +37,13 @@ defmodule Glific.AI.Conversation do
     timestamps(type: :utc_datetime)
   end
 
-  @doc false
+  @doc "Standard changeset pattern we use for all data types"
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(conversation, attrs) do
     conversation
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
+    |> validate_length(:title, max: 255)
     |> foreign_key_constraint(:user_id)
     |> foreign_key_constraint(:organization_id)
   end

--- a/lib/glific/ai/conversation.ex
+++ b/lib/glific/ai/conversation.ex
@@ -2,9 +2,8 @@ defmodule Glific.AI.Conversation do
   @moduledoc """
   A Glific AI chat thread, owned by one user within one organization.
 
-  A conversation groups many `Glific.AI.Message`s, which in turn hold the
-  individual `Glific.AI.Event`s. It carries only what identifies the thread; the
-  columns a thread list would need arrive with the interface that needs them.
+  Groups many `Glific.AI.Message`s, each of which holds its own
+  `Glific.AI.Event`s.
   """
 
   use Ecto.Schema

--- a/lib/glific/ai/conversation.ex
+++ b/lib/glific/ai/conversation.ex
@@ -34,7 +34,7 @@ defmodule Glific.AI.Conversation do
     belongs_to :user, User
     belongs_to :organization, Organization
 
-    timestamps(type: :utc_datetime)
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc "Standard changeset pattern we use for all data types"

--- a/lib/glific/ai/event.ex
+++ b/lib/glific/ai/event.ex
@@ -2,12 +2,9 @@ defmodule Glific.AI.Event do
   @moduledoc """
   A single step taken while answering a question.
 
-  The event log is append-only, and it *is* the resumable state — there is no
-  separate checkpoint table. Reload a conversation's events in `step` order,
-  rebuild the model context, and carry on. Rows are therefore never rewritten.
-
-  Glific AI is read-only at this stage, so there is no `:suggestion` type yet. When
-  the approval path lands, a proposal becomes an event carrying its own status.
+  Append-only: rows are never rewritten. Reloading a conversation's events in
+  `step` order rebuilds the context sent to the model, which is how a follow-up
+  question keeps what came before.
   """
 
   use Ecto.Schema

--- a/lib/glific/ai/event.ex
+++ b/lib/glific/ai/event.ex
@@ -15,12 +15,12 @@ defmodule Glific.AI.Event do
 
   alias Glific.{
     AI.Conversation,
-    AI.Request,
+    AI.Message,
     Enums.GlificAIEventType,
     Partners.Organization
   }
 
-  @required_fields [:request_id, :conversation_id, :organization_id, :step, :type]
+  @required_fields [:message_id, :conversation_id, :organization_id, :step, :type]
   @optional_fields [:content, :data, :tool_call_id]
 
   @type t() :: %__MODULE__{
@@ -31,8 +31,8 @@ defmodule Glific.AI.Event do
           content: String.t() | nil,
           data: map() | nil,
           tool_call_id: String.t() | nil,
-          request_id: non_neg_integer | nil,
-          request: Request.t() | Ecto.Association.NotLoaded.t() | nil,
+          message_id: non_neg_integer | nil,
+          message: Message.t() | Ecto.Association.NotLoaded.t() | nil,
           conversation_id: non_neg_integer | nil,
           conversation: Conversation.t() | Ecto.Association.NotLoaded.t() | nil,
           organization_id: non_neg_integer | nil,
@@ -48,7 +48,7 @@ defmodule Glific.AI.Event do
     field :data, :map, default: %{}
     field :tool_call_id, :string
 
-    belongs_to :request, Request
+    belongs_to :message, Message
     belongs_to :conversation, Conversation
     belongs_to :organization, Organization
 
@@ -62,9 +62,9 @@ defmodule Glific.AI.Event do
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_number(:step, greater_than: 0)
-    |> foreign_key_constraint(:request_id)
+    |> foreign_key_constraint(:message_id)
     |> foreign_key_constraint(:conversation_id)
     |> foreign_key_constraint(:organization_id)
-    |> unique_constraint([:request_id, :step])
+    |> unique_constraint([:message_id, :step])
   end
 end

--- a/lib/glific/ai/event.ex
+++ b/lib/glific/ai/event.ex
@@ -49,7 +49,7 @@ defmodule Glific.AI.Event do
     belongs_to :conversation, Conversation
     belongs_to :organization, Organization
 
-    timestamps(type: :utc_datetime)
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc "Standard changeset pattern we use for all data types"

--- a/lib/glific/ai/event.ex
+++ b/lib/glific/ai/event.ex
@@ -34,8 +34,8 @@ defmodule Glific.AI.Event do
           conversation: Conversation.t() | Ecto.Association.NotLoaded.t() | nil,
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
-          inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
 
   schema "glific_ai_events" do
@@ -52,7 +52,7 @@ defmodule Glific.AI.Event do
     timestamps(type: :utc_datetime)
   end
 
-  @doc false
+  @doc "Standard changeset pattern we use for all data types"
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(event, attrs) do
     event

--- a/lib/glific/ai/event.ex
+++ b/lib/glific/ai/event.ex
@@ -1,0 +1,70 @@
+defmodule Glific.AI.Event do
+  @moduledoc """
+  A single step taken while answering a question.
+
+  The event log is append-only, and it *is* the resumable state — there is no
+  separate checkpoint table. Reload a conversation's events in `step` order,
+  rebuild the model context, and carry on. Rows are therefore never rewritten.
+
+  Glific AI is read-only at this stage, so there is no `:suggestion` type yet. When
+  the approval path lands, a proposal becomes an event carrying its own status.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Glific.{
+    AI.Conversation,
+    AI.Request,
+    Enums.GlificAIEventType,
+    Partners.Organization
+  }
+
+  @required_fields [:request_id, :conversation_id, :organization_id, :step, :type]
+  @optional_fields [:content, :data, :tool_call_id]
+
+  @type t() :: %__MODULE__{
+          __meta__: Ecto.Schema.Metadata.t(),
+          id: non_neg_integer | nil,
+          step: non_neg_integer | nil,
+          type: GlificAIEventType.t() | nil,
+          content: String.t() | nil,
+          data: map() | nil,
+          tool_call_id: String.t() | nil,
+          request_id: non_neg_integer | nil,
+          request: Request.t() | Ecto.Association.NotLoaded.t() | nil,
+          conversation_id: non_neg_integer | nil,
+          conversation: Conversation.t() | Ecto.Association.NotLoaded.t() | nil,
+          organization_id: non_neg_integer | nil,
+          organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: :utc_datetime | nil,
+          updated_at: :utc_datetime | nil
+        }
+
+  schema "glific_ai_events" do
+    field :step, :integer
+    field :type, GlificAIEventType
+    field :content, :string
+    field :data, :map, default: %{}
+    field :tool_call_id, :string
+
+    belongs_to :request, Request
+    belongs_to :conversation, Conversation
+    belongs_to :organization, Organization
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(event, attrs) do
+    event
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:step, greater_than: 0)
+    |> foreign_key_constraint(:request_id)
+    |> foreign_key_constraint(:conversation_id)
+    |> foreign_key_constraint(:organization_id)
+    |> unique_constraint([:request_id, :step])
+  end
+end

--- a/lib/glific/ai/message.ex
+++ b/lib/glific/ai/message.ex
@@ -58,7 +58,7 @@ defmodule Glific.AI.Message do
     belongs_to :user, User
     belongs_to :organization, Organization
 
-    timestamps(type: :utc_datetime)
+    timestamps(type: :utc_datetime_usec)
   end
 
   @doc "Standard changeset pattern we use for all data types"

--- a/lib/glific/ai/message.ex
+++ b/lib/glific/ai/message.ex
@@ -1,12 +1,12 @@
-defmodule Glific.AI.Request do
+defmodule Glific.AI.Message do
   @moduledoc """
   One question and every step taken to answer it.
 
-  A request is the unit that has a lifecycle, costs money, and can fail — an
+  A message is the unit that has a lifecycle, costs money, and can fail — an
   individual `Glific.AI.Event` is only a fact that happened and has none of those.
 
-  Glific AI answers one question per request at this stage. When a skill can
-  invoke another skill, a `parent_request_id` records that nesting.
+  Glific AI answers one question per message at this stage. When a skill can
+  invoke another skill, a `parent_message_id` records that nesting.
   """
 
   use Ecto.Schema
@@ -14,7 +14,7 @@ defmodule Glific.AI.Request do
 
   alias Glific.{
     AI.Conversation,
-    Enums.GlificAIRequestStatus,
+    Enums.GlificAIMessageStatus,
     Partners.Organization,
     Users.User
   }
@@ -34,7 +34,7 @@ defmodule Glific.AI.Request do
           __meta__: Ecto.Schema.Metadata.t(),
           id: non_neg_integer | nil,
           skill: String.t() | nil,
-          status: GlificAIRequestStatus.t() | nil,
+          status: GlificAIMessageStatus.t() | nil,
           error: String.t() | nil,
           model: String.t() | nil,
           input_tokens: non_neg_integer | nil,
@@ -50,9 +50,9 @@ defmodule Glific.AI.Request do
           updated_at: :utc_datetime | nil
         }
 
-  schema "glific_ai_requests" do
+  schema "glific_ai_messages" do
     field :skill, :string
-    field :status, GlificAIRequestStatus, default: :pending
+    field :status, GlificAIMessageStatus, default: :pending
     field :error, :string
     field :model, :string
 
@@ -69,8 +69,8 @@ defmodule Glific.AI.Request do
 
   @doc false
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
-  def changeset(request, attrs) do
-    request
+  def changeset(message, attrs) do
+    message
     |> cast(attrs, @required_fields ++ @optional_fields)
     |> validate_required(@required_fields)
     |> validate_number(:input_tokens, greater_than_or_equal_to: 0)

--- a/lib/glific/ai/message.ex
+++ b/lib/glific/ai/message.ex
@@ -1,12 +1,9 @@
 defmodule Glific.AI.Message do
   @moduledoc """
-  One question and every step taken to answer it.
+  One question asked of Glific AI, and how answering it went.
 
-  A message is the unit that has a lifecycle, costs money, and can fail — an
-  individual `Glific.AI.Event` is only a fact that happened and has none of those.
-
-  Glific AI answers one question per message at this stage. When a skill can
-  invoke another skill, a `parent_message_id` records that nesting.
+  Carries the outcome, the model used and the token cost. The individual steps
+  taken are `Glific.AI.Event` rows belonging to it.
   """
 
   use Ecto.Schema

--- a/lib/glific/ai/message.ex
+++ b/lib/glific/ai/message.ex
@@ -18,7 +18,6 @@ defmodule Glific.AI.Message do
 
   @required_fields [:conversation_id, :user_id, :organization_id]
   @optional_fields [
-    :skill,
     :status,
     :error,
     :model,
@@ -30,7 +29,6 @@ defmodule Glific.AI.Message do
   @type t() :: %__MODULE__{
           __meta__: Ecto.Schema.Metadata.t(),
           id: non_neg_integer | nil,
-          skill: String.t() | nil,
           status: GlificAIMessageStatus.t() | nil,
           error: String.t() | nil,
           model: String.t() | nil,
@@ -48,7 +46,6 @@ defmodule Glific.AI.Message do
         }
 
   schema "glific_ai_messages" do
-    field :skill, :string
     field :status, GlificAIMessageStatus, default: :pending
     field :error, :string
     field :model, :string

--- a/lib/glific/ai/message.ex
+++ b/lib/glific/ai/message.ex
@@ -41,8 +41,8 @@ defmodule Glific.AI.Message do
           user: User.t() | Ecto.Association.NotLoaded.t() | nil,
           organization_id: non_neg_integer | nil,
           organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
-          inserted_at: :utc_datetime | nil,
-          updated_at: :utc_datetime | nil
+          inserted_at: DateTime.t() | nil,
+          updated_at: DateTime.t() | nil
         }
 
   schema "glific_ai_messages" do
@@ -61,7 +61,7 @@ defmodule Glific.AI.Message do
     timestamps(type: :utc_datetime)
   end
 
-  @doc false
+  @doc "Standard changeset pattern we use for all data types"
   @spec changeset(t(), map()) :: Ecto.Changeset.t()
   def changeset(message, attrs) do
     message

--- a/lib/glific/ai/request.ex
+++ b/lib/glific/ai/request.ex
@@ -1,0 +1,82 @@
+defmodule Glific.AI.Request do
+  @moduledoc """
+  One question and every step taken to answer it.
+
+  A request is the unit that has a lifecycle, costs money, and can fail — an
+  individual `Glific.AI.Event` is only a fact that happened and has none of those.
+
+  Glific AI answers one question per request at this stage. When a skill can
+  invoke another skill, a `parent_request_id` records that nesting.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Glific.{
+    AI.Conversation,
+    Enums.GlificAIRequestStatus,
+    Partners.Organization,
+    Users.User
+  }
+
+  @required_fields [:conversation_id, :user_id, :organization_id]
+  @optional_fields [
+    :skill,
+    :status,
+    :error,
+    :model,
+    :input_tokens,
+    :output_tokens,
+    :cost
+  ]
+
+  @type t() :: %__MODULE__{
+          __meta__: Ecto.Schema.Metadata.t(),
+          id: non_neg_integer | nil,
+          skill: String.t() | nil,
+          status: GlificAIRequestStatus.t() | nil,
+          error: String.t() | nil,
+          model: String.t() | nil,
+          input_tokens: non_neg_integer | nil,
+          output_tokens: non_neg_integer | nil,
+          cost: Decimal.t() | nil,
+          conversation_id: non_neg_integer | nil,
+          conversation: Conversation.t() | Ecto.Association.NotLoaded.t() | nil,
+          user_id: non_neg_integer | nil,
+          user: User.t() | Ecto.Association.NotLoaded.t() | nil,
+          organization_id: non_neg_integer | nil,
+          organization: Organization.t() | Ecto.Association.NotLoaded.t() | nil,
+          inserted_at: :utc_datetime | nil,
+          updated_at: :utc_datetime | nil
+        }
+
+  schema "glific_ai_requests" do
+    field :skill, :string
+    field :status, GlificAIRequestStatus, default: :pending
+    field :error, :string
+    field :model, :string
+
+    field :input_tokens, :integer, default: 0
+    field :output_tokens, :integer, default: 0
+    field :cost, :decimal, default: Decimal.new("0")
+
+    belongs_to :conversation, Conversation
+    belongs_to :user, User
+    belongs_to :organization, Organization
+
+    timestamps(type: :utc_datetime)
+  end
+
+  @doc false
+  @spec changeset(t(), map()) :: Ecto.Changeset.t()
+  def changeset(request, attrs) do
+    request
+    |> cast(attrs, @required_fields ++ @optional_fields)
+    |> validate_required(@required_fields)
+    |> validate_number(:input_tokens, greater_than_or_equal_to: 0)
+    |> validate_number(:output_tokens, greater_than_or_equal_to: 0)
+    |> foreign_key_constraint(:conversation_id)
+    |> foreign_key_constraint(:user_id)
+    |> foreign_key_constraint(:organization_id)
+  end
+end

--- a/lib/glific/enums/constants/enums.ex
+++ b/lib/glific/enums/constants/enums.ex
@@ -139,6 +139,10 @@ defmodule Glific.Enums.Constants do
       @assistant_config_version_status_const [:in_progress, :ready, :failed]
       @knowledge_base_status_const [:in_progress, :completed, :failed]
       @ai_evaluation_status_const [:create_in_progress, :processing, :failed, :completed]
+
+      # Glific AI — see the schemas under Glific.AI
+      @glific_ai_event_type_const [:user, :assistant, :tool_call, :tool_result]
+      @glific_ai_request_status_const [:pending, :running, :succeeded, :failed, :cancelled]
     end
   end
 end

--- a/lib/glific/enums/constants/enums.ex
+++ b/lib/glific/enums/constants/enums.ex
@@ -142,7 +142,7 @@ defmodule Glific.Enums.Constants do
 
       # Glific AI — see the schemas under Glific.AI
       @glific_ai_event_type_const [:user, :assistant, :tool_call, :tool_result]
-      @glific_ai_request_status_const [:pending, :running, :succeeded, :failed, :cancelled]
+      @glific_ai_message_status_const [:pending, :running, :succeeded, :failed, :cancelled]
     end
   end
 end

--- a/lib/glific/enums/ecto_enums.ex
+++ b/lib/glific/enums/ecto_enums.ex
@@ -164,3 +164,15 @@ defenum(
   :ai_evaluation_status_enum,
   Glific.Enums.ai_evaluation_status_const()
 )
+
+defenum(
+  Glific.Enums.GlificAIRequestStatus,
+  :glific_ai_request_status_enum,
+  Glific.Enums.glific_ai_request_status_const()
+)
+
+defenum(
+  Glific.Enums.GlificAIEventType,
+  :glific_ai_event_type_enum,
+  Glific.Enums.glific_ai_event_type_const()
+)

--- a/lib/glific/enums/ecto_enums.ex
+++ b/lib/glific/enums/ecto_enums.ex
@@ -166,9 +166,9 @@ defenum(
 )
 
 defenum(
-  Glific.Enums.GlificAIRequestStatus,
-  :glific_ai_request_status_enum,
-  Glific.Enums.glific_ai_request_status_const()
+  Glific.Enums.GlificAIMessageStatus,
+  :glific_ai_message_status_enum,
+  Glific.Enums.glific_ai_message_status_const()
 )
 
 defenum(

--- a/lib/glific/enums/enums.ex
+++ b/lib/glific/enums/enums.ex
@@ -129,6 +129,12 @@ defmodule Glific.Enums do
 
   iex> Glific.Enums.AIEvaluationStatus.__enum_map__()
   Glific.Enums.ai_evaluation_status_const()
+
+  iex> Glific.Enums.GlificAIRequestStatus.__enum_map__()
+  Glific.Enums.glific_ai_request_status_const()
+
+  iex> Glific.Enums.GlificAIEventType.__enum_map__()
+  Glific.Enums.glific_ai_event_type_const()
   """
 
   defmacro api_status_const,
@@ -208,4 +214,10 @@ defmodule Glific.Enums do
 
   defmacro ai_evaluation_status_const,
     do: Macro.expand(@ai_evaluation_status_const, __CALLER__)
+
+  defmacro glific_ai_request_status_const,
+    do: Macro.expand(@glific_ai_request_status_const, __CALLER__)
+
+  defmacro glific_ai_event_type_const,
+    do: Macro.expand(@glific_ai_event_type_const, __CALLER__)
 end

--- a/lib/glific/enums/enums.ex
+++ b/lib/glific/enums/enums.ex
@@ -130,8 +130,8 @@ defmodule Glific.Enums do
   iex> Glific.Enums.AIEvaluationStatus.__enum_map__()
   Glific.Enums.ai_evaluation_status_const()
 
-  iex> Glific.Enums.GlificAIRequestStatus.__enum_map__()
-  Glific.Enums.glific_ai_request_status_const()
+  iex> Glific.Enums.GlificAIMessageStatus.__enum_map__()
+  Glific.Enums.glific_ai_message_status_const()
 
   iex> Glific.Enums.GlificAIEventType.__enum_map__()
   Glific.Enums.glific_ai_event_type_const()
@@ -215,8 +215,8 @@ defmodule Glific.Enums do
   defmacro ai_evaluation_status_const,
     do: Macro.expand(@ai_evaluation_status_const, __CALLER__)
 
-  defmacro glific_ai_request_status_const,
-    do: Macro.expand(@glific_ai_request_status_const, __CALLER__)
+  defmacro glific_ai_message_status_const,
+    do: Macro.expand(@glific_ai_message_status_const, __CALLER__)
 
   defmacro glific_ai_event_type_const,
     do: Macro.expand(@glific_ai_event_type_const, __CALLER__)

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -621,6 +621,9 @@ defmodule Glific.Erase do
       flow_roles
       flows
       gcs_jobs
+      glific_ai_events
+      glific_ai_requests
+      glific_ai_conversations
       golden_qas
       group_roles
       groups

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -491,6 +491,9 @@ defmodule Glific.Erase do
         "DELETE FROM knowledge_base_versions WHERE organization_id = #{organization_id}",
         "DELETE FROM knowledge_bases WHERE organization_id = #{organization_id}",
         "DELETE FROM assistants WHERE organization_id = #{organization_id}",
+        "DELETE FROM glific_ai_events WHERE organization_id = #{organization_id}",
+        "DELETE FROM glific_ai_messages WHERE organization_id = #{organization_id}",
+        "DELETE FROM glific_ai_conversations WHERE organization_id = #{organization_id}",
 
         # Keep NGO Main Account, SaaS Admin, and Simulator contacts
         "DELETE FROM contacts

--- a/lib/glific/erase.ex
+++ b/lib/glific/erase.ex
@@ -622,7 +622,7 @@ defmodule Glific.Erase do
       flows
       gcs_jobs
       glific_ai_events
-      glific_ai_requests
+      glific_ai_messages
       glific_ai_conversations
       golden_qas
       group_roles

--- a/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
+++ b/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
@@ -8,21 +8,8 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
     * `glific_ai_messages`      — one question and every step taken to answer it
     * `glific_ai_events`        — each individual step, in order
 
-  There is deliberately no checkpoint table: the event log is the resumable state.
-  Reload a message's events in `step` order, rebuild the model context, continue.
-
-  Only what the read-only stage actually needs is here. Three things that earlier
-  designs included are deliberately absent, each a small migration when its feature
-  arrives:
-
-    * the approval path — a proposal will become an event of type `suggestion`
-      carrying its own status. Note that re-adding an enum value needs
-      `ALTER TYPE ... ADD VALUE`, which cannot run inside a transaction, so that
-      migration needs `@disable_ddl_transaction true`.
-    * composition — `parent_message_id` and a depth cap, once a skill can invoke
-      another skill.
-    * a thread list — a title, an archived state and a last-event timestamp, once
-      there is an interface that lists conversations.
+  Reloading a conversation's events in `step` order rebuilds the context sent to
+  the model, which is how a follow-up question keeps what came before.
   """
 
   use Ecto.Migration
@@ -100,8 +87,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
       add :status, :glific_ai_message_status_enum,
         null: false,
         default: "pending",
-        comment:
-          "Read-only for now, so there are no waiting states. The approval path adds awaiting_input and awaiting_approval."
+        comment: "Glific AI only reads data at this stage, so a message either finishes or fails."
 
       add :error, :text, comment: "Why it failed, when status is failed"
 
@@ -127,8 +113,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
 
       add :user_id, references(:users, on_delete: :delete_all),
         null: false,
-        comment:
-          "Who asked. An Oban worker has no GraphQL layer to authorize against, so the tool wrapper checks this user's role before every read."
+        comment: "Who asked. Reads made while answering are scoped to this user's permissions."
 
       add :organization_id, references(:organizations, on_delete: :delete_all),
         null: false,
@@ -150,17 +135,17 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
   defp create_events do
     create table(:glific_ai_events,
              comment:
-               "Every step taken while answering a question, in order. Append-only: this log is the resumable state, so rows are never rewritten."
+               "Every step taken while answering a question, in order. Append-only: rows are never rewritten."
            ) do
       add :step, :integer,
         null: false,
         comment:
-          "Which step of its own message this is, numbering from 1. It restarts for each message, so conversation order is (message_id, step) and not step alone. Explicit rather than derived from inserted_at so that a retried job cannot write the same step twice."
+          "Which step of its own message this is, from 1. It restarts for each message, so conversation order is (message_id, step). Unique per message, so a retried job cannot write the same step twice."
 
       add :type, :glific_ai_event_type_enum,
         null: false,
         comment:
-          "tool_result is kept distinct from assistant on purpose: it is untrusted content, and the type is what lets the loader frame it as data rather than instruction when rebuilding the context."
+          "tool_result is separate from assistant because tool output is data about the account, never instructions to the model."
 
       add :content, :text,
         comment: "The human-readable part. Reading down this column reads the conversation."

--- a/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
+++ b/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
@@ -1,0 +1,207 @@
+defmodule Glific.Repo.Migrations.CreateGlificAiTables do
+  @moduledoc """
+  Storage for Glific AI.
+
+  Three levels, from outermost in:
+
+    * `glific_ai_conversations` — a thread, owned by one user in one organization
+    * `glific_ai_requests`      — one question and every step taken to answer it
+    * `glific_ai_events`        — each individual step, in order
+
+  There is deliberately no checkpoint table: the event log is the resumable state.
+  Reload a request's events in `step` order, rebuild the model context, continue.
+
+  Only what the read-only stage actually needs is here. Three things that earlier
+  designs included are deliberately absent, each a small migration when its feature
+  arrives:
+
+    * the approval path — a proposal will become an event of type `suggestion`
+      carrying its own status. Note that re-adding an enum value needs
+      `ALTER TYPE ... ADD VALUE`, which cannot run inside a transaction, so that
+      migration needs `@disable_ddl_transaction true`.
+    * composition — `parent_request_id` and a depth cap, once a skill can invoke
+      another skill.
+    * a thread list — a title, an archived state and a last-event timestamp, once
+      there is an interface that lists conversations.
+  """
+
+  use Ecto.Migration
+
+  def up do
+    create_enums()
+    create_conversations()
+    create_requests()
+    create_events()
+  end
+
+  def down do
+    drop_if_exists(table(:glific_ai_events))
+    drop_if_exists(table(:glific_ai_requests))
+    drop_if_exists(table(:glific_ai_conversations))
+    drop_enums()
+  end
+
+  defp create_enums do
+    execute("""
+    CREATE TYPE public.glific_ai_request_status_enum AS ENUM (
+      'pending',
+      'running',
+      'succeeded',
+      'failed',
+      'cancelled'
+    );
+    """)
+
+    execute("""
+    CREATE TYPE public.glific_ai_event_type_enum AS ENUM (
+      'user',
+      'assistant',
+      'tool_call',
+      'tool_result'
+    );
+    """)
+  end
+
+  defp drop_enums do
+    execute("DROP TYPE IF EXISTS public.glific_ai_event_type_enum;")
+    execute("DROP TYPE IF EXISTS public.glific_ai_request_status_enum;")
+  end
+
+  defp create_conversations do
+    create table(:glific_ai_conversations,
+             comment: "A Glific AI chat thread, owned by one user within one organization"
+           ) do
+      add :title, :string,
+        comment: "Short label derived from the first question. Null until the first answer."
+
+      add :user_id, references(:users, on_delete: :delete_all),
+        null: false,
+        comment: "The staff member who owns this thread"
+
+      add :organization_id, references(:organizations, on_delete: :delete_all),
+        null: false,
+        comment: "Organization scope"
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:glific_ai_conversations, [:organization_id])
+    create index(:glific_ai_conversations, [:organization_id, :user_id])
+  end
+
+  defp create_requests do
+    create table(:glific_ai_requests,
+             comment:
+               "One question and every step taken to answer it. Carries the lifecycle, the cost, and the composition tree."
+           ) do
+      add :skill, :string,
+        comment: "Which skill the router selected. Null until routing completes."
+
+      add :status, :glific_ai_request_status_enum,
+        null: false,
+        default: "pending",
+        comment:
+          "Read-only for now, so there are no waiting states. The approval path adds awaiting_input and awaiting_approval."
+
+      add :error, :text, comment: "Why it failed, when status is failed"
+
+      add :model, :string, comment: "Model that served this request, e.g. anthropic:claude-opus-5"
+
+      add :input_tokens, :integer,
+        null: false,
+        default: 0,
+        comment: "Summed across every model call made answering this one question"
+
+      add :output_tokens, :integer, null: false, default: 0
+
+      add :cost, :decimal,
+        precision: 12,
+        scale: 6,
+        null: false,
+        default: 0,
+        comment: "Estimated USD, summed across every model call. Observability, not an invoice."
+
+      add :conversation_id, references(:glific_ai_conversations, on_delete: :delete_all),
+        null: false,
+        comment: "The thread this belongs to"
+
+      add :user_id, references(:users, on_delete: :delete_all),
+        null: false,
+        comment:
+          "Who asked. An Oban worker has no GraphQL layer to authorize against, so the tool wrapper checks this user's role before every read."
+
+      add :organization_id, references(:organizations, on_delete: :delete_all),
+        null: false,
+        comment: "Organization scope"
+
+      timestamps(type: :utc_datetime)
+    end
+
+    create index(:glific_ai_requests, [:organization_id])
+    create index(:glific_ai_requests, [:organization_id, :conversation_id])
+
+    create index(:glific_ai_requests, [:organization_id, :status],
+             where: "status IN ('pending', 'running')",
+             name: :glific_ai_requests_in_flight_index,
+             comment: "Finds work that is still open without scanning finished requests"
+           )
+  end
+
+  defp create_events do
+    create table(:glific_ai_events,
+             comment:
+               "Every step taken while answering a question, in order. Append-only: this log is the resumable state, so rows are never rewritten."
+           ) do
+      add :step, :integer,
+        null: false,
+        comment:
+          "Which step of its own request this is, numbering from 1. It restarts for each request, so conversation order is (request_id, step) and not step alone. Explicit rather than derived from inserted_at so that a retried job cannot write the same step twice."
+
+      add :type, :glific_ai_event_type_enum,
+        null: false,
+        comment:
+          "tool_result is kept distinct from assistant on purpose: it is untrusted content, and the type is what lets the loader frame it as data rather than instruction when rebuilding the context."
+
+      add :content, :text,
+        comment: "The human-readable part. Reading down this column reads the conversation."
+
+      add :data, :map,
+        null: false,
+        default: %{},
+        comment:
+          "The structured part: tool arguments and tool output. Kept out of content so the table stays readable."
+
+      add :tool_call_id, :string,
+        comment:
+          "Pairs a tool_call with its tool_result. Required to rebuild the context faithfully on replay."
+
+      add :request_id, references(:glific_ai_requests, on_delete: :delete_all),
+        null: false,
+        comment: "The question this step was taken in service of"
+
+      add :conversation_id, references(:glific_ai_conversations, on_delete: :delete_all),
+        null: false,
+        comment:
+          "Denormalized from the request so a whole thread loads in one query, with no join"
+
+      add :organization_id, references(:organizations, on_delete: :delete_all),
+        null: false,
+        comment: "Organization scope"
+
+      timestamps(type: :utc_datetime)
+    end
+
+    # Scoped to the request, not the conversation: two requests in one thread run
+    # concurrently, and conversation-wide numbering would make them race for the same
+    # value. This also stops an Oban retry writing a step twice.
+    create unique_index(:glific_ai_events, [:request_id, :step])
+
+    create index(:glific_ai_events, [:organization_id])
+
+    create index(:glific_ai_events, [:request_id, :tool_call_id],
+             where: "tool_call_id IS NOT NULL",
+             name: :glific_ai_events_tool_call_index,
+             comment: "Pairs calls to their results during replay"
+           )
+  end
+end

--- a/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
+++ b/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
@@ -81,9 +81,6 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
              comment:
                "One question and every step taken to answer it. Carries the lifecycle, the cost, and the composition tree."
            ) do
-      add :skill, :string,
-        comment: "Which skill the router selected. Null until routing completes."
-
       add :status, :glific_ai_message_status_enum,
         null: false,
         default: "pending",
@@ -123,13 +120,6 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
     end
 
     create index(:glific_ai_messages, [:organization_id])
-    create index(:glific_ai_messages, [:organization_id, :conversation_id])
-
-    create index(:glific_ai_messages, [:organization_id, :status],
-             where: "status IN ('pending', 'running')",
-             name: :glific_ai_messages_in_flight_index,
-             comment: "Finds work that is still open without scanning finished messages"
-           )
   end
 
   defp create_events do
@@ -182,11 +172,6 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
     create unique_index(:glific_ai_events, [:message_id, :step])
 
     create index(:glific_ai_events, [:organization_id])
-
-    create index(:glific_ai_events, [:message_id, :tool_call_id],
-             where: "tool_call_id IS NOT NULL",
-             name: :glific_ai_events_tool_call_index,
-             comment: "Pairs calls to their results during replay"
-           )
+    create index(:glific_ai_events, [:organization_id, :conversation_id])
   end
 end

--- a/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
+++ b/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
@@ -69,7 +69,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
         null: false,
         comment: "Organization scope"
 
-      timestamps(type: :utc_datetime)
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:glific_ai_conversations, [:organization_id])
@@ -116,7 +116,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
         null: false,
         comment: "Organization scope"
 
-      timestamps(type: :utc_datetime)
+      timestamps(type: :utc_datetime_usec)
     end
 
     create index(:glific_ai_messages, [:organization_id])
@@ -163,7 +163,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
         null: false,
         comment: "Organization scope"
 
-      timestamps(type: :utc_datetime)
+      timestamps(type: :utc_datetime_usec)
     end
 
     # Scoped to the message, not the conversation: two messages in one thread run

--- a/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
+++ b/priv/repo/migrations/20260825000000_create_glific_ai_tables.exs
@@ -5,11 +5,11 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
   Three levels, from outermost in:
 
     * `glific_ai_conversations` — a thread, owned by one user in one organization
-    * `glific_ai_requests`      — one question and every step taken to answer it
+    * `glific_ai_messages`      — one question and every step taken to answer it
     * `glific_ai_events`        — each individual step, in order
 
   There is deliberately no checkpoint table: the event log is the resumable state.
-  Reload a request's events in `step` order, rebuild the model context, continue.
+  Reload a message's events in `step` order, rebuild the model context, continue.
 
   Only what the read-only stage actually needs is here. Three things that earlier
   designs included are deliberately absent, each a small migration when its feature
@@ -19,7 +19,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
       carrying its own status. Note that re-adding an enum value needs
       `ALTER TYPE ... ADD VALUE`, which cannot run inside a transaction, so that
       migration needs `@disable_ddl_transaction true`.
-    * composition — `parent_request_id` and a depth cap, once a skill can invoke
+    * composition — `parent_message_id` and a depth cap, once a skill can invoke
       another skill.
     * a thread list — a title, an archived state and a last-event timestamp, once
       there is an interface that lists conversations.
@@ -30,20 +30,20 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
   def up do
     create_enums()
     create_conversations()
-    create_requests()
+    create_messages()
     create_events()
   end
 
   def down do
     drop_if_exists(table(:glific_ai_events))
-    drop_if_exists(table(:glific_ai_requests))
+    drop_if_exists(table(:glific_ai_messages))
     drop_if_exists(table(:glific_ai_conversations))
     drop_enums()
   end
 
   defp create_enums do
     execute("""
-    CREATE TYPE public.glific_ai_request_status_enum AS ENUM (
+    CREATE TYPE public.glific_ai_message_status_enum AS ENUM (
       'pending',
       'running',
       'succeeded',
@@ -64,7 +64,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
 
   defp drop_enums do
     execute("DROP TYPE IF EXISTS public.glific_ai_event_type_enum;")
-    execute("DROP TYPE IF EXISTS public.glific_ai_request_status_enum;")
+    execute("DROP TYPE IF EXISTS public.glific_ai_message_status_enum;")
   end
 
   defp create_conversations do
@@ -89,15 +89,15 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
     create index(:glific_ai_conversations, [:organization_id, :user_id])
   end
 
-  defp create_requests do
-    create table(:glific_ai_requests,
+  defp create_messages do
+    create table(:glific_ai_messages,
              comment:
                "One question and every step taken to answer it. Carries the lifecycle, the cost, and the composition tree."
            ) do
       add :skill, :string,
         comment: "Which skill the router selected. Null until routing completes."
 
-      add :status, :glific_ai_request_status_enum,
+      add :status, :glific_ai_message_status_enum,
         null: false,
         default: "pending",
         comment:
@@ -105,7 +105,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
 
       add :error, :text, comment: "Why it failed, when status is failed"
 
-      add :model, :string, comment: "Model that served this request, e.g. anthropic:claude-opus-5"
+      add :model, :string, comment: "Model that served this message, e.g. anthropic:claude-opus-5"
 
       add :input_tokens, :integer,
         null: false,
@@ -137,13 +137,13 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
       timestamps(type: :utc_datetime)
     end
 
-    create index(:glific_ai_requests, [:organization_id])
-    create index(:glific_ai_requests, [:organization_id, :conversation_id])
+    create index(:glific_ai_messages, [:organization_id])
+    create index(:glific_ai_messages, [:organization_id, :conversation_id])
 
-    create index(:glific_ai_requests, [:organization_id, :status],
+    create index(:glific_ai_messages, [:organization_id, :status],
              where: "status IN ('pending', 'running')",
-             name: :glific_ai_requests_in_flight_index,
-             comment: "Finds work that is still open without scanning finished requests"
+             name: :glific_ai_messages_in_flight_index,
+             comment: "Finds work that is still open without scanning finished messages"
            )
   end
 
@@ -155,7 +155,7 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
       add :step, :integer,
         null: false,
         comment:
-          "Which step of its own request this is, numbering from 1. It restarts for each request, so conversation order is (request_id, step) and not step alone. Explicit rather than derived from inserted_at so that a retried job cannot write the same step twice."
+          "Which step of its own message this is, numbering from 1. It restarts for each message, so conversation order is (message_id, step) and not step alone. Explicit rather than derived from inserted_at so that a retried job cannot write the same step twice."
 
       add :type, :glific_ai_event_type_enum,
         null: false,
@@ -175,14 +175,14 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
         comment:
           "Pairs a tool_call with its tool_result. Required to rebuild the context faithfully on replay."
 
-      add :request_id, references(:glific_ai_requests, on_delete: :delete_all),
+      add :message_id, references(:glific_ai_messages, on_delete: :delete_all),
         null: false,
         comment: "The question this step was taken in service of"
 
       add :conversation_id, references(:glific_ai_conversations, on_delete: :delete_all),
         null: false,
         comment:
-          "Denormalized from the request so a whole thread loads in one query, with no join"
+          "Denormalized from the message so a whole thread loads in one query, with no join"
 
       add :organization_id, references(:organizations, on_delete: :delete_all),
         null: false,
@@ -191,14 +191,14 @@ defmodule Glific.Repo.Migrations.CreateGlificAiTables do
       timestamps(type: :utc_datetime)
     end
 
-    # Scoped to the request, not the conversation: two requests in one thread run
+    # Scoped to the message, not the conversation: two messages in one thread run
     # concurrently, and conversation-wide numbering would make them race for the same
     # value. This also stops an Oban retry writing a step twice.
-    create unique_index(:glific_ai_events, [:request_id, :step])
+    create unique_index(:glific_ai_events, [:message_id, :step])
 
     create index(:glific_ai_events, [:organization_id])
 
-    create index(:glific_ai_events, [:request_id, :tool_call_id],
+    create index(:glific_ai_events, [:message_id, :tool_call_id],
              where: "tool_call_id IS NOT NULL",
              name: :glific_ai_events_tool_call_index,
              comment: "Pairs calls to their results during replay"

--- a/test/glific/ai/storage_test.exs
+++ b/test/glific/ai/storage_test.exs
@@ -31,7 +31,7 @@ defmodule Glific.AI.StorageTest do
           conversation_id: conversation.id,
           user_id: conversation.user_id,
           organization_id: conversation.organization_id,
-          skill: "flow-review"
+          status: :running
         },
         attrs
       )
@@ -115,7 +115,7 @@ defmodule Glific.AI.StorageTest do
     # This is the case conversation-wide numbering would break: both messages are
     # live in the same thread and each starts its own event numbering.
     first = message(conversation)
-    second = message(conversation, %{skill: "knowledge"})
+    second = message(conversation, %{})
 
     assert {:ok, _} = event(first, %{step: 1, type: :user, content: "why is it stuck?"})
     assert {:ok, _} = event(second, %{step: 1, type: :user, content: "and what is an HSM?"})
@@ -145,7 +145,6 @@ defmodule Glific.AI.StorageTest do
 
     failed =
       message(conversation, %{
-        skill: "flow-review",
         status: :failed,
         error: "the provider returned a 400",
         model: "anthropic:claude-opus-5",

--- a/test/glific/ai/storage_test.exs
+++ b/test/glific/ai/storage_test.exs
@@ -1,0 +1,164 @@
+defmodule Glific.AI.StorageTest do
+  use Glific.DataCase
+
+  import Ecto.Query
+
+  alias Glific.{
+    AI.Conversation,
+    AI.Event,
+    AI.Request,
+    Fixtures,
+    Repo
+  }
+
+  defp conversation(organization_id) do
+    user = Fixtures.user_fixture(%{organization_id: organization_id})
+
+    %Conversation{}
+    |> Conversation.changeset(%{
+      title: "why is my flow stuck?",
+      user_id: user.id,
+      organization_id: organization_id
+    })
+    |> Repo.insert!()
+  end
+
+  defp request(conversation, attrs \\ %{}) do
+    %Request{}
+    |> Request.changeset(
+      Map.merge(
+        %{
+          conversation_id: conversation.id,
+          user_id: conversation.user_id,
+          organization_id: conversation.organization_id,
+          skill: "flow-review"
+        },
+        attrs
+      )
+    )
+    |> Repo.insert!()
+  end
+
+  defp event(request, attrs) do
+    %Event{}
+    |> Event.changeset(
+      Map.merge(
+        %{
+          request_id: request.id,
+          conversation_id: request.conversation_id,
+          organization_id: request.organization_id
+        },
+        attrs
+      )
+    )
+    |> Repo.insert()
+  end
+
+  test "one organization cannot see another's conversations, requests or events" do
+    other_org = Fixtures.organization_fixture(%{shortcode: "glific_ai_other"})
+
+    mine = conversation(1)
+    my_request = request(mine)
+    {:ok, _} = event(my_request, %{step: 1, type: :user, content: "hello"})
+
+    Repo.put_organization_id(other_org.id)
+
+    assert [] == Repo.all(Conversation)
+    assert [] == Repo.all(Request)
+    assert [] == Repo.all(Event)
+
+    Repo.put_organization_id(1)
+
+    assert [^mine] = Repo.all(Conversation)
+    assert 1 == Repo.aggregate(Event, :count)
+  end
+
+  test "deleting a conversation removes its requests and events, and the organization FKs cascade" do
+    conversation = conversation(1)
+    first = request(conversation)
+    {:ok, _} = event(first, %{step: 1, type: :assistant, content: "here you go"})
+
+    Repo.delete!(conversation)
+
+    assert 0 == Repo.aggregate(Request, :count)
+    assert 0 == Repo.aggregate(Event, :count)
+
+    # An organization being removed must take its Glific AI data with it.
+    cascading =
+      Repo.all(
+        from(c in "pg_constraint",
+          join: t in "pg_class",
+          on: t.oid == c.conrelid,
+          where:
+            t.relname in ^[
+              "glific_ai_conversations",
+              "glific_ai_requests",
+              "glific_ai_events"
+            ] and
+              c.contype == "f" and c.confdeltype == "c",
+          select: t.relname,
+          distinct: true
+        ),
+        skip_organization_id: true
+      )
+
+    assert Enum.sort(cascading) == [
+             "glific_ai_conversations",
+             "glific_ai_events",
+             "glific_ai_requests"
+           ]
+  end
+
+  test "two requests in one conversation can both number their steps from 1" do
+    conversation = conversation(1)
+
+    # This is the case conversation-wide numbering would break: both requests are
+    # live in the same thread and each starts its own event numbering.
+    first = request(conversation)
+    second = request(conversation, %{skill: "knowledge"})
+
+    assert {:ok, _} = event(first, %{step: 1, type: :user, content: "why is it stuck?"})
+    assert {:ok, _} = event(second, %{step: 1, type: :user, content: "and what is an HSM?"})
+
+    assert {:ok, _} =
+             event(first, %{
+               step: 2,
+               type: :tool_call,
+               tool_call_id: "call_a1",
+               data: %{"name" => "list_flows"}
+             })
+
+    # ...but a request may not reuse a step of its own.
+    assert {:error, changeset} = event(first, %{step: 1, type: :assistant})
+    assert errors_on(changeset).request_id != [] or errors_on(changeset).step != []
+
+    # A whole thread reads back in order across both requests.
+    assert [{_, 1}, {_, 2}, {_, 1}] =
+             Event
+             |> order_by([e], asc: e.request_id, asc: e.step)
+             |> select([e], {e.request_id, e.step})
+             |> Repo.all()
+  end
+
+  test "a failed request keeps its reason and its cost" do
+    conversation = conversation(1)
+
+    failed =
+      request(conversation, %{
+        skill: "flow-review",
+        status: :failed,
+        error: "the provider returned a 400",
+        model: "anthropic:claude-opus-5",
+        input_tokens: 120,
+        output_tokens: 40,
+        cost: Decimal.new("0.0042")
+      })
+
+    assert failed.status == :failed
+    assert failed.error == "the provider returned a 400"
+    assert Decimal.equal?(failed.cost, Decimal.new("0.0042"))
+
+    # A failed request is still listed, so the thread renders.
+    assert [failed.id] == Request |> select([r], r.id) |> Repo.all()
+  end
+end

--- a/test/glific/ai/storage_test.exs
+++ b/test/glific/ai/storage_test.exs
@@ -6,7 +6,7 @@ defmodule Glific.AI.StorageTest do
   alias Glific.{
     AI.Conversation,
     AI.Event,
-    AI.Request,
+    AI.Message,
     Fixtures,
     Repo
   }
@@ -23,9 +23,9 @@ defmodule Glific.AI.StorageTest do
     |> Repo.insert!()
   end
 
-  defp request(conversation, attrs \\ %{}) do
-    %Request{}
-    |> Request.changeset(
+  defp message(conversation, attrs \\ %{}) do
+    %Message{}
+    |> Message.changeset(
       Map.merge(
         %{
           conversation_id: conversation.id,
@@ -39,14 +39,14 @@ defmodule Glific.AI.StorageTest do
     |> Repo.insert!()
   end
 
-  defp event(request, attrs) do
+  defp event(message, attrs) do
     %Event{}
     |> Event.changeset(
       Map.merge(
         %{
-          request_id: request.id,
-          conversation_id: request.conversation_id,
-          organization_id: request.organization_id
+          message_id: message.id,
+          conversation_id: message.conversation_id,
+          organization_id: message.organization_id
         },
         attrs
       )
@@ -54,17 +54,17 @@ defmodule Glific.AI.StorageTest do
     |> Repo.insert()
   end
 
-  test "one organization cannot see another's conversations, requests or events" do
+  test "one organization cannot see another's conversations, messages or events" do
     other_org = Fixtures.organization_fixture(%{shortcode: "glific_ai_other"})
 
     mine = conversation(1)
-    my_request = request(mine)
-    {:ok, _} = event(my_request, %{step: 1, type: :user, content: "hello"})
+    my_message = message(mine)
+    {:ok, _} = event(my_message, %{step: 1, type: :user, content: "hello"})
 
     Repo.put_organization_id(other_org.id)
 
     assert [] == Repo.all(Conversation)
-    assert [] == Repo.all(Request)
+    assert [] == Repo.all(Message)
     assert [] == Repo.all(Event)
 
     Repo.put_organization_id(1)
@@ -73,14 +73,14 @@ defmodule Glific.AI.StorageTest do
     assert 1 == Repo.aggregate(Event, :count)
   end
 
-  test "deleting a conversation removes its requests and events, and the organization FKs cascade" do
+  test "deleting a conversation removes its messages and events, and the organization FKs cascade" do
     conversation = conversation(1)
-    first = request(conversation)
+    first = message(conversation)
     {:ok, _} = event(first, %{step: 1, type: :assistant, content: "here you go"})
 
     Repo.delete!(conversation)
 
-    assert 0 == Repo.aggregate(Request, :count)
+    assert 0 == Repo.aggregate(Message, :count)
     assert 0 == Repo.aggregate(Event, :count)
 
     # An organization being removed must take its Glific AI data with it.
@@ -92,7 +92,7 @@ defmodule Glific.AI.StorageTest do
           where:
             t.relname in ^[
               "glific_ai_conversations",
-              "glific_ai_requests",
+              "glific_ai_messages",
               "glific_ai_events"
             ] and
               c.contype == "f" and c.confdeltype == "c",
@@ -105,17 +105,17 @@ defmodule Glific.AI.StorageTest do
     assert Enum.sort(cascading) == [
              "glific_ai_conversations",
              "glific_ai_events",
-             "glific_ai_requests"
+             "glific_ai_messages"
            ]
   end
 
-  test "two requests in one conversation can both number their steps from 1" do
+  test "two messages in one conversation can both number their steps from 1" do
     conversation = conversation(1)
 
-    # This is the case conversation-wide numbering would break: both requests are
+    # This is the case conversation-wide numbering would break: both messages are
     # live in the same thread and each starts its own event numbering.
-    first = request(conversation)
-    second = request(conversation, %{skill: "knowledge"})
+    first = message(conversation)
+    second = message(conversation, %{skill: "knowledge"})
 
     assert {:ok, _} = event(first, %{step: 1, type: :user, content: "why is it stuck?"})
     assert {:ok, _} = event(second, %{step: 1, type: :user, content: "and what is an HSM?"})
@@ -128,23 +128,23 @@ defmodule Glific.AI.StorageTest do
                data: %{"name" => "list_flows"}
              })
 
-    # ...but a request may not reuse a step of its own.
+    # ...but a message may not reuse a step of its own.
     assert {:error, changeset} = event(first, %{step: 1, type: :assistant})
-    assert errors_on(changeset).request_id != [] or errors_on(changeset).step != []
+    assert errors_on(changeset).message_id != [] or errors_on(changeset).step != []
 
-    # A whole thread reads back in order across both requests.
+    # A whole thread reads back in order across both messages.
     assert [{_, 1}, {_, 2}, {_, 1}] =
              Event
-             |> order_by([e], asc: e.request_id, asc: e.step)
-             |> select([e], {e.request_id, e.step})
+             |> order_by([e], asc: e.message_id, asc: e.step)
+             |> select([e], {e.message_id, e.step})
              |> Repo.all()
   end
 
-  test "a failed request keeps its reason and its cost" do
+  test "a failed message keeps its reason and its cost" do
     conversation = conversation(1)
 
     failed =
-      request(conversation, %{
+      message(conversation, %{
         skill: "flow-review",
         status: :failed,
         error: "the provider returned a 400",
@@ -158,7 +158,7 @@ defmodule Glific.AI.StorageTest do
     assert failed.error == "the provider returned a 400"
     assert Decimal.equal?(failed.cost, Decimal.new("0.0042"))
 
-    # A failed request is still listed, so the thread renders.
-    assert [failed.id] == Request |> select([r], r.id) |> Repo.all()
+    # A failed message is still listed, so the thread renders.
+    assert [failed.id] == Message |> select([r], r.id) |> Repo.all()
   end
 end


### PR DESCRIPTION
Closes #5604 · Part of #5368

Creates the three tables Glific AI stores its data in, plus their Ecto schemas.
**Nothing reads or writes them yet** — later PRs do. No behaviour changes.

```
glific_ai_conversations        a chat thread, owned by one user
  └── glific_ai_messages       one question, and how answering it went
        └── glific_ai_events   each step taken answering it
```

A question is two events today — the question and the answer. Once the assistant can read Glific data it becomes six or more, since each tool call and result is also an event.

### `glific_ai_conversations`

| Column | |
|---|---|
| `title` | label taken from the first question |
| `user_id`, `organization_id` | owner and tenant scope |

### `glific_ai_messages`

| Column | |
|---|---|
| `skill` | which capability handled it |
| `status` | `pending · running · succeeded · failed · cancelled` |
| `error` | why it failed |
| `model` | what served it |
| `input_tokens`, `output_tokens`, `cost` | summed across every model call |
| `conversation_id`, `user_id`, `organization_id` | |

`user_id` is here because the assistant runs in a background job, which has no
GraphQL layer to authorise against — reads need to be scoped to whoever asked,
not to an admin.

Separate from events because a question can fail with no answer to hang `status`
and `error` on, and because cost belongs to the whole question rather than to any
one step.

### `glific_ai_events`

| Column | |
|---|---|
| `step` | which step of *its own message*, from 1 |
| `type` | `user · assistant · tool_call · tool_result` |
| `content` | the readable part |
| `data` | tool arguments and output, kept out of `content` |
| `tool_call_id` | pairs a `tool_call` with its `tool_result` |
| `message_id`, `conversation_id`, `organization_id` | |

`step` restarts per message, so conversation order is `ORDER BY message_id, step`.
Numbering per message rather than per conversation means two questions asked at once can't race for the same value, and the unique index stops a retried job writing the same step twice.

`tool_result` is a distinct type from `assistant` deliberately: tool output is untrusted content, and keeping it typed is what lets the code present it to the model as data rather than instruction.


### Deleting an organisation

The tables are added to `Erase.org_data_deletion_order/0` — foreign keys alone aren't enough, since org deletion walks that list rather than relying on cascades.
