### PR TITLE
feat(assistants): add GraphQL subscriptions for config/knowledge-base version status

### DIFF
--- a/assets/gql/assistants/subscribe.gql
+++ b/assets/gql/assistants/subscribe.gql
@@ -1,0 +1,26 @@
+subscription assistantConfigVersionUpdated {
+  assistantConfigVersionUpdated {
+    id
+    versionNumber
+    model
+    prompt
+    settings
+    status
+    isLive
+    description
+    insertedAt
+    updatedAt
+  }
+}
+
+subscription knowledgeBaseVersionUpdated {
+  knowledgeBaseVersionUpdated {
+    id
+    knowledgeBaseId
+    versionNumber
+    status
+    size
+    insertedAt
+    updatedAt
+  }
+}

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -347,10 +347,54 @@ defmodule Glific.Assistants do
   @spec update_knowledge_base_version(KnowledgeBaseVersion.t(), map()) ::
           {:ok, KnowledgeBaseVersion.t()} | {:error, Ecto.Changeset.t()}
   def update_knowledge_base_version(knowledge_base_version, params) do
-    knowledge_base_version
-    |> KnowledgeBaseVersion.changeset(params)
-    |> Repo.update()
+    with {:ok, updated_knowledge_base_version} <-
+           knowledge_base_version
+           |> KnowledgeBaseVersion.changeset(params)
+           |> Repo.update() do
+      publish_knowledge_base_version_update(updated_knowledge_base_version)
+      {:ok, updated_knowledge_base_version}
+    end
   end
