### PR TITLE
fix(bigquery): dedup query used INTERVAL MONTH, which TIMESTAMP_SUB rejects

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -124,6 +124,10 @@ defmodule Glific.BigQuery do
   @partition_field "inserted_at"
   @partition_type "MONTH"
 
+  # Expressed in DAY because BigQuery's TIMESTAMP_SUB rejects MONTH — DAY is the largest
+  # date part it accepts. See `partition_filter/2`.
+  @partition_window_days 90
+
   # Per-table clustering keys (highest-selectivity first, max 4). Each org has its
   # own dataset, so there is no `organization_id` column to cluster on. Partitioned
   # tables cluster by entity keys only (time is the partition); unpartitioned fact
@@ -1090,11 +1094,11 @@ defmodule Glific.BigQuery do
   # For MONTH-partitioned tables, also bound the dedup scan by `inserted_at` (the
   # partition key) so BigQuery prunes to recent partitions instead of full-scanning.
   # These are transactional tables whose `updated_at` stays close to creation, so
-  # duplicates (from re-syncs of recently-updated rows) fall inside a 3-month window.
+  # duplicates (from re-syncs of recently-updated rows) fall inside the window.
   @spec partition_filter(String.t(), String.t()) :: String.t()
   defp partition_filter(table, timezone) when table in @partitioned_tables,
     do:
-      "\n    AND #{@partition_field} >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 MONTH), '#{timezone}')"
+      "\n    AND #{@partition_field} >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL #{@partition_window_days} DAY), '#{timezone}')"
 
   defp partition_filter(_table, _timezone), do: ""
 

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -180,7 +180,7 @@ defmodule Glific.BigQueryTest do
       FROM `test_dataset.messages` delta
       WHERE updated_at < DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR),
         'Asia/Kolkata')
-      AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 MONTH), 'Asia/Kolkata')) a WHERE a.rn <> 1 ORDER BY id);
+      AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY), 'Asia/Kolkata')) a WHERE a.rn <> 1 ORDER BY id);
   """
 
   test "generate_duplicate_removal_query/3 should create sql query", attrs do
@@ -224,7 +224,30 @@ defmodule Glific.BigQueryTest do
       )
 
     assert query =~ "DELETE FROM `test_dataset.contacts`"
-    refute query =~ "INTERVAL 3 MONTH"
+    refute query =~ "INTERVAL 90 DAY"
+  end
+
+  test "generate_duplicate_removal_query/3 only uses date parts TIMESTAMP_SUB accepts", attrs do
+    # BigQuery's TIMESTAMP_SUB rejects anything larger than DAY, and the failure is a
+    # query-analysis error, so an invalid part breaks the dedup for every org silently.
+    for table <- ~w(messages flow_contexts flow_results wa_messages messages_media contacts) do
+      query =
+        BigQuery.generate_duplicate_removal_query(
+          table,
+          %{project_id: "test_project", dataset_id: "test_dataset"},
+          attrs.organization_id
+        )
+
+      parts =
+        Regex.scan(~r/TIMESTAMP_SUB\(.*?INTERVAL \d+ (\w+)\)/s, query, capture: :all_but_first)
+
+      refute parts == [], "#{table}: expected at least one TIMESTAMP_SUB in the dedup query"
+
+      for [part] <- parts do
+        assert part in ~w(MICROSECOND MILLISECOND SECOND MINUTE HOUR DAY),
+               "#{table}: TIMESTAMP_SUB does not support the #{part} date part"
+      end
+    end
   end
 
   test "handle_insert_query_response/3 should update table", attrs do


### PR DESCRIPTION
## What & why

The BigQuery dedup job has been failing for **every organization** on the five partitioned tables since #5230 merged on 2026-06-19. Closes #5642.

`partition_filter/2` bounds the dedup scan with:

```sql
AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 MONTH), 'Asia/Kolkata')
```

**`TIMESTAMP_SUB` only accepts date parts up to `DAY`** — `MONTH`/`QUARTER`/`YEAR` are rejected, because months aren't a fixed duration in timestamp arithmetic ([docs](https://cloud.google.com/bigquery/docs/reference/standard-sql/timestamp_functions)). The `INTERVAL 3 HOUR` clause directly above it is valid, which is why only the new filter breaks.

This is a **query-analysis error**, so BigQuery never executes the statement — it's not a partial delete, it's zero rows deleted. It fails deterministically for every org, and regardless of whether that org's table is actually partitioned (the filter keys off the table name in `@partitioned_tables`, not the table's real layout).

## Blast radius

`messages`, `flow_contexts`, `flow_results`, `wa_messages`, `messages_media` — all orgs, every nightly run (`daily_tasks`, 23:58) for ~69 days. `contact_histories` is in `@partitioned_tables` but is insert-only per `ignore_updates_for_table/0`, so it never gets a dedup job. Non-partitioned tables were unaffected.

Duplicate rows have been accumulating unswept on the five heaviest tables that whole time.

## The fix

Express the same ~3-month window in a unit `TIMESTAMP_SUB` accepts:

```sql
AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY), 'Asia/Kolkata')
```

Both sides stay `DATETIME`, matching the column type in `bigquery_schema.ex` — no implicit cast. `DATETIME_SUB` would also work and gives exact calendar months, but that precision doesn't buy anything for a dedup horizon, and this keeps the diff to one token.

The window deliberately isn't shrunk. It bounds `inserted_at` (row creation), while duplicates come from *updates* — and the update sync watermarks purely on `updated_at` with no `inserted_at` floor (`bigquery_worker.ex:254`). So an old row updated today produces a duplicate with an old `inserted_at`. A shorter window would push those permanently outside the scan, turning a loud failure into a silent one.

## Why CI didn't catch it

The existing test asserted the dedup SQL by **string equality** against a hardcoded `@delete_query` containing the same broken `INTERVAL 3 MONTH`, with BigQuery mocked via `Tesla.Mock`. A string-equality test structurally cannot catch an invalid function signature.

Added `generate_duplicate_removal_query/3 only uses date parts TIMESTAMP_SUB accepts`, which extracts the date part from every `TIMESTAMP_SUB(...)` in the generated SQL and asserts it's one BigQuery actually supports. I verified it fails on the pre-fix code with `messages: TIMESTAMP_SUB does not support the MONTH date part`, and it asserts at least one match so it can't pass vacuously.

## Tests

`mix test test/glific/bigquery_test.exs` — 46 tests, 0 failures. `mix compile --warnings-as-errors`, `mix format --check-formatted`, and `mix credo --strict` on the changed file all pass.

Not verified against live BigQuery — my gcloud token is expired, so no `bq query --dry_run` confirmation. Worth one dry-run before merge if someone has working creds.

## Follow-ups (not in this PR)

1. **Backfill.** Duplicates from June/July are now older than 90 days, so the restored nightly job won't reach them. Needs a one-off wider-window cleanup.
2. **Alerting.** `handle_duplicate_removal_job_error/4` logs and bumps an Instrumentation counter but doesn't raise, and the worker is `max_attempts: 1` — so a permanently broken dedup was invisible for ~2 months.
3. **Is the filter even worth keeping?** #5230 only sets partitioning in `create_table/2`, so every pre-#5230 org's tables are unpartitioned — there are no partitions to prune and the filter buys them nothing. It only helps orgs onboarded after 2026-06-19. Dropping it, or gating it on the table actually being partitioned, is worth discussing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
