### PR TITLE
[glific-ai]: Add feature flag for Glific AI

### DIFF
--- a/assets/gql/organizations/get_services.gql
+++ b/assets/gql/organizations/get_services.gql
@@ -17,6 +17,7 @@ query organizationServices {
     ai_evaluation_v2_enabled
     template_v2_enabled
     template_library_enabled
+    glific_ai_enabled
     errors {
       key
       message

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -471,18 +471,8 @@ defmodule Glific.Flags do
   """
   @spec get_glific_ai_enabled(map()) :: boolean
   def get_glific_ai_enabled(organization) do
-    app_env = Application.get_env(:glific, :environment)
-
-    cond do
-      FunWithFlags.enabled?(:glific_ai_enabled, for: %{organization_id: organization.id}) ->
-        true
-
-      Glific.trusted_env?(app_env, organization.id) ->
-        true
-
-      true ->
-        false
-    end
+    get_flag_enabled(:glific_ai_enabled, organization) or
+      Glific.trusted_env?(Application.get_env(:glific, :environment), organization.id)
   end
 
   @doc """

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -463,27 +463,6 @@ defmodule Glific.Flags do
   end
 
   @doc """
-  Get Glific AI feature flag for the organization.
-
-  On for the Glific organization itself in a trusted environment, so internal
-  testing needs no manual toggle. Every other organization is off until the flag
-  is enabled for them.
-  """
-  @spec get_glific_ai_enabled(map()) :: boolean
-  def get_glific_ai_enabled(organization) do
-    get_flag_enabled(:glific_ai_enabled, organization) or
-      Glific.trusted_env?(Application.get_env(:glific, :environment), organization.id)
-  end
-
-  @doc """
-  Set fun_with_flag toggle for Glific AI enabled for an organization
-  """
-  @spec set_glific_ai_enabled(map()) :: map()
-  def set_glific_ai_enabled(organization) do
-    Map.put(organization, :glific_ai_enabled, get_glific_ai_enabled(organization))
-  end
-
-  @doc """
   Set fun_with_flag toggle for ask_glific enabled for an organization
   """
   @spec set_is_ask_glific_enabled(map()) :: map()

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -463,6 +463,37 @@ defmodule Glific.Flags do
   end
 
   @doc """
+  Get Glific AI feature flag for the organization.
+
+  On for the Glific organization itself in a trusted environment, so internal
+  testing needs no manual toggle. Every other organization is off until the flag
+  is enabled for them.
+  """
+  @spec get_glific_ai_enabled(map()) :: boolean
+  def get_glific_ai_enabled(organization) do
+    app_env = Application.get_env(:glific, :environment)
+
+    cond do
+      FunWithFlags.enabled?(:glific_ai_enabled, for: %{organization_id: organization.id}) ->
+        true
+
+      Glific.trusted_env?(app_env, organization.id) ->
+        true
+
+      true ->
+        false
+    end
+  end
+
+  @doc """
+  Set fun_with_flag toggle for Glific AI enabled for an organization
+  """
+  @spec set_glific_ai_enabled(map()) :: map()
+  def set_glific_ai_enabled(organization) do
+    Map.put(organization, :glific_ai_enabled, get_glific_ai_enabled(organization))
+  end
+
+  @doc """
   Set fun_with_flag toggle for ask_glific enabled for an organization
   """
   @spec set_is_ask_glific_enabled(map()) :: map()
@@ -527,7 +558,8 @@ defmodule Glific.Flags do
       :is_ai_evaluation_enabled,
       :is_prompt_generator_enabled,
       :is_template_v2_enabled,
-      :is_template_library_enabled
+      :is_template_library_enabled,
+      :glific_ai_enabled
     ]
     |> Enum.each(fn flag ->
       if !FunWithFlags.enabled?(

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -597,6 +597,7 @@ defmodule Glific.Partners do
       |> Flags.set_flag_enabled(:is_prompt_generator_enabled)
       |> Flags.set_flag_enabled(:is_template_v2_enabled)
       |> Flags.set_flag_enabled(:is_template_library_enabled)
+      |> Flags.set_glific_ai_enabled()
 
     Caches.set(
       @global_organization_id,
@@ -1500,7 +1501,8 @@ defmodule Glific.Partners do
         Flags.get_flag_enabled(:is_prompt_generator_enabled, organization),
       "template_v2_enabled" => Flags.get_flag_enabled(:is_template_v2_enabled, organization),
       "template_library_enabled" =>
-        Flags.get_flag_enabled(:is_template_library_enabled, organization)
+        Flags.get_flag_enabled(:is_template_library_enabled, organization),
+      "glific_ai_enabled" => Flags.get_glific_ai_enabled(organization)
     }
   end
 

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -597,7 +597,7 @@ defmodule Glific.Partners do
       |> Flags.set_flag_enabled(:is_prompt_generator_enabled)
       |> Flags.set_flag_enabled(:is_template_v2_enabled)
       |> Flags.set_flag_enabled(:is_template_library_enabled)
-      |> Flags.set_glific_ai_enabled()
+      |> Flags.set_flag_enabled(:glific_ai_enabled)
 
     Caches.set(
       @global_organization_id,
@@ -1502,7 +1502,7 @@ defmodule Glific.Partners do
       "template_v2_enabled" => Flags.get_flag_enabled(:is_template_v2_enabled, organization),
       "template_library_enabled" =>
         Flags.get_flag_enabled(:is_template_library_enabled, organization),
-      "glific_ai_enabled" => Flags.get_glific_ai_enabled(organization)
+      "glific_ai_enabled" => Flags.get_flag_enabled(:glific_ai_enabled, organization)
     }
   end
 

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -205,6 +205,9 @@ defmodule Glific.Partners.Organization do
     # A virtual field to conditionally enable the Template Library button for an organization
     field(:is_template_library_enabled, :boolean, default: false, virtual: true)
 
+    # A virtual field to conditionally enable Glific AI for an organization
+    field(:glific_ai_enabled, :boolean, default: false, virtual: true)
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -37,6 +37,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:prompt_generator_enabled, :boolean)
     field(:template_v2_enabled, :boolean)
     field(:template_library_enabled, :boolean)
+    field(:glific_ai_enabled, :boolean)
   end
 
   object :organization_export_result do

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -153,6 +153,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:is_prompt_generator_enabled, :boolean)
     field(:is_template_v2_enabled, :boolean)
     field(:is_template_library_enabled, :boolean)
+    field(:glific_ai_enabled, :boolean)
 
     field(:inserted_at, :datetime)
 

--- a/test/glific/flags_test.exs
+++ b/test/glific/flags_test.exs
@@ -217,20 +217,4 @@ defmodule Glific.FlagsTest do
     assert %{is_prompt_generator_enabled: false} =
              Flags.set_flag_enabled(organization, :is_prompt_generator_enabled)
   end
-
-  test "glific_ai_enabled is on for the Glific org in a trusted env, and togglable elsewhere" do
-    # trusted_env?/2 matches only :dev and :prod; tests run as :test
-    original_env = Application.get_env(:glific, :environment)
-    Application.put_env(:glific, :environment, :dev)
-    on_exit(fn -> Application.put_env(:glific, :environment, original_env) end)
-
-    glific_org = Partners.organization(Glific.glific_organization_id())
-    assert Flags.get_glific_ai_enabled(glific_org)
-
-    other_org = Fixtures.organization_fixture(%{shortcode: "glific_ai_other"})
-    refute Flags.get_glific_ai_enabled(other_org)
-
-    FunWithFlags.enable(:glific_ai_enabled, for_actor: %{organization_id: other_org.id})
-    assert %{glific_ai_enabled: true} = Flags.set_glific_ai_enabled(other_org)
-  end
 end

--- a/test/glific/flags_test.exs
+++ b/test/glific/flags_test.exs
@@ -217,4 +217,20 @@ defmodule Glific.FlagsTest do
     assert %{is_prompt_generator_enabled: false} =
              Flags.set_flag_enabled(organization, :is_prompt_generator_enabled)
   end
+
+  test "glific_ai_enabled is on for the Glific org in a trusted env, and togglable elsewhere" do
+    # trusted_env?/2 matches only :dev and :prod; tests run as :test
+    original_env = Application.get_env(:glific, :environment)
+    Application.put_env(:glific, :environment, :dev)
+    on_exit(fn -> Application.put_env(:glific, :environment, original_env) end)
+
+    glific_org = Partners.organization(Glific.glific_organization_id())
+    assert Flags.get_glific_ai_enabled(glific_org)
+
+    other_org = Fixtures.organization_fixture(%{shortcode: "glific_ai_other"})
+    refute Flags.get_glific_ai_enabled(other_org)
+
+    FunWithFlags.enable(:glific_ai_enabled, for_actor: %{organization_id: other_org.id})
+    assert %{glific_ai_enabled: true} = Flags.set_glific_ai_enabled(other_org)
+  end
 end

--- a/test/glific_web/schema/organization_test.exs
+++ b/test/glific_web/schema/organization_test.exs
@@ -645,6 +645,7 @@ defmodule GlificWeb.Schema.OrganizationTest do
     assert services["template_v2_enabled"] == false
     assert services["template_library_enabled"] == false
     assert services["ai_evaluation_v2_enabled"] == false
+    assert services["glific_ai_enabled"] == false
   end
 
   test "update an organization with organization settings", %{user: user} do


### PR DESCRIPTION
Closes #5603 · Part of #5368

## What this does

Adds a per-organisation feature flag, `glific_ai_enabled`, so the Glific AI
assistant can be turned on for one organisation at a time. Nothing reads the flag
yet — later PRs do. No behaviour changes for anyone.