+
+  @spec publish_knowledge_base_version_update(KnowledgeBaseVersion.t()) :: :ok
+  defp publish_knowledge_base_version_update(%{status: status} = knowledge_base_version)
+       when status in [:completed, :failed] do
+    Absinthe.Subscription.publish(
+      GlificWeb.Endpoint,
+      knowledge_base_version,
+      [{:knowledge_base_version_updated, "#{knowledge_base_version.organization_id}"}]
+    )
+
+    :ok
+  end
+
+  defp publish_knowledge_base_version_update(_knowledge_base_version), do: :ok
+
+  @spec update_config_version_status(AssistantConfigVersion.t(), map()) ::
+          {:ok, AssistantConfigVersion.t()} | {:error, Ecto.Changeset.t()}
+  defp update_config_version_status(config_version, attrs) do
+    with {:ok, updated_config_version} <-
+           config_version
+           |> AssistantConfigVersion.changeset(attrs)
+           |> Repo.update() do
+      publish_config_version_update(updated_config_version)
+      {:ok, updated_config_version}
+    end
+  end
+
+  @spec publish_config_version_update(AssistantConfigVersion.t()) :: :ok
+  defp publish_config_version_update(%{status: status} = config_version)
+       when status in [:ready, :failed] do
+    Absinthe.Subscription.publish(
+      GlificWeb.Endpoint,
+      config_version,
+      [{:assistant_config_version_updated, "#{config_version.organization_id}"}]
+    )
+
+    :ok
+  end
+
+  defp publish_config_version_update(_config_version), do: :ok
 
   @doc """
   Creates an Assistant
@@ -384,12 +428,10 @@ defmodule Glific.Assistants do
         kaapi_version_number = kaapi_response.data.version.version
 
         {:ok, updated_config_version} =
-          config_version
-          |> AssistantConfigVersion.changeset(%{
+          update_config_version_status(config_version, %{
             status: :ready,
             kaapi_version_number: kaapi_version_number
           })
-          |> Repo.update()
 
         {:ok, updated_assistant} =
           assistant
@@ -399,9 +441,7 @@ defmodule Glific.Assistants do
         {:ok, %{assistant: updated_assistant, config_version: updated_config_version}}
 
       {:error, error} ->
-        config_version
-        |> AssistantConfigVersion.changeset(%{status: :failed})
-        |> Repo.update()
+        update_config_version_status(config_version, %{status: :failed})
 
         Glific.log_exception(%Error{
           message:
@@ -659,12 +699,10 @@ defmodule Glific.Assistants do
       {:ok, kaapi_response} ->
         kaapi_version_number = kaapi_response.data.version
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :ready,
           kaapi_version_number: kaapi_version_number
         })
-        |> Repo.update()
 
         {:ok, kaapi_response.data.id}
 
@@ -673,13 +711,11 @@ defmodule Glific.Assistants do
           "Kaapi config version creation failed for assistant #{assistant.id}: #{Glific.SafeLog.safe_inspect(reason)}"
         )
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :failed,
           failure_reason:
             "Kaapi config version creation failed: #{Glific.SafeLog.safe_inspect(reason)}"
         })
-        |> Repo.update()
 
         {:error, reason}
     end
@@ -1251,12 +1287,10 @@ defmodule Glific.Assistants do
 
     case knowledge_base_version.assistant_config_versions do
       [config_version] ->
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :failed,
           failure_reason: failure_reason
         })
-        |> Repo.update()
 
         send_kb_notification(
           knowledge_base_version,
@@ -1324,25 +1358,21 @@ defmodule Glific.Assistants do
         |> Assistant.changeset(%{kaapi_uuid: kaapi_response.data.id})
         |> Repo.update()
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :ready,
           kaapi_version_number: kaapi_version_number
         })
-        |> Repo.update()
 
       {:error, reason} ->
         Logger.error(
           "Deferred Kaapi config creation failed for assistant #{assistant.id}: #{Glific.SafeLog.safe_inspect(reason)}"
         )
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :failed,
           failure_reason:
             "Deferred Kaapi config creation failed: #{Glific.SafeLog.safe_inspect(reason)}"
         })
-        |> Repo.update()
 
         {:error, "Deferred Kaapi config creation failed: #{Glific.SafeLog.safe_inspect(reason)}"}
     end
@@ -1359,25 +1389,21 @@ defmodule Glific.Assistants do
       {:ok, kaapi_response} ->
         kaapi_version_number = kaapi_response.data.version
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :ready,
           kaapi_version_number: kaapi_version_number
         })
-        |> Repo.update()
 
       {:error, reason} ->
         Logger.error(
           "Deferred Kaapi config version creation failed for assistant #{assistant.id}: #{Glific.SafeLog.safe_inspect(reason)}"
         )
 
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :failed,
           failure_reason:
             "Deferred Kaapi config creation failed: #{Glific.SafeLog.safe_inspect(reason)}"
         })
-        |> Repo.update()
 
         {:error, "Deferred Kaapi config creation failed: #{Glific.SafeLog.safe_inspect(reason)}"}
     end
@@ -1499,10 +1525,7 @@ defmodule Glific.Assistants do
       "Marking KnowledgeBaseVersion #{knowledge_base_version.id} as failed due to timeout"
     )
 
-    {:ok, _updated} =
-      knowledge_base_version
-      |> KnowledgeBaseVersion.changeset(%{status: :failed})
-      |> Repo.update()
+    {:ok, _updated} = update_knowledge_base_version(knowledge_base_version, %{status: :failed})
 
     affected_config_versions =
       knowledge_base_version.assistant_config_versions
@@ -1520,12 +1543,10 @@ defmodule Glific.Assistants do
   defp update_linked_config_versions(config_versions) do
     Enum.map(config_versions, fn config_version ->
       {:ok, updated} =
-        config_version
-        |> AssistantConfigVersion.changeset(%{
+        update_config_version_status(config_version, %{
           status: :failed,
           failure_reason: "Linked vector store creation timed out"
         })
-        |> Repo.update()
 
       updated.id
     end)

--- a/lib/glific_web/schema.ex
+++ b/lib/glific_web/schema.ex
@@ -251,6 +251,8 @@ defmodule GlificWeb.Schema do
     import_fields(:assistant_chat_subscriptions)
 
     import_fields(:ai_evaluation_subscriptions)
+
+    import_fields(:assistant_subscriptions)
   end
 
   @doc """

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -168,6 +168,16 @@ defmodule GlificWeb.Schema.AssistantTypes do
     field(:name_or_assistant_id, :string)
   end
 
