### PR TITLE
fix(bigquery): dedup query used INTERVAL MONTH, which TIMESTAMP_SUB rejects (#5643)

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -124,6 +124,10 @@ defmodule Glific.BigQuery do
   @partition_field "inserted_at"
   @partition_type "MONTH"
 
+  # Expressed in DAY because BigQuery's TIMESTAMP_SUB rejects MONTH — DAY is the largest
+  # date part it accepts. See `partition_filter/2`.
+  @partition_window_days 90
+
   # Per-table clustering keys (highest-selectivity first, max 4). Each org has its
   # own dataset, so there is no `organization_id` column to cluster on. Partitioned
   # tables cluster by entity keys only (time is the partition); unpartitioned fact
@@ -1090,11 +1094,11 @@ defmodule Glific.BigQuery do
   # For MONTH-partitioned tables, also bound the dedup scan by `inserted_at` (the
   # partition key) so BigQuery prunes to recent partitions instead of full-scanning.
   # These are transactional tables whose `updated_at` stays close to creation, so
-  # duplicates (from re-syncs of recently-updated rows) fall inside a 3-month window.
+  # duplicates (from re-syncs of recently-updated rows) fall inside the window.
   @spec partition_filter(String.t(), String.t()) :: String.t()
   defp partition_filter(table, timezone) when table in @partitioned_tables,
     do:
-      "\n    AND #{@partition_field} >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 MONTH), '#{timezone}')"
+      "\n    AND #{@partition_field} >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL #{@partition_window_days} DAY), '#{timezone}')"
 
   defp partition_filter(_table, _timezone), do: ""
 

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -180,7 +180,7 @@ defmodule Glific.BigQueryTest do
       FROM `test_dataset.messages` delta
       WHERE updated_at < DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 HOUR),
         'Asia/Kolkata')
-      AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 3 MONTH), 'Asia/Kolkata')) a WHERE a.rn <> 1 ORDER BY id);
+      AND inserted_at >= DATETIME(TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY), 'Asia/Kolkata')) a WHERE a.rn <> 1 ORDER BY id);
   """
 
   test "generate_duplicate_removal_query/3 should create sql query", attrs do
@@ -224,7 +224,30 @@ defmodule Glific.BigQueryTest do
       )
 
     assert query =~ "DELETE FROM `test_dataset.contacts`"
-    refute query =~ "INTERVAL 3 MONTH"
+    refute query =~ "INTERVAL 90 DAY"
+  end
+
+  test "generate_duplicate_removal_query/3 only uses date parts TIMESTAMP_SUB accepts", attrs do
+    # BigQuery's TIMESTAMP_SUB rejects anything larger than DAY, and the failure is a
+    # query-analysis error, so an invalid part breaks the dedup for every org silently.
+    for table <- ~w(messages flow_contexts flow_results wa_messages messages_media contacts) do
+      query =
+        BigQuery.generate_duplicate_removal_query(
+          table,
+          %{project_id: "test_project", dataset_id: "test_dataset"},
+          attrs.organization_id
+        )
+
+      parts =
+        Regex.scan(~r/TIMESTAMP_SUB\(.*?INTERVAL \d+ (\w+)\)/s, query, capture: :all_but_first)
+
+      refute parts == [], "#{table}: expected at least one TIMESTAMP_SUB in the dedup query"
+
+      for [part] <- parts do
+        assert part in ~w(MICROSECOND MILLISECOND SECOND MINUTE HOUR DAY),
+               "#{table}: TIMESTAMP_SUB does not support the #{part} date part"
+      end
+    end
   end
 
   test "handle_insert_query_response/3 should update table", attrs do


### PR DESCRIPTION
Backport of #5643 onto `hotfix/v8.10.4`, cut from `v8.10.3`. 