### PR TITLE
fix(flows): stop a late callback relabelling a timed-out webhook log

### DIFF
--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -991,6 +991,17 @@ defmodule Glific.Flows.FlowContext do
   end
 
   @doc """
+  Whether the contact still has a flow parked on `flow_id` awaiting a webhook result.
+  """
+  @spec awaiting_result?(non_neg_integer(), non_neg_integer()) :: boolean()
+  def awaiting_result?(contact_id, flow_id) do
+    FlowContext
+    |> where([fc], fc.contact_id == ^contact_id and fc.flow_id == ^flow_id)
+    |> where([fc], fc.is_await_result == true and is_nil(fc.completed_at))
+    |> Repo.exists?()
+  end
+
+  @doc """
   Resume the flow for a given contact and a given flow id if still active
   """
   @spec resume_contact_flow(
@@ -1175,7 +1186,7 @@ defmodule Glific.Flows.FlowContext do
       webhook_log_id = fetch_latest_webhook_log_id(context)
 
       if webhook_log_id do
-        Webhook.update_log(webhook_log_id, "Timeout: taking long to process response")
+        Webhook.update_log(webhook_log_id, Webhook.timeout_error())
       end
 
       # Always count the timeout failure, even when no WebhookLog row exists yet.

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -991,15 +991,34 @@ defmodule Glific.Flows.FlowContext do
   end
 
   @doc """
-  Whether the contact still has a flow parked on `flow_id` awaiting a webhook result.
+  The context still parked on the node that dispatched an async webhook, or nil if the flow
+  has moved on.
+
+  `:context_id` and `:node_uuid` pin the lookup to that one node execution. Matching on
+  contact and flow alone also matches a *later* async node in the same run, or a fresh run of
+  the same flow, and a late callback would then resume that with a stale result. They are nil
+  for callbacks dispatched before those fields were sent, which fall back to contact + flow.
+
+  Bounded to one row: the pinned lookup can only match one, and the fallback takes the newest
+  rather than raising on a contact that somehow has two parked contexts on the same flow --
+  this runs on the callback path, where raising would lose the callback.
   """
-  @spec awaiting_result?(non_neg_integer(), non_neg_integer()) :: boolean()
-  def awaiting_result?(contact_id, flow_id) do
+  @spec awaiting_context(map()) :: FlowContext.t() | nil
+  def awaiting_context(%{contact_id: contact_id, flow_id: flow_id} = dispatch) do
     FlowContext
     |> where([fc], fc.contact_id == ^contact_id and fc.flow_id == ^flow_id)
     |> where([fc], fc.is_await_result == true and is_nil(fc.completed_at))
-    |> Repo.exists?()
+    |> pin_to(:id, dispatch[:context_id])
+    |> pin_to(:node_uuid, dispatch[:node_uuid])
+    |> order_by([fc], desc: fc.id)
+    |> limit(1)
+    |> preload(:flow)
+    |> Repo.one()
   end
+
+  @spec pin_to(Ecto.Query.t(), atom(), term()) :: Ecto.Query.t()
+  defp pin_to(query, _field, nil), do: query
+  defp pin_to(query, field, value), do: where(query, [fc], field(fc, ^field) == ^value)
 
   @doc """
   Resume the flow for a given contact and a given flow id if still active

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -188,8 +188,9 @@ defmodule Glific.Flows.Webhook do
         webhook_log_id: webhook_log.id,
         flow_id: context.flow_id,
         contact_id: context.contact_id,
-        # for job uniqueness
+        # for job uniqueness, and to pin an async callback to this node execution
         context_id: context.id,
+        node_uuid: context.node_uuid,
         context: %{id: context.id, delay: context.delay, uuids_seen: context.uuids_seen},
         organization_id: context.organization_id,
         action_id: action.uuid
@@ -294,6 +295,8 @@ defmodule Glific.Flows.Webhook do
     enrichment = %{
       "flow_id" => args["flow_id"],
       "contact_id" => args["contact_id"],
+      "context_id" => args["context_id"],
+      "node_uuid" => args["node_uuid"],
       "webhook_log_id" => webhook_log_id,
       "result_name" => result_name
     }
@@ -475,16 +478,19 @@ defmodule Glific.Flows.Webhook do
   @spec resume(non_neg_integer(), map(), map()) :: :ok
   def resume(organization_id, result, response) do
     with_validated_callback(organization_id, response, "Flow resume", fn contact ->
-      if still_awaiting?(response),
-        do: resume(organization_id, result, response, contact),
-        else: record_late_callback(result, response)
+      case awaiting_context(response) do
+        {:ok, context} -> resume(organization_id, result, response, contact, context)
+        :none -> record_late_callback(result, response)
+        :unknown -> resume(organization_id, result, response, contact, flow_id(response))
+      end
     end)
   end
 
-  # The await window already closed, so there is no context to resume. Stop here rather than
-  # letting resume_contact_flow/4 fail with "no active flows awaiting results" and report a
-  # SystemError for an expected outcome. Skipping also avoids Dispatcher.callback/3, whose
-  # handle_callback/3 does the voice node's NMT + TTS post-processing.
+  # The node that dispatched this webhook is no longer parked, so there is nothing to resume.
+  # Stop here rather than letting resume_contact_flow/4 fail with "no active flows awaiting
+  # results" and report a SystemError for an expected outcome. Skipping also avoids
+  # Dispatcher.callback/3, whose handle_callback/3 does the voice node's NMT + TTS
+  # post-processing.
   @spec record_late_callback(map(), map()) :: :ok
   defp record_late_callback(result, response) do
     response = Map.put(response, "error_type", "flow_not_awaiting")
@@ -493,7 +499,7 @@ defmodule Glific.Flows.Webhook do
     Instrumentation.track_webhook_count(response["webhook_name"], "late_callback")
 
     Logger.info(
-      "Late callback ignored, flow no longer awaiting a result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}"
+      "Late callback ignored, node no longer awaiting a result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}, node_uuid=#{response["node_uuid"]}"
     )
 
     :ok
@@ -528,8 +534,14 @@ defmodule Glific.Flows.Webhook do
     :ok
   end
 
-  @spec resume(non_neg_integer(), map(), map(), Contact.t()) :: :ok
-  defp resume(organization_id, result, response, contact) do
+  @spec resume(
+          non_neg_integer(),
+          map(),
+          map(),
+          Contact.t(),
+          FlowContext.t() | non_neg_integer() | nil
+        ) :: :ok
+  defp resume(organization_id, result, response, contact, target) do
     maybe_update_log(response["webhook_log_id"], callback_log_message(result, response))
 
     shaped = Dispatcher.callback(response["webhook_name"], result, response)
@@ -538,7 +550,7 @@ defmodule Glific.Flows.Webhook do
 
     FlowContext.resume_contact_flow(
       contact,
-      response["flow_id"],
+      target,
       %{response_key => shaped},
       resume_message(result, response, organization_id)
     )
@@ -633,14 +645,14 @@ defmodule Glific.Flows.Webhook do
 
   def maybe_upload_tts_audio(response), do: response
 
-  # The flow already moved on -- timed out or completed -- so nothing can consume the audio.
-  # Skipping saves a multi-megabyte GCS upload whose result is discarded. The base64 has to be
-  # dropped as well: callback_log_message/2 copies "message" into the webhook log's response_json,
-  # so leaving it would write the whole payload into the row.
+  # The node that asked for this audio has moved on -- timed out or completed -- so nothing can
+  # consume it. Skipping saves a multi-megabyte GCS upload whose result is discarded. The base64
+  # has to be dropped as well: callback_log_message/2 copies "message" into the webhook log's
+  # response_json, so leaving it would write the whole payload into the row.
   @spec skip_tts_upload(map()) :: map()
   defp skip_tts_upload(response) do
     Logger.info(
-      "Skipping TTS upload, flow no longer awaiting result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}"
+      "Skipping TTS upload, node no longer awaiting result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}, node_uuid=#{response["node_uuid"]}"
     )
 
     response
@@ -650,19 +662,47 @@ defmodule Glific.Flows.Webhook do
     |> Map.put("reason", "Flow is no longer awaiting a result; TTS upload skipped")
   end
 
-  # Unusable ids mean we cannot run the lookup, so fall through to the upload -- the same
-  # behaviour as before this check existed. Skipping instead would drop audio a flow may
-  # genuinely be waiting on.
-  @spec still_awaiting?(map()) :: boolean()
-  defp still_awaiting?(response) do
-    case {integer_field(response["contact_id"]), integer_field(response["flow_id"])} do
+  # Resolves the one parked context this callback belongs to. `:unknown` means the ids were
+  # unusable so the lookup could not run -- callers then fall through to the behaviour that
+  # existed before this check, rather than discarding a result a flow may genuinely await.
+  @spec awaiting_context(map()) :: {:ok, FlowContext.t()} | :none | :unknown
+  defp awaiting_context(response) do
+    case {integer_field(response["contact_id"]), flow_id(response)} do
       {contact_id, flow_id} when is_integer(contact_id) and is_integer(flow_id) ->
-        FlowContext.awaiting_result?(contact_id, flow_id)
+        %{
+          contact_id: contact_id,
+          flow_id: flow_id,
+          context_id: integer_field(response["context_id"]),
+          node_uuid: uuid_field(response["node_uuid"])
+        }
+        |> FlowContext.awaiting_context()
+        |> case do
+          nil -> :none
+          context -> {:ok, context}
+        end
 
       _ ->
-        true
+        :unknown
     end
   end
+
+  @spec still_awaiting?(map()) :: boolean()
+  defp still_awaiting?(response), do: awaiting_context(response) != :none
+
+  @spec flow_id(map()) :: integer() | nil
+  defp flow_id(response), do: integer_field(response["flow_id"])
+
+  # A node_uuid that is not a well-formed UUID would make the query raise, so drop it and let
+  # the lookup fall back to contact + flow.
+  @spec uuid_field(any()) :: Ecto.UUID.t() | nil
+  defp uuid_field(value) when is_binary(value) do
+    case Ecto.UUID.cast(value) do
+      {:ok, uuid} -> uuid
+      :error -> nil
+    end
+  end
+
+  defp uuid_field(_value), do: nil
 
   @spec integer_field(any()) :: integer() | nil
   defp integer_field(value) when is_integer(value), do: value

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -43,6 +43,8 @@ defmodule Glific.Flows.Webhook do
     defexception [:message, :reason, :organization_id]
   end
 
+  @timeout_error "Timeout: taking long to process response"
+
   @non_unique_urls [
     "parse_via_gpt_vision",
     "parse_via_chat_gpt",
@@ -118,14 +120,14 @@ defmodule Glific.Flows.Webhook do
     attrs = %{response_json: result, status_code: 400, error: error}
 
     webhook_log
-    |> WebhookLog.update_webhook_log(attrs)
+    |> update_outcome(attrs)
   end
 
   def update_log(webhook_log, result) when is_map(result) do
     attrs = %{response_json: result, status_code: 200}
 
     webhook_log
-    |> WebhookLog.update_webhook_log(attrs)
+    |> update_outcome(attrs)
   end
 
   def update_log(webhook_log, error_message) do
@@ -137,6 +139,21 @@ defmodule Glific.Flows.Webhook do
     webhook_log
     |> WebhookLog.update_webhook_log(attrs)
   end
+
+  @doc "The error recorded on a webhook log when an async node's await window expires."
+  @spec timeout_error() :: String.t()
+  def timeout_error, do: @timeout_error
+
+  # A callback can still arrive after the await window expired, by which point the flow has
+  # already routed to Failure. Record the late response, but leave the outcome alone -- otherwise
+  # a timed-out interaction is relabelled 200/Success and webhook_logs undercount timeouts.
+  @spec update_outcome(WebhookLog.t(), map()) ::
+          {:ok, WebhookLog.t()} | {:error, Ecto.Changeset.t()}
+  defp update_outcome(%WebhookLog{error: @timeout_error} = webhook_log, attrs),
+    do: WebhookLog.update_webhook_log(webhook_log, Map.take(attrs, [:response_json]))
+
+  defp update_outcome(webhook_log, attrs),
+    do: WebhookLog.update_webhook_log(webhook_log, attrs)
 
   @spec method(Action.t(), FlowContext.t()) :: nil
   defp method(action, context) do
@@ -588,7 +605,59 @@ defmodule Glific.Flows.Webhook do
   copied into the supervised resume task.
   """
   @spec maybe_upload_tts_audio(map()) :: map()
-  def maybe_upload_tts_audio(%{"output_type" => "audio", "message" => base64_audio} = response) do
+  def maybe_upload_tts_audio(%{"output_type" => "audio", "message" => _audio} = response) do
+    if still_awaiting?(response),
+      do: do_upload_tts_audio(response),
+      else: skip_tts_upload(response)
+  end
+
+  def maybe_upload_tts_audio(response), do: response
+
+  # The flow already moved on -- timed out or completed -- so nothing can consume the audio.
+  # Skipping saves a multi-megabyte GCS upload whose result is discarded. The base64 has to be
+  # dropped as well: callback_log_message/2 copies "message" into the webhook log's response_json,
+  # so leaving it would write the whole payload into the row.
+  @spec skip_tts_upload(map()) :: map()
+  defp skip_tts_upload(response) do
+    Logger.info(
+      "Skipping TTS upload, flow no longer awaiting result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}"
+    )
+
+    response
+    |> Map.put("message", nil)
+    |> Map.put("success", false)
+    |> Map.put("error_type", "flow_not_awaiting")
+    |> Map.put("reason", "Flow is no longer awaiting a result; TTS upload skipped")
+  end
+
+  # Unusable ids mean we cannot run the lookup, so fall through to the upload -- the same
+  # behaviour as before this check existed. Skipping instead would drop audio a flow may
+  # genuinely be waiting on.
+  @spec still_awaiting?(map()) :: boolean()
+  defp still_awaiting?(response) do
+    case {integer_field(response["contact_id"]), integer_field(response["flow_id"])} do
+      {contact_id, flow_id} when is_integer(contact_id) and is_integer(flow_id) ->
+        FlowContext.awaiting_result?(contact_id, flow_id)
+
+      _ ->
+        true
+    end
+  end
+
+  @spec integer_field(any()) :: integer() | nil
+  defp integer_field(value) when is_integer(value), do: value
+
+  defp integer_field(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {parsed, ""} -> parsed
+      _ -> nil
+    end
+  end
+
+  defp integer_field(_value), do: nil
+
+  @spec do_upload_tts_audio(map()) :: map()
+  defp do_upload_tts_audio(%{"message" => base64_audio} = response) do
     {:ok, organization_id} = response["organization_id"] |> Glific.parse_maybe_integer()
 
     case upload_tts_audio(base64_audio, organization_id) do
@@ -606,8 +675,6 @@ defmodule Glific.Flows.Webhook do
         |> Map.put("reason", reason)
     end
   end
-
-  def maybe_upload_tts_audio(response), do: response
 
   @spec upload_tts_audio(String.t() | nil, non_neg_integer()) ::
           {:ok, String.t()} | {:error, String.t()}

--- a/lib/glific/flows/webhook.ex
+++ b/lib/glific/flows/webhook.ex
@@ -475,8 +475,28 @@ defmodule Glific.Flows.Webhook do
   @spec resume(non_neg_integer(), map(), map()) :: :ok
   def resume(organization_id, result, response) do
     with_validated_callback(organization_id, response, "Flow resume", fn contact ->
-      resume(organization_id, result, response, contact)
+      if still_awaiting?(response),
+        do: resume(organization_id, result, response, contact),
+        else: record_late_callback(result, response)
     end)
+  end
+
+  # The await window already closed, so there is no context to resume. Stop here rather than
+  # letting resume_contact_flow/4 fail with "no active flows awaiting results" and report a
+  # SystemError for an expected outcome. Skipping also avoids Dispatcher.callback/3, whose
+  # handle_callback/3 does the voice node's NMT + TTS post-processing.
+  @spec record_late_callback(map(), map()) :: :ok
+  defp record_late_callback(result, response) do
+    response = Map.put(response, "error_type", "flow_not_awaiting")
+
+    maybe_update_log(response["webhook_log_id"], callback_log_message(result, response))
+    Instrumentation.track_webhook_count(response["webhook_name"], "late_callback")
+
+    Logger.info(
+      "Late callback ignored, flow no longer awaiting a result: organization_id=#{response["organization_id"]}, webhook_log_id=#{response["webhook_log_id"]}"
+    )
+
+    :ok
   end
 
   # Restores tenant context, validates the callback signature and resolves the

--- a/lib/glific/flows/webhooks/kaapi.ex
+++ b/lib/glific/flows/webhooks/kaapi.ex
@@ -75,7 +75,9 @@ defmodule Glific.Flows.Webhooks.Kaapi do
       timestamp: timestamp,
       signature: signature,
       webhook_log_id: fields["webhook_log_id"],
-      result_name: fields["result_name"]
+      result_name: fields["result_name"],
+      context_id: fields["context_id"],
+      node_uuid: fields["node_uuid"]
     }
 
     {callback_url, request_metadata}

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -431,6 +431,51 @@ defmodule Glific.Flows.WebhookTest do
     end
   end
 
+  describe "Webhook.resume/3 when the flow already moved on" do
+    test "does not attempt a resume and records the late arrival on the log", attrs do
+      contact = Fixtures.contact_fixture(attrs)
+      flow = Fixtures.flow_fixture(Map.merge(attrs, %{keywords: [], name: Faker.Person.name()}))
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+
+      {:ok, timed_out} = Webhook.update_log(webhook_log, Webhook.timeout_error())
+
+      timestamp = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+      signature_payload = %{
+        "organization_id" => attrs.organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp
+      }
+
+      response = %{
+        "organization_id" => attrs.organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp,
+        "signature" =>
+          Glific.signature(
+            attrs.organization_id,
+            Jason.encode!(signature_payload),
+            timestamp
+          ),
+        "webhook_log_id" => timed_out.id,
+        "webhook_name" => "text_to_speech",
+        "message" => "a late answer"
+      }
+
+      assert :ok = Webhook.resume(attrs.organization_id, %{"success" => true}, response)
+
+      log = Repo.get!(WebhookLog, timed_out.id)
+      # the timeout stands, but the late arrival is still recorded
+      assert log.status_code == 400
+      assert log.error == Webhook.timeout_error()
+      assert log.response_json["message"] == "a late answer"
+      # the marker proves resume/4 was skipped -- it does not set error_type
+      assert log.response_json["error_type"] == "flow_not_awaiting"
+    end
+  end
+
   describe "Webhook.update_log/2 after the await window expired" do
     test "a late success callback records its response without relabelling the row", attrs do
       webhook_log = Fixtures.webhook_log_fixture(attrs)

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -431,6 +431,78 @@ defmodule Glific.Flows.WebhookTest do
     end
   end
 
+  describe "Webhook.maybe_upload_tts_audio/1 when another node is awaiting" do
+    setup attrs do
+      contact = Fixtures.contact_fixture(attrs)
+      flow = Fixtures.flow_fixture(Map.merge(attrs, %{keywords: [], name: Faker.Person.name()}))
+
+      {:ok, context} =
+        FlowContext.create_flow_context(%{
+          contact_id: contact.id,
+          flow_id: flow.id,
+          flow_uuid: flow.uuid,
+          uuid_map: %{},
+          organization_id: attrs.organization_id,
+          node_uuid: Ecto.UUID.generate(),
+          is_await_result: true
+        })
+
+      response = %{
+        "output_type" => "audio",
+        "message" => Base.encode64("fake audio bytes"),
+        "organization_id" => attrs.organization_id,
+        "contact_id" => contact.id,
+        "flow_id" => flow.id,
+        "context_id" => context.id,
+        "node_uuid" => context.node_uuid
+      }
+
+      %{contact: contact, flow: flow, context: context, response: response}
+    end
+
+    test "skips when the same context has since parked on a different node", ctx do
+      # the timed-out node took the Failure branch and the flow parked on a later async node --
+      # contact + flow still matches, so only the node_uuid distinguishes them
+      result =
+        Webhook.maybe_upload_tts_audio(%{ctx.response | "node_uuid" => Ecto.UUID.generate()})
+
+      assert result["success"] == false
+      assert result["error_type"] == "flow_not_awaiting"
+      assert is_nil(result["message"])
+    end
+
+    test "skips when the contact re-entered the flow and parked on the same node", ctx do
+      # a fresh run reaches the same node: node_uuid matches but it is a different execution,
+      # so only the context_id distinguishes them
+      result =
+        Webhook.maybe_upload_tts_audio(%{ctx.response | "context_id" => ctx.context.id + 1})
+
+      assert result["success"] == false
+      assert result["error_type"] == "flow_not_awaiting"
+    end
+
+    test "attempts the upload when both the context and the node match", ctx do
+      result = Webhook.maybe_upload_tts_audio(ctx.response)
+
+      refute result["error_type"] == "flow_not_awaiting"
+    end
+
+    test "falls back to contact and flow when the callback carries no node_uuid", ctx do
+      # callbacks dispatched before these fields were sent must keep resuming
+      response = Map.drop(ctx.response, ["context_id", "node_uuid"])
+
+      result = Webhook.maybe_upload_tts_audio(response)
+
+      refute result["error_type"] == "flow_not_awaiting"
+    end
+
+    test "falls back to contact and flow when the node_uuid is not a valid uuid", ctx do
+      result = Webhook.maybe_upload_tts_audio(%{ctx.response | "node_uuid" => "not-a-uuid"})
+
+      refute result["error_type"] == "flow_not_awaiting"
+    end
+  end
+
   describe "Webhook.resume/3 when the flow already moved on" do
     test "does not attempt a resume and records the late arrival on the log", attrs do
       contact = Fixtures.contact_fixture(attrs)
@@ -473,6 +545,65 @@ defmodule Glific.Flows.WebhookTest do
       assert log.response_json["message"] == "a late answer"
       # the marker proves resume/4 was skipped -- it does not set error_type
       assert log.response_json["error_type"] == "flow_not_awaiting"
+    end
+
+    test "does not resume a later node the same context has since parked on", attrs do
+      contact = Fixtures.contact_fixture(attrs)
+      flow = Fixtures.flow_fixture(Map.merge(attrs, %{keywords: [], name: Faker.Person.name()}))
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+
+      {:ok, timed_out} = Webhook.update_log(webhook_log, Webhook.timeout_error())
+
+      # the node that timed out took the Failure branch; the flow walked on and parked this same
+      # context on a later async node
+      {:ok, parked_on_later_node} =
+        FlowContext.create_flow_context(%{
+          contact_id: contact.id,
+          flow_id: flow.id,
+          flow_uuid: flow.uuid,
+          uuid_map: %{},
+          organization_id: attrs.organization_id,
+          node_uuid: Ecto.UUID.generate(),
+          is_await_result: true
+        })
+
+      timestamp = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+
+      signature_payload = %{
+        "organization_id" => attrs.organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp
+      }
+
+      response = %{
+        "organization_id" => attrs.organization_id,
+        "flow_id" => flow.id,
+        "contact_id" => contact.id,
+        "timestamp" => timestamp,
+        "signature" =>
+          Glific.signature(
+            attrs.organization_id,
+            Jason.encode!(signature_payload),
+            timestamp
+          ),
+        "webhook_log_id" => timed_out.id,
+        "webhook_name" => "text_to_speech",
+        "context_id" => parked_on_later_node.id,
+        "node_uuid" => Ecto.UUID.generate(),
+        "result_name" => "tts",
+        "message" => "a late answer"
+      }
+
+      assert :ok = Webhook.resume(attrs.organization_id, %{"success" => true}, response)
+
+      # the later node must be left untouched -- still parked, and with none of the stale
+      # result written into it
+      reloaded = Repo.get!(FlowContext, parked_on_later_node.id)
+      assert reloaded.is_await_result == true
+      assert is_nil(reloaded.completed_at)
+      assert reloaded.node_uuid == parked_on_later_node.node_uuid
+      assert reloaded.results == %{}
     end
   end
 
@@ -664,6 +795,41 @@ defmodule Glific.Flows.WebhookTest do
     jobs = all_enqueued(worker: Webhook, prefix: "global")
     # although we had 2 webhook calls, only 1 job got enqueued
     assert 1 == length(jobs)
+  end
+
+  test "the enqueued webhook job carries the dispatching node's identifiers", attrs do
+    Tesla.Mock.mock(fn %{method: :post} ->
+      %Tesla.Env{status: 200, body: Jason.encode!(@results)}
+    end)
+
+    node_uuid = Ecto.UUID.generate()
+
+    {:ok, context} =
+      FlowContext.create_flow_context(%{
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        contact_id: Fixtures.contact_fixture(attrs).id,
+        organization_id: attrs.organization_id,
+        node_uuid: node_uuid
+      })
+
+    context = Repo.preload(context, [:contact, :flow])
+
+    action = %Action{
+      headers: %{"Accept" => "application/json"},
+      method: "POST",
+      url: "some url",
+      body: Jason.encode!(@action_body)
+    }
+
+    assert Webhook.execute(action, context) == nil
+
+    [job] = all_enqueued(worker: Webhook, prefix: "global")
+
+    # an async callback is pinned to this node execution by these two -- without them the
+    # guard degrades to a flow-wide check and can resume the wrong node
+    assert job.args["node_uuid"] == node_uuid
+    assert job.args["context_id"] == context.id
   end
 
   test "execute a webhook where url is parse_via_gpt_vision, consecutive webhook calls should work",

--- a/test/glific/flows/webhook_test.exs
+++ b/test/glific/flows/webhook_test.exs
@@ -386,6 +386,90 @@ defmodule Glific.Flows.WebhookTest do
     end
   end
 
+  describe "Webhook.maybe_upload_tts_audio/1 when the flow already moved on" do
+    setup attrs do
+      contact = Fixtures.contact_fixture(attrs)
+      flow = Fixtures.flow_fixture(Map.merge(attrs, %{keywords: [], name: Faker.Person.name()}))
+
+      response = %{
+        "output_type" => "audio",
+        "message" => Base.encode64("fake audio bytes"),
+        "organization_id" => attrs.organization_id,
+        "contact_id" => contact.id,
+        "flow_id" => flow.id
+      }
+
+      %{contact: contact, flow: flow, response: response}
+    end
+
+    test "skips the upload when no context is awaiting a result", %{response: response} do
+      result = Webhook.maybe_upload_tts_audio(response)
+
+      assert result["success"] == false
+      assert result["error_type"] == "flow_not_awaiting"
+      # the base64 must not survive: callback_log_message/2 copies "message" into the webhook
+      # log's response_json, so leaving it would write the whole payload into the row
+      assert is_nil(result["message"])
+    end
+
+    test "attempts the upload when a context is awaiting a result", ctx do
+      {:ok, _context} =
+        FlowContext.create_flow_context(%{
+          contact_id: ctx.contact.id,
+          flow_id: ctx.flow.id,
+          flow_uuid: ctx.flow.uuid,
+          uuid_map: %{},
+          organization_id: ctx.response["organization_id"],
+          is_await_result: true
+        })
+
+      result = Webhook.maybe_upload_tts_audio(ctx.response)
+
+      # GCS is not configured under test, so the upload is reached and fails on its own terms --
+      # which is the point: it was attempted rather than skipped
+      refute result["error_type"] == "flow_not_awaiting"
+    end
+  end
+
+  describe "Webhook.update_log/2 after the await window expired" do
+    test "a late success callback records its response without relabelling the row", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+
+      assert {:ok, timed_out} = Webhook.update_log(webhook_log, Webhook.timeout_error())
+      assert timed_out.status_code == 400
+      assert timed_out.error == Webhook.timeout_error()
+
+      late = %{success: true, message: "https://storage.googleapis.com/bucket/audio.mp3"}
+      assert {:ok, log} = Webhook.update_log(timed_out, late)
+
+      # the flow already routed to Failure, so the outcome must not flip to 200/Success
+      assert log.status_code == 400
+      assert log.error == Webhook.timeout_error()
+      assert log.response_json == late
+    end
+
+    test "a late failure callback also leaves the recorded timeout intact", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      {:ok, timed_out} = Webhook.update_log(webhook_log, Webhook.timeout_error())
+
+      late = %{success: false, reason: "Kaapi TTS failed"}
+      assert {:ok, log} = Webhook.update_log(timed_out, late)
+
+      assert log.status_code == 400
+      assert log.error == Webhook.timeout_error()
+      assert log.response_json == late
+    end
+
+    test "an ordinary success is still recorded as 200 when no timeout was written", attrs do
+      webhook_log = Fixtures.webhook_log_fixture(attrs)
+      result = %{success: true, message: "ok"}
+
+      assert {:ok, log} = Webhook.update_log(webhook_log, result)
+      assert log.status_code == 200
+      assert log.error == nil
+    end
+  end
+
   describe "Webhook.update_log/2 failure handling" do
     test "records %{success: false, reason: _} as status 400 with the reason as error", attrs do
       webhook_log = Fixtures.webhook_log_fixture(attrs)

--- a/test/glific/flows/webhooks/kaapi_test.exs
+++ b/test/glific/flows/webhooks/kaapi_test.exs
@@ -1,5 +1,5 @@
 defmodule Glific.Flows.Webhooks.KaapiTest do
-  use ExUnit.Case, async: true
+  use Glific.DataCase, async: true
 
   alias Glific.Flows.Webhooks.ErrorType
   alias Glific.Flows.Webhooks.Kaapi, as: KaapiSupport
@@ -111,6 +111,26 @@ defmodule Glific.Flows.Webhooks.KaapiTest do
       assert KaapiSupport.from_http_status("File download failed") == :unknown
       assert KaapiSupport.from_http_status(%{"error" => "boom"}) == :unknown
       assert KaapiSupport.from_http_status(nil) == :unknown
+    end
+  end
+
+  describe "build_flow_resume_metadata/4" do
+    test "carries the dispatching node's identifiers through to Kaapi" do
+      node_uuid = Ecto.UUID.generate()
+
+      fields = %{
+        "webhook_log_id" => 7,
+        "result_name" => "tts",
+        "context_id" => 42,
+        "node_uuid" => node_uuid
+      }
+
+      {_callback_url, metadata} = KaapiSupport.build_flow_resume_metadata(1, 2, 3, fields)
+
+      # Kaapi echoes this map back on the callback; without these two the late-callback guard
+      # falls back to a flow-wide check and can resume the wrong node
+      assert metadata.context_id == 42
+      assert metadata.node_uuid == node_uuid
     end
   end
 end

--- a/test/glific_web/flows/flow_resume_controller_test.exs
+++ b/test/glific_web/flows/flow_resume_controller_test.exs
@@ -912,6 +912,20 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
         "reason" => "TTS audio upload failed (GCS may not be enabled for this organization)"
       }
 