+  object :knowledge_base_version_update do
+    field :id, :id
+    field :knowledge_base_id, :id
+    field :version_number, :integer
+    field :status, :string
+    field :size, :integer
+    field :inserted_at, :datetime
+    field :updated_at, :datetime
+  end
+
   object :assistant_config_version_for_evals do
     field :id, :id
     field :assistant_id, :id
@@ -284,6 +294,30 @@ defmodule GlificWeb.Schema.AssistantTypes do
       arg(:file_id, non_null(:string))
       middleware(Authorize, :manager)
       resolve(&Resolvers.Assistants.get_file/3)
+    end
+  end
+
+  object :assistant_subscriptions do
+    @desc "Delivers an assistant config version's status as it changes (e.g. once Kaapi's sync completes)."
+    field :assistant_config_version_updated, :assistant_config_version do
+      middleware(Authorize, :staff)
+
+      config(fn _args, %{context: %{current_user: user}} ->
+        {:ok, topic: "#{user.organization_id}"}
+      end)
+
+      resolve(fn config_version, _args, _resolution -> {:ok, config_version} end)
+    end
+
+    @desc "Delivers a knowledge base version's status as it changes (e.g. once Kaapi's indexing callback arrives)."
+    field :knowledge_base_version_updated, :knowledge_base_version_update do
+      middleware(Authorize, :staff)
+
+      config(fn _args, %{context: %{current_user: user}} ->
+        {:ok, topic: "#{user.organization_id}"}
+      end)
+
+      resolve(fn knowledge_base_version, _args, _resolution -> {:ok, knowledge_base_version} end)
     end
   end
 end

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -1,6 +1,5 @@
 defmodule Glific.AssistantsTest do
   use Glific.DataCase
-  import Mock
   import Tesla.Mock
 
   import Ecto.Query
@@ -187,68 +186,6 @@ defmodule Glific.AssistantsTest do
       assert updated.size == kbv.size
       assert updated.knowledge_base_id == kbv.knowledge_base_id
       assert updated.organization_id == kbv.organization_id
-    end
-
-    test "publishes knowledge_base_version_updated when status becomes completed", %{
-      knowledge_base_version: kbv,
-      organization_id: organization_id
-    } do
-      test_pid = self()
-
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert {:ok, updated} =
-                 Assistants.update_knowledge_base_version(kbv, %{status: :completed})
-
-        assert_receive {:published, payload, [{:knowledge_base_version_updated, topic}]}, 1000
-        assert payload.id == updated.id
-        assert payload.status == :completed
-        assert topic == "#{organization_id}"
-      end
-    end
-
-    test "publishes knowledge_base_version_updated when status becomes failed", %{
-      knowledge_base_version: kbv,
-      organization_id: organization_id
-    } do
-      test_pid = self()
-
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert {:ok, updated} = Assistants.update_knowledge_base_version(kbv, %{status: :failed})
-
-        assert_receive {:published, payload, [{:knowledge_base_version_updated, topic}]}, 1000
-        assert payload.id == updated.id
-        assert payload.status == :failed
-        assert topic == "#{organization_id}"
-      end
-    end
-
-    test "does not publish when status stays in_progress or is untouched", %{
-      knowledge_base_version: kbv
-    } do
-      with_mocks([
-        {Absinthe.Subscription, [], [publish: fn _endpoint, _payload, _opts -> :ok end]}
-      ]) do
-        Assistants.update_knowledge_base_version(kbv, %{status: :in_progress, size: 300})
-        Assistants.update_knowledge_base_version(kbv, %{kaapi_job_id: "job_xyz"})
-
-        refute called(Absinthe.Subscription.publish(:_, :_, :_))
-      end
     end
   end
 
