### PR TITLE
Let webhook nodes set their own await window, capped at 5 minutes

### DIFF
--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -576,7 +576,7 @@ defmodule Glific.Flows.Action do
       when is_integer(wait_time) and wait_time > @max_webhook_wait_time do
     [
       {Webhook,
-       "A webhook can wait at most #{div(@max_webhook_wait_time, 60)} minutes; this node will wait that long instead.",
+       "You've configured a wait_time of #{wait_time} seconds which exceeds the allowed wait time of #{@max_webhook_wait_time} seconds. We will use the allowed wait time only.",
        "Warning"}
       | errors
     ]

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -82,6 +82,11 @@ defmodule Glific.Flows.Action do
     "nmt_tts_with_bhasini" => "text_to_speech"
   }
 
+  # Upper bound on how long an async webhook node may park the flow. A parked contact sits in
+  # silence until the callback arrives or the window expires, so authors cannot push this past
+  # 5 minutes however long their webhook takes.
+  @max_webhook_wait_time 5 * 60
+
   # They fall under actions, thus not using "wait for response" with them, as that is a router.
   @wait_for ["wait_for_time", "wait_for_result"]
   @template_type ["send_msg", "send_broadcast"]
@@ -116,8 +121,8 @@ defmodule Glific.Flows.Action do
           node_uuid: Ecto.UUID.t() | nil,
           node: Node.t() | nil,
           templating: Templating.t() | nil,
-          ## this is a custom delay in minutes for wait for time nodes.
-          ## Currently we use this only for the wait for time node.
+          ## seconds to wait at this node: how long a wait for time/result node parks the
+          ## flow, or how long an async webhook node awaits its callback.
           wait_time: integer() | nil,
 
           # Google sheet node specific fields
@@ -343,7 +348,8 @@ defmodule Glific.Flows.Action do
       method: json["method"],
       result_name: json["result_name"],
       body: json["body"],
-      headers: json["headers"]
+      headers: json["headers"],
+      wait_time: webhook_wait_time(json["wait_time"])
     })
   end
 
@@ -566,6 +572,16 @@ defmodule Glific.Flows.Action do
     ]
   end
 
+  def validate(%{type: "call_webhook", wait_time: wait_time}, errors, _flow)
+      when is_integer(wait_time) and wait_time > @max_webhook_wait_time do
+    [
+      {Webhook,
+       "A webhook can wait at most #{div(@max_webhook_wait_time, 60)} minutes; this node will wait that long instead.",
+       "Warning"}
+      | errors
+    ]
+  end
+
   # default validate, do nothing
   def validate(_action, errors, _flow), do: errors
 
@@ -662,6 +678,14 @@ defmodule Glific.Flows.Action do
   rescue
     # in case any of the uuids don't exist, we just trap the exception
     _ -> :unknown
+  end
+
+  @spec webhook_wait_time(String.t() | integer() | nil) :: non_neg_integer() | nil
+  defp webhook_wait_time(value) do
+    case Glific.parse_maybe_integer(value) do
+      {:ok, seconds} when is_integer(seconds) and seconds > 0 -> seconds
+      _ -> nil
+    end
   end
 
   ## Label formatter so that we can apply the dynamic label to the message
@@ -1081,9 +1105,11 @@ defmodule Glific.Flows.Action do
 
   @spec do_park(Action.t(), FlowContext.t(), non_neg_integer()) :: FlowContext.t()
   defp do_park(action, context, default_wait_time) do
+    wait_time = min(action.wait_time || default_wait_time, @max_webhook_wait_time)
+
     {:ok, context} =
       FlowContext.update_flow_context(context, %{
-        wakeup_at: DateTime.add(DateTime.utc_now(), action.wait_time || default_wait_time),
+        wakeup_at: DateTime.add(DateTime.utc_now(), wait_time),
         is_background_flow: context.flow.is_background,
         is_await_result: true
       })

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -349,7 +349,7 @@ defmodule Glific.Flows.Action do
       result_name: json["result_name"],
       body: json["body"],
       headers: json["headers"],
