### PR TITLE
fix(assistants): set last_evaluation_run_id on set_live_version

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -9,6 +9,7 @@ defmodule Glific.Assistants do
   require Logger
 
   alias Ecto.Multi
+  alias Glific.AIEvaluations.AIEvaluation
   alias Glific.Assistants.Assistant
   alias Glific.Assistants.AssistantConfigVersion
   alias Glific.Assistants.KnowledgeBase
@@ -136,7 +137,8 @@ defmodule Glific.Assistants do
          {:ok, updated_assistant} <-
            assistant
            |> Assistant.set_active_config_version_changeset(%{
-             active_config_version_id: version_id
+             active_config_version_id: version_id,
+             last_evaluation_run_id: latest_evaluation_run_id(version_id)
            })
            |> Repo.update() do
       {:ok,
@@ -153,6 +155,19 @@ defmodule Glific.Assistants do
 
   defp validate_version_ready(_version),
     do: {:error, "Version must be in ready status to be set as live"}
+
+  @spec latest_evaluation_run_id(non_neg_integer()) :: non_neg_integer() | nil
+  defp latest_evaluation_run_id(assistant_config_version_id) do
+    AIEvaluation
+    |> where(
+      [e],
+      e.assistant_config_version_id == ^assistant_config_version_id and e.status == :completed
+    )
+    |> order_by([e], desc: e.inserted_at, desc: e.id)
+    |> select([e], e.id)
+    |> limit(1)
+    |> Repo.one()
+  end
 
   @doc "Sets the last evaluation run on the assistant whose active config version matches the given config version id"
   @spec set_last_evaluation_run(non_neg_integer(), non_neg_integer()) :: :ok

--- a/lib/glific/assistants/assistant.ex
+++ b/lib/glific/assistants/assistant.ex
@@ -62,11 +62,11 @@ defmodule Glific.Assistants.Assistant do
     timestamps(type: :utc_datetime)
   end
 
-  @doc "Changeset for updating the active_config_version_id"
+  @doc "Changeset for updating the active_config_version_id and its derived last_evaluation_run_id"
   @spec set_active_config_version_changeset(Assistant.t(), map()) :: Ecto.Changeset.t()
   def set_active_config_version_changeset(assistant, attrs) do
     assistant
-    |> cast(attrs, [:active_config_version_id])
+    |> cast(attrs, [:active_config_version_id, :last_evaluation_run_id])
     |> validate_required([:active_config_version_id])
   end
 

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -3206,4 +3206,56 @@ defmodule Glific.AssistantsTest do
       assert Repo.get!(Assistant, assistant.id).last_evaluation_run_id == nil
     end
   end
+
+  describe "set_live_version/2 evaluation summary" do
+    test "carries over the completed evaluation of the newly live version", attrs do
+      assistant = Fixtures.assistant_fixture(attrs)
+
+      new_config_version =
+        Fixtures.assistant_config_version_fixture(Map.merge(attrs, %{assistant_id: assistant.id}))
+
+      evaluation =
+        Fixtures.ai_evaluation_fixture(
+          Map.merge(attrs, %{
+            assistant_config_version_id: new_config_version.id,
+            status: :completed
+          })
+        )
+
+      assert {:ok, _result} = Assistants.set_live_version(assistant.id, new_config_version.id)
+
+      assert Repo.get!(Assistant, assistant.id).last_evaluation_run_id == evaluation.id
+    end
+
+    test "clears a stale evaluation when the newly live version has none", attrs do
+      assistant = Fixtures.assistant_fixture(attrs)
+
+      old_config_version =
+        Fixtures.assistant_config_version_fixture(Map.merge(attrs, %{assistant_id: assistant.id}))
+
+      old_evaluation =
+        Fixtures.ai_evaluation_fixture(
+          Map.merge(attrs, %{
+            assistant_config_version_id: old_config_version.id,
+            status: :completed
+          })
+        )
+
+      {:ok, assistant} =
+        assistant
+        |> Assistant.set_active_config_version_changeset(%{
+          active_config_version_id: old_config_version.id,
+          last_evaluation_run_id: old_evaluation.id
+        })
+        |> Repo.update()
+
+      unevaluated_config_version =
+        Fixtures.assistant_config_version_fixture(Map.merge(attrs, %{assistant_id: assistant.id}))
+
+      assert {:ok, _result} =
+               Assistants.set_live_version(assistant.id, unevaluated_config_version.id)
+
+      assert Repo.get!(Assistant, assistant.id).last_evaluation_run_id == nil
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #5639.

Reported from staging: after `setLiveVersion`, the Assistant list page's Evaluation Health
badge/summary doesn't reflect the newly-live version.

`Assistants.set_live_version/2` flipped `active_config_version_id` but never touched
`last_evaluation_run_id`. That pointer is only ever set by `set_last_evaluation_run/2`
(called when an evaluation completes), and it only matches assistants whose
`active_config_version_id` equals the evaluation's config version **at that moment** — so
switching the live version left the pointer stuck on the old version's evaluation (or stale
if the new version was never evaluated while active).

- `Assistant.set_active_config_version_changeset/2` now also casts `last_evaluation_run_id`
  (still optional; only `active_config_version_id` stays required).
- `Assistants.set_live_version/2` looks up the newly-live version's latest `:completed`
  evaluation and sets `last_evaluation_run_id` to it, or to `nil` when none exists — clearing
  stale summaries instead of leaving old data behind.

## Test plan

- [x] `mix test test/glific/assistants_test.exs` — 93/93 passing, including two new cases:
  switching to a version with a completed evaluation carries its id over; switching to an
  unevaluated version clears the pointer to `nil`.
- [x] `mix compile --warnings-as-errors`, `mix credo --strict` on touched files — clean.