@@ -1328,7 +1265,7 @@ defmodule Glific.AssistantsTest do
       assert length(config_version.knowledge_base_versions) == 1
     end
 
-    test "creates assistant with in-progress KB and sets config status to in_progress, without publishing",
+    test "creates assistant with in-progress KB and sets config status to in_progress",
          %{organization_id: organization_id} do
       {:ok, kb} =
         Assistants.create_knowledge_base(%{
@@ -1346,26 +1283,21 @@ defmodule Glific.AssistantsTest do
           size: 500
         })
 
-      with_mocks([
-        {Absinthe.Subscription, [], [publish: fn _endpoint, _payload, _opts -> :ok end]}
-      ]) do
-        assert {:ok, %{assistant: assistant, config_version: config_version}} =
-                 Assistants.create_assistant(%{
-                   name: "Deferred Assistant",
-                   model: "gpt-4o",
-                   instructions: "You are a helpful assistant",
-                   temperature: 1.0,
-                   knowledge_base_version_id: kbv.id,
-                   organization_id: organization_id
-                 })
+      assert {:ok, %{assistant: assistant, config_version: config_version}} =
+               Assistants.create_assistant(%{
+                 name: "Deferred Assistant",
+                 model: "gpt-4o",
+                 instructions: "You are a helpful assistant",
+                 temperature: 1.0,
+                 knowledge_base_version_id: kbv.id,
+                 organization_id: organization_id
+               })
 
-        assert is_nil(assistant.kaapi_uuid)
-        assert config_version.status == :in_progress
-        refute called(Absinthe.Subscription.publish(:_, :_, :_))
-      end
+      assert is_nil(assistant.kaapi_uuid)
+      assert config_version.status == :in_progress
     end
 
-    test "creates assistant without knowledge_base_version_id and publishes assistant_config_version_updated",
+    test "creates assistant without knowledge_base_version_id",
          %{organization_id: organization_id} do
       enable_kaapi(%{organization_id: organization_id})
 
@@ -1377,63 +1309,14 @@ defmodule Glific.AssistantsTest do
           }
       end)
 
-      test_pid = self()
+      assert {:ok, %{assistant: assistant, config_version: config_version}} =
+               Assistants.create_assistant(%{
+                 name: "No KB Assistant",
+                 organization_id: organization_id
+               })
 
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert {:ok, %{assistant: assistant, config_version: config_version}} =
-                 Assistants.create_assistant(%{
-                   name: "No KB Assistant",
-                   organization_id: organization_id
-                 })
-
-        assert assistant.name == "No KB Assistant"
-        assert config_version.status == :ready
-
-        assert_receive {:published, payload, [{:assistant_config_version_updated, topic}]}, 1000
-        assert payload.id == config_version.id
-        assert payload.status == :ready
-        assert topic == "#{organization_id}"
-      end
-    end
-
-    test "publishes assistant_config_version_updated as failed when Kaapi config creation fails",
-         %{organization_id: organization_id} do
-      enable_kaapi(%{organization_id: organization_id})
-
-      Tesla.Mock.mock(fn
-        %{method: :post} ->
-          %Tesla.Env{status: 500, body: %{error: "kaapi unavailable"}}
-      end)
-
-      test_pid = self()
-
-      with_mocks([
-        {Absinthe.Subscription, [],
-         [
-           publish: fn _endpoint, payload, opts ->
-             send(test_pid, {:published, payload, opts})
-             :ok
-           end
-         ]}
-      ]) do
-        assert {:error, _reason} =
-                 Assistants.create_assistant(%{
-                   name: "Failing Assistant",
-                   organization_id: organization_id
-                 })
-
-        assert_receive {:published, payload, [{:assistant_config_version_updated, topic}]}, 1000
-        assert payload.status == :failed
-        assert topic == "#{organization_id}"
-      end
+      assert assistant.name == "No KB Assistant"
+      assert config_version.status == :ready
     end
 
     test "uses default values when optional params are missing",

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -1,5 +1,6 @@
 defmodule Glific.AssistantsTest do
   use Glific.DataCase