-      wait_time: webhook_wait_time(json["wait_time"])
+      wait_time: webhook_wait_time(json["body"])
     })
   end
 
@@ -680,13 +680,31 @@ defmodule Glific.Flows.Action do
     _ -> :unknown
   end
 
-  @spec webhook_wait_time(String.t() | integer() | nil) :: non_neg_integer() | nil
-  defp webhook_wait_time(value) do
-    case Glific.parse_maybe_integer(value) do
-      {:ok, seconds} when is_integer(seconds) and seconds > 0 -> seconds
+  ## The await window rides in the webhook body the author already edits, so no flow-editor
+  ## change is needed to expose it. Every webhook implementation allowlists the fields it
+  ## forwards, so this key never reaches Kaapi. Read at compile time, hence literals only --
+  ## an expression here would not have been substituted yet.
+  @spec webhook_wait_time(String.t() | nil) :: non_neg_integer() | nil
+  defp webhook_wait_time(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, %{"wait_time" => value}} -> parse_wait_time(value)
       _ -> nil
     end
   end
+
+  defp webhook_wait_time(_body), do: nil
+
+  @spec parse_wait_time(any()) :: non_neg_integer() | nil
+  defp parse_wait_time(value) when is_integer(value) and value > 0, do: value
+
+  defp parse_wait_time(value) when is_binary(value) do
+    case Integer.parse(String.trim(value)) do
+      {seconds, ""} when seconds > 0 -> seconds
+      _ -> nil
+    end
+  end
+
+  defp parse_wait_time(_value), do: nil
 
   ## Label formatter so that we can apply the dynamic label to the message
   @spec process_labels(list() | nil) :: list() | nil

--- a/lib/glific/flows/webhooks/core/async.ex
+++ b/lib/glific/flows/webhooks/core/async.ex
@@ -6,7 +6,8 @@ defmodule Glific.Flows.Webhooks.Async do
 
   Authors write `call/2`; the parsed callback is merged into the flow context by
   `Glific.Flows.Webhook` on resume. Override `wait_time_default/0` if the default 60s await
-  window doesn't fit.
+  window doesn't fit; a flow author can also set `wait_time` on the node itself, which wins over
+  this default. Either way `Glific.Flows.Action` caps the actual park at 5 minutes.
   """
 
   @doc """

--- a/lib/glific/flows/webhooks/core/behaviour.ex
+++ b/lib/glific/flows/webhooks/core/behaviour.ex
@@ -31,6 +31,8 @@ defmodule Glific.Flows.Webhooks.Behaviour do
   @callback name() :: String.t()
   @callback mode() :: :sync | :async
   @callback call(fields :: map(), ctx :: ctx()) :: result()
+  # Seconds to await the callback when the flow node doesn't set its own `wait_time`. Both are
+  # capped at 5 minutes by `Glific.Flows.Action`.
   @callback wait_time_default() :: non_neg_integer()
 
   # Async callback phase (Kaapi POSTs back): `Dispatcher.callback` runs these through the same

