### PR TITLE
Bump version from 8.10.2 to 8.10.3

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Glific.MixProject do
   def project do
     [
       app: :glific,
-      version: "8.10.2",
+      version: "8.10.3",
       elixir: "~> 1.18.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [


### PR DESCRIPTION
Version bump 8.10.2 -> 8.10.3, opened by bin/gigalixir-release.sh.