+  import Mock
   import Tesla.Mock
 
   import Ecto.Query
@@ -186,6 +187,68 @@ defmodule Glific.AssistantsTest do
       assert updated.size == kbv.size
       assert updated.knowledge_base_id == kbv.knowledge_base_id
       assert updated.organization_id == kbv.organization_id
+    end
+
+    test "publishes knowledge_base_version_updated when status becomes completed", %{
+      knowledge_base_version: kbv,
+      organization_id: organization_id
+    } do
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, updated} =
+                 Assistants.update_knowledge_base_version(kbv, %{status: :completed})
+
+        assert_receive {:published, payload, [{:knowledge_base_version_updated, topic}]}, 1000
+        assert payload.id == updated.id
+        assert payload.status == :completed
+        assert topic == "#{organization_id}"
+      end
+    end
+
+    test "publishes knowledge_base_version_updated when status becomes failed", %{
+      knowledge_base_version: kbv,
+      organization_id: organization_id
+    } do
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, updated} = Assistants.update_knowledge_base_version(kbv, %{status: :failed})
+
+        assert_receive {:published, payload, [{:knowledge_base_version_updated, topic}]}, 1000
+        assert payload.id == updated.id
+        assert payload.status == :failed
+        assert topic == "#{organization_id}"
+      end
+    end
+
+    test "does not publish when status stays in_progress or is untouched", %{
+      knowledge_base_version: kbv
+    } do
+      with_mocks([
+        {Absinthe.Subscription, [], [publish: fn _endpoint, _payload, _opts -> :ok end]}
+      ]) do
+        Assistants.update_knowledge_base_version(kbv, %{status: :in_progress, size: 300})
+        Assistants.update_knowledge_base_version(kbv, %{kaapi_job_id: "job_xyz"})
+
+        refute called(Absinthe.Subscription.publish(:_, :_, :_))
+      end
     end
   end
 
@@ -1265,7 +1328,7 @@ defmodule Glific.AssistantsTest do
       assert length(config_version.knowledge_base_versions) == 1
     end
 
-    test "creates assistant with in-progress KB and sets config status to in_progress",
+    test "creates assistant with in-progress KB and sets config status to in_progress, without publishing",
          %{organization_id: organization_id} do
       {:ok, kb} =
         Assistants.create_knowledge_base(%{
@@ -1283,21 +1346,26 @@ defmodule Glific.AssistantsTest do
           size: 500
         })
 
-      assert {:ok, %{assistant: assistant, config_version: config_version}} =
-               Assistants.create_assistant(%{
-                 name: "Deferred Assistant",
-                 model: "gpt-4o",
-                 instructions: "You are a helpful assistant",
-                 temperature: 1.0,
-                 knowledge_base_version_id: kbv.id,
-                 organization_id: organization_id
-               })
+      with_mocks([
+        {Absinthe.Subscription, [], [publish: fn _endpoint, _payload, _opts -> :ok end]}
+      ]) do
+        assert {:ok, %{assistant: assistant, config_version: config_version}} =
+                 Assistants.create_assistant(%{
+                   name: "Deferred Assistant",
+                   model: "gpt-4o",
+                   instructions: "You are a helpful assistant",
+                   temperature: 1.0,
+                   knowledge_base_version_id: kbv.id,
+                   organization_id: organization_id
+                 })
 
-      assert is_nil(assistant.kaapi_uuid)
-      assert config_version.status == :in_progress
+        assert is_nil(assistant.kaapi_uuid)
+        assert config_version.status == :in_progress
+        refute called(Absinthe.Subscription.publish(:_, :_, :_))
+      end
     end
 