--- a/priv/data/flows/webhook.json
+++ b/priv/data/flows/webhook.json
@@ -17,7 +17,7 @@
   },
   {
     "name": "speech_to_text",
-    "body": "{\n\"speech\": \"\"\n}",
+    "body": "{\n\"speech\": \"\",\n\"wait_time\": \"\"\n}",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -25,7 +25,7 @@
   },
   {
     "name": "text_to_speech",
-    "body": "{\n\"text\": \"\"\n}",
+    "body": "{\n\"text\": \"\",\n\"wait_time\": \"\"\n}",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -33,7 +33,7 @@
   },
   {
     "name": "filesearch-gpt",
-    "body": "{\n\"question\": \"\",\n\"assistant_id\": \"\"}",
+    "body": "{\n\"question\": \"\",\n\"assistant_id\": \"\",\n\"wait_time\": \"\"\n}",
     "headers": {
       "Content-Type": "application/json"
     },
@@ -41,7 +41,7 @@
   },
   {
     "name": "voice-filesearch-gpt",
-    "body": "{\n\"contact\": \"\",\n\"speech\": \"\",\n\"assistant_id\": \"\",\n\"source_language\": \"\",\n\"target_language\": \"\"\n}",
+    "body": "{\n\"contact\": \"\",\n\"speech\": \"\",\n\"assistant_id\": \"\",\n\"source_language\": \"\",\n\"target_language\": \"\",\n\"wait_time\": \"\"\n}",
     "headers": {
       "Content-Type": "application/json"
     },

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -412,6 +412,45 @@ defmodule Glific.Flows.ActionTest do
     assert_raise ArgumentError, fn -> Action.process(json, %{}, node) end
   end
 
+  describe "process/3 — call_webhook wait_time" do
+    @webhook_json %{
+      "uuid" => "UUID 1",
+      "type" => "call_webhook",
+      "url" => "URL",
+      "method" => "METHOD",
+      "result_name" => "RESULT_NAME",
+      "headers" => %{"Content-Type" => "application/json"}
+    }
+
+    defp process_webhook(wait_time) do
+      json =
+        if wait_time == :absent,
+          do: @webhook_json,
+          else: Map.put(@webhook_json, "wait_time", wait_time)
+
+      {action, _uuid_map} = Action.process(json, %{}, %Node{uuid: "Test UUID"})
+      action.wait_time
+    end
+
+    test "parses an integer wait_time" do
+      assert process_webhook(120) == 120
+    end
+
+    test "parses a string wait_time, as the flow editor sends it" do
+      assert process_webhook("120") == 120
+    end
+
+    test "keeps the authored value even above the cap, so validate/3 can flag it" do
+      assert process_webhook(600) == 600
+    end
+
+    test "falls back to nil when absent, blank, zero, negative or unparseable" do
+      for value <- [:absent, nil, "", "  ", 0, "0", -30, "-30", "abc", "60s"] do
+        assert process_webhook(value) == nil
+      end
+    end
+  end
+
   test "process extracts the right values from json for send_broadcast" do
     node = %Node{uuid: "Test UUID"}
 
@@ -1592,6 +1631,34 @@ defmodule Glific.Flows.ActionTest do
       assert {:wait, parked, []} = Action.execute(action, context, [])
       assert parked.is_await_result == false
     end
+
+    defp park_seconds(context, wait_time) do
+      action = %Action{
+        type: "call_webhook",
+        method: "FUNCTION",
+        url: "filesearch-gpt",
+        headers: %{"Content-Type" => "application/json"},
+        body: Jason.encode!(%{"question" => "hi", "assistant_id" => "asst_1"}),
+        result_name: "r",
+        wait_time: wait_time
+      }
+
+      assert {:wait, parked, []} = Action.execute(action, context, [])
+      DateTime.diff(parked.wakeup_at, DateTime.utc_now())
+    end
+
+    test "falls back to the webhook's default window when the node sets no wait_time",
+         %{context: context} do
+      assert_in_delta park_seconds(context, nil), 60, 5
+    end
+
+    test "honours the node's own wait_time over the default", %{context: context} do
+      assert_in_delta park_seconds(context, 240), 240, 5
+    end
+
+    test "caps the park at 5 minutes however long the node asks for", %{context: context} do
+      assert_in_delta park_seconds(context, 3600), 300, 5
+    end
   end
 
   describe "validate/3 — deprecated Bhashini webhooks" do
@@ -1633,6 +1700,29 @@ defmodule Glific.Flows.ActionTest do
         action = %Action{type: "call_webhook", url: url}
         assert Action.validate(action, [], %{}) == []
       end
+    end
+  end
+
+  describe "validate/3 — call_webhook wait_time cap" do
+    test "warns when the node asks to wait longer than the 5 minute cap" do
+      action = %Action{type: "call_webhook", url: "filesearch-gpt", wait_time: 600}
+
+      assert [{Webhook, message, "Warning"}] = Action.validate(action, [], %{})
+      assert message =~ "at most 5 minutes"
+    end
+
+    test "stays quiet at or below the cap, and when no wait_time is set" do
+      for wait_time <- [nil, 60, 300] do
+        action = %Action{type: "call_webhook", url: "filesearch-gpt", wait_time: wait_time}
+        assert Action.validate(action, [], %{}) == []
+      end
+    end
+
+    test "a deprecated webhook still reports the Critical migration error first" do
+      action = %Action{type: "call_webhook", url: "text_to_speech_with_bhasini", wait_time: 600}
+
+      assert [{Webhook, message, "Critical"}] = Action.validate(action, [], %{})
+      assert message =~ "deprecated"
     end
   end
 

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -412,7 +412,7 @@ defmodule Glific.Flows.ActionTest do
     assert_raise ArgumentError, fn -> Action.process(json, %{}, node) end
   end
 
-  describe "process/3 — call_webhook wait_time" do
+  describe "process/3 — call_webhook wait_time read from the body" do
     @webhook_json %{
       "uuid" => "UUID 1",
       "type" => "call_webhook",
@@ -422,31 +422,63 @@ defmodule Glific.Flows.ActionTest do
       "headers" => %{"Content-Type" => "application/json"}
     }
 
-    defp process_webhook(wait_time) do
-      json =
-        if wait_time == :absent,
-          do: @webhook_json,
-          else: Map.put(@webhook_json, "wait_time", wait_time)
-
+    defp process_body(body) do
+      json = Map.put(@webhook_json, "body", body)
       {action, _uuid_map} = Action.process(json, %{}, %Node{uuid: "Test UUID"})
       action.wait_time
     end
 
-    test "parses an integer wait_time" do
-      assert process_webhook(120) == 120
+    test "reads an integer wait_time out of the body" do
+      assert process_body(~s|{"speech": "@results.x", "wait_time": 120}|) == 120
     end
 
-    test "parses a string wait_time, as the flow editor sends it" do
-      assert process_webhook("120") == 120
+    test "reads a string wait_time, as the flow editor's json template leaves it" do
+      assert process_body(~s|{"speech": "", "wait_time": "120"}|) == 120
     end
 
     test "keeps the authored value even above the cap, so validate/3 can flag it" do
-      assert process_webhook(600) == 600
+      assert process_body(~s|{"wait_time": 600}|) == 600
     end
 
-    test "falls back to nil when absent, blank, zero, negative or unparseable" do
-      for value <- [:absent, nil, "", "  ", 0, "0", -30, "-30", "abc", "60s"] do
-        assert process_webhook(value) == nil
+    test "ignores a blank, zero, negative, unparseable or non-scalar wait_time" do
+      for value <- [
+            ~s|""|,
+            ~s|"  "|,
+            "0",
+            ~s|"0"|,
+            "-30",
+            ~s|"-30"|,
+            ~s|"abc"|,
+            ~s|"60s"|,
+            "12.5",
+            "{}",
+            "[]",
+            "null",
+            "true"
+          ] do
+        assert process_body(~s|{"wait_time": | <> value <> "}") == nil
+      end
+    end
+
+    test "is nil when the body has no wait_time, is absent, or is not valid json" do
+      assert process_body(~s|{"speech": ""}|) == nil
+      assert process_body(nil) == nil
+      assert process_body("") == nil
+      assert process_body("not json at all") == nil
+      assert process_body(~s|["a", "list"]|) == nil
+    end
+
+    test "the auto-json template for every async webhook parses to no wait_time" do
+      templates =
+        Path.join(File.cwd!(), "priv/data/flows/webhook.json")
+        |> File.read!()
+        |> Jason.decode!()
+        |> Map.new(fn entry -> {entry["name"], entry["body"]} end)
+
+      for name <- ["speech_to_text", "text_to_speech", "filesearch-gpt", "voice-filesearch-gpt"] do
+        body = Map.fetch!(templates, name)
+        assert body =~ "wait_time", "#{name} template should offer a wait_time field"
+        assert process_body(body) == nil, "#{name} template should default, not park early"
       end
     end
   end

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -1736,11 +1736,12 @@ defmodule Glific.Flows.ActionTest do
   end
 
   describe "validate/3 — call_webhook wait_time cap" do
-    test "warns when the node asks to wait longer than the 5 minute cap" do
+    test "warns with both the configured and the allowed wait time" do
       action = %Action{type: "call_webhook", url: "filesearch-gpt", wait_time: 600}
 
       assert [{Webhook, message, "Warning"}] = Action.validate(action, [], %{})
-      assert message =~ "at most 5 minutes"
+      assert message =~ "wait_time of 600 seconds"
+      assert message =~ "allowed wait time of 300 seconds"
     end
 
     test "stays quiet at or below the cap, and when no wait_time is set" do


### PR DESCRIPTION
Closes #5633

## Problem

Async webhook nodes park the flow for a fixed 60s (`Webhooks.Async.wait_time_default/0`). That was sized for text-speed webhooks and is too short for audio, so the flow gives up and routes the contact to Failure while Kaapi is still working, and the reply arrives as a late callback nothing can consume.

Per the issue's AppSignal data: `speech_to_text` times out 7.5× as often as the text-only `filesearch-gpt` baseline, and roughly **31 of 51** `text_to_speech` failures in a week were the await window expiring rather than callback errors.

## Backend-only, by design

The await window is read from the **webhook body** the flow author already edits, rather than from a new node-level field. A dedicated field would have needed a matching input in glific-frontend before any NGO could use it; this way the whole feature ships from this repo.

```json
{
  "speech": "@results.audio_query",
  "wait_time": 120
}
```

This is safe to do:

- `Request.create_body/2` decodes the raw body **before** substituting variables, so a webhook body is already required to be valid JSON at rest. Parsing it at compile time in `process/3` is therefore reliable — if it doesn't decode, the webhook was already broken.
- The key **never reaches Kaapi**. `build_unified_llm_payload/5` and `build_flow_resume_metadata/6` both construct explicit allowlisted payloads, and the STT/TTS implementations pick fields out by name (`fields["speech"]`, `fields["text"]`), so an extra body key is inert.

Consequence worth knowing: because it's read at compile time, **literals only**. `"wait_time": "@results.x"` won't resolve — it hasn't been substituted at that point, so it parses to `nil` and falls back to the default.

## What changed

`do_park/3` already honoured a per-action value and `Action` already had the `wait_time` field, but `process/3` never populated it for `call_webhook` nodes, so it was always `nil` and the 60s default always won. Three pieces:

1. **`process/3` reads `wait_time` out of `json["body"]`**, keeping it only when it's a positive integer (or a string holding one). Blank, zero, negative, unparseable, non-scalar, missing, or an undecodable body all stay `nil` so the webhook module's `wait_time_default/0` still applies.

2. **`do_park/3` caps the park at 5 minutes.** The clamp lives here rather than at parse time so a single runtime guard covers *both* an authored value and any module that overrides `wait_time_default/0` past the cap.

3. **A `validate/3` warning** when a node asks for more than 300s, so the author learns at publish time instead of silently getting less. Ordered after the deprecated-Bhashini clause so that Critical error still wins.

`priv/data/flows/webhook.json` gains `"wait_time": ""` on the **four async entries only** (`speech_to_text`, `text_to_speech`, `filesearch-gpt`, `voice-filesearch-gpt`) so the field is discoverable on the nodes that actually park. The sync entries are left alone, where it would be ignored. Blank parses to `nil`, so **existing flows are unaffected**.

Docs on `Webhooks.Async` / `Webhooks.Behaviour` and the stale `wait_time` type comment (it said "minutes"; it's seconds) updated to match.

<img width="774" height="550" alt="Screenshot 2026-08-27 at 4 25 07 PM" src="https://github.com/user-attachments/assets/5a53774b-7f04-41a5-95cf-53bf7c77726e" />