+      [node | _tail] = flow.nodes
+
+      {:ok, _context} =
+        FlowContext.create_flow_context(%{
+          contact_id: contact.id,
+          flow_id: flow.id,
+          flow_uuid: flow.uuid,
+          uuid_map: %{},
+          organization_id: organization_id,
+          wakeup_at: DateTime.add(DateTime.utc_now(), 60),
+          is_await_result: true,
+          node_uuid: node.uuid
+        })
+
       with_mock FlowContext, [:passthrough],
         resume_contact_flow: fn _contact, _flow_id, _results, message ->
           send(self(), {:resume_message, message})
@@ -1021,6 +1035,20 @@ defmodule GlificWeb.Flows.FlowResumeControllerTest do
 
       {exception, tags} =
         capture_appsignal(fn ->
+          [node | _tail] = flow.nodes
+
+          {:ok, _context} =
+            FlowContext.create_flow_context(%{
+              contact_id: contact.id,
+              flow_id: flow.id,
+              flow_uuid: flow.uuid,
+              uuid_map: %{},
+              organization_id: organization_id,
+              wakeup_at: DateTime.add(DateTime.utc_now(), 60),
+              is_await_result: true,
+              node_uuid: node.uuid
+            })
+
           with_mock FlowContext, [:passthrough],
             resume_contact_flow: fn _contact, _flow_id, _results, _message ->
               {:error, "flow context not found"}


### PR DESCRIPTION
## Summary

Target issue is #5623

When an async webhook node's await window expires, two writers touch the same `webhook_logs` row and the second partially undoes the first.

**At 60s** `FlowContext.handle_nil_message/2` records the timeout and the contact takes the Failure branch — `error: "Timeout: taking long to process response"`, `status_code: 400`.

**If the callback then arrives**, it validates, uploads the TTS audio to GCS, and writes `%{success: true, ...}`, which lands in:

```elixir
def update_log(webhook_log, result) when is_map(result) do
  attrs = %{response_json: result, status_code: 200}
```

That flips `status_code` back to 200 and never clears `error`. The row ends up showing Success / 200 / a valid GCS URL / and a stale timeout message — four things that are individually true but describe two separate events.

Two consequences: `webhook_logs` **undercount timeouts**, because anything that eventually called back reads as a clean success; and the row misleads whoever is debugging.

## What changed

**1. Freeze the outcome once a timeout is recorded.** `update_outcome/2` keeps `status_code` and `error` as written by the timeout, while still storing the late `response_json` so the callback's arrival stays visible.

**2. Skip the work the late callback would otherwise do.** `maybe_upload_tts_audio/1` now checks `FlowContext.awaiting_result?/2` before uploading — the same condition `await_context/2` already uses (`is_await_result == true` and no `completed_at`). If nothing is waiting, the multi-megabyte GCS round trip is skipped entirely.

The base64 has to be dropped along with it: `callback_log_message/2` copies `"message"` into `response_json`, and today the upload is what replaces it with the GCS URL. Skipping without clearing it would write the whole payload into the row.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. — n/a
- [x] Coding standard and conventions are followed.

## Notes

Both guards were verified to fail without the fix: `left: 200, right: 400` for the relabelling, and `left: "tts_upload_failed"` for the upload — the latter confirming GCS really was being reached. Tests use no mocks, so `webhook_test.exs` stays `async: true`.

Two judgement calls worth a look:

- `still_awaiting?/1` **fails open** when `contact_id`/`flow_id` can't be read as integers. We can't run the lookup, so it falls through to the upload — the behaviour that existed before this check. Skipping instead could drop audio a flow is genuinely waiting on.
- The `%{success: false}` path is guarded too, not just the success one. Without it, a late *failure* callback would overwrite `"Timeout..."` with its own reason and hide that the flow had already given up. The rule applied is: once the window expires the outcome is decided, and nothing later changes it.

The check is best-effort — a context can expire between the check and the resume, so an upload is occasionally still wasted. Closing that fully would need locking, which isn't worth it here.

**Sequencing:** #5624 should merge first. It moves the TTS upload into the supervised task behind signature validation, which puts this `awaiting_result?` check after validation rather than before. They touch different regions of `webhook.ex`, so a conflict is unlikely.