-    test "creates assistant without knowledge_base_version_id",
+    test "creates assistant without knowledge_base_version_id and publishes assistant_config_version_updated",
          %{organization_id: organization_id} do
       enable_kaapi(%{organization_id: organization_id})
 
@@ -1309,14 +1377,63 @@ defmodule Glific.AssistantsTest do
           }
       end)
 
-      assert {:ok, %{assistant: assistant, config_version: config_version}} =
-               Assistants.create_assistant(%{
-                 name: "No KB Assistant",
-                 organization_id: organization_id
-               })
+      test_pid = self()
 
-      assert assistant.name == "No KB Assistant"
-      assert config_version.status == :ready
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:ok, %{assistant: assistant, config_version: config_version}} =
+                 Assistants.create_assistant(%{
+                   name: "No KB Assistant",
+                   organization_id: organization_id
+                 })
+
+        assert assistant.name == "No KB Assistant"
+        assert config_version.status == :ready
+
+        assert_receive {:published, payload, [{:assistant_config_version_updated, topic}]}, 1000
+        assert payload.id == config_version.id
+        assert payload.status == :ready
+        assert topic == "#{organization_id}"
+      end
+    end
+
+    test "publishes assistant_config_version_updated as failed when Kaapi config creation fails",
+         %{organization_id: organization_id} do
+      enable_kaapi(%{organization_id: organization_id})
+
+      Tesla.Mock.mock(fn
+        %{method: :post} ->
+          %Tesla.Env{status: 500, body: %{error: "kaapi unavailable"}}
+      end)
+
+      test_pid = self()
+
+      with_mocks([
+        {Absinthe.Subscription, [],
+         [
+           publish: fn _endpoint, payload, opts ->
+             send(test_pid, {:published, payload, opts})
+             :ok
+           end
+         ]}
+      ]) do
+        assert {:error, _reason} =
+                 Assistants.create_assistant(%{
+                   name: "Failing Assistant",
+                   organization_id: organization_id
+                 })
+
+        assert_receive {:published, payload, [{:assistant_config_version_updated, topic}]}, 1000
+        assert payload.status == :failed
+        assert topic == "#{organization_id}"
+      end
     end
 
     test "uses default values when optional params are missing",


### PR DESCRIPTION
## Summary
Target issue is #5631

Assistant config-version creation (Kaapi sync) and knowledge-base indexing are both async: the client currently has to poll the assistant/config-version list to notice a config version land on `ready`/`failed` or a knowledge-base version land on `completed`/`failed`.

Adds `assistant_config_version_updated` and `knowledge_base_version_updated` GraphQL subscriptions so both status changes reach the client as soon as they happen, mirroring the `ai_evaluation_updated` subscription added in #5567.

- New `assistant_subscriptions` object (`assistant_types.ex`, imported in `schema.ex`) with both fields, topic-scoped by `organization_id`, gated behind `Authorize, :staff`, each with an explicit `resolve/3` returning the published payload.
- `AssistantConfigVersion` status writes were scattered across ~8 direct `changeset |> Repo.update()` call sites in `assistants.ex`. These now all route through a new `update_config_version_status/2`, which publishes only when the resulting status is `:ready` or `:failed`.
- `update_knowledge_base_version/2` now publishes the same way for `:completed`/`:failed`. `mark_as_failed/1` (the timeout cron path) previously bypassed it with a raw changeset update — it now goes through `update_knowledge_base_version/2` too, so there isn't a second, unpublished status-write path.
- Added `assets/gql/assistants/subscribe.gql`.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] Added/updated tests (`test/glific/assistants_test.exs`) covering both publish and non-publish paths for each entity.
- [ ] Postman request (n/a — subscription, not REST).
- [x] Coding standard and conventions followed.

## Notes
No frontend consumer yet — this is backend subscription plumbing only, same posture as #5567 and #5602.
