### PR TITLE
autofix: decode vendor response bodies leniently in Maytapi/Gupshup Enterprise handlers (incident #363)

### DIFF
--- a/lib/glific/providers/gupshup_enterprise/response_handler.ex
+++ b/lib/glific/providers/gupshup_enterprise/response_handler.ex
@@ -59,23 +59,40 @@ defmodule Glific.Providers.Gupshup.Enterprise.ResponseHandler do
 
   @spec add_error_payload(Tesla.Env.t() | map()) :: Tesla.Env.t()
   defp add_error_payload(response) do
-    %{"response" => error} = Jason.decode!(response.body)
+    # Gupshup Enterprise (or an intermediary) can return a non-JSON
+    # plaintext body on infra-level failures, so decode leniently
+    # instead of crashing the Oban job.
+    reason =
+      case Jason.decode(response.body) do
+        {:ok, %{"response" => error}} -> error["details"]
+        _ -> Glific.SafeLog.safe_inspect(response.body)
+      end
 
-    %{"payload" => %{"payload" => %{"reason" => error["details"]}}}
+    %{"payload" => %{"payload" => %{"reason" => reason}}}
     |> then(&Map.put(response, :body, &1))
   end
 
   @spec add_success_payload(Tesla.Env.t()) :: Tesla.Env.t()
   defp add_success_payload(response) do
-    %{"response" => success_response} = Jason.decode!(response.body)
+    # Same rationale as add_error_payload/1: decode leniently instead of
+    # crashing the Oban job on a non-JSON 2xx body.
+    message_id =
+      case Jason.decode(response.body) do
+        {:ok, %{"response" => success_response}} -> success_response["id"]
+        _ -> nil
+      end
 
-    %{"messageId" => success_response["id"]}
+    %{"messageId" => message_id}
     |> then(&Map.put(response, :body, Jason.encode!(&1)))
   end
 
   @spec check_message_status(Tesla.Env.t()) :: String.t()
   defp check_message_status(%{body: body} = _response) do
-    %{"response" => response} = Jason.decode!(body)
-    response["status"]
+    # A non-JSON body can't confirm success, so treat it as an error and
+    # let add_error_payload/1 (which itself decodes leniently) take over.
+    case Jason.decode(body) do
+      {:ok, %{"response" => response}} -> response["status"]
+      _ -> "error"
+    end
   end
 end

--- a/lib/glific/providers/maytapi/response_handler.ex
+++ b/lib/glific/providers/maytapi/response_handler.ex
@@ -58,33 +58,43 @@ defmodule Glific.Providers.Maytapi.ResponseHandler do
     handle_error_response(%{body: Jason.encode!(default_error)}, message)
   end
 
-  @spec handle_success_response(Tesla.Env.t(), WAMessage.t()) :: {:ok, WAMessage.t()}
+  @spec handle_success_response(Tesla.Env.t(), WAMessage.t()) ::
+          {:ok, WAMessage.t()} | {:error, String.t()}
   defp handle_success_response(response, message) do
-    message_id =
-      response.body
-      |> Jason.decode!()
-      |> Map.get("data")
-      |> Map.get("msgId")
+    case Jason.decode(response.body) do
+      {:ok, decoded} ->
+        message_id =
+          decoded
+          |> Map.get("data")
+          |> Map.get("msgId")
 
-    {:ok, message} =
-      message
-      |> Poison.encode!()
-      |> Poison.decode!(as: %WAMessage{})
-      |> WAMessages.update_message(%{
-        bsp_id: message_id,
-        bsp_status: :enqueued,
-        status: :sent,
-        sent_at: DateTime.truncate(DateTime.utc_now(), :second)
-      })
+        {:ok, message} =
+          message
+          |> Poison.encode!()
+          |> Poison.decode!(as: %WAMessage{})
+          |> WAMessages.update_message(%{
+            bsp_id: message_id,
+            bsp_status: :enqueued,
+            status: :sent,
+            sent_at: DateTime.truncate(DateTime.utc_now(), :second)
+          })
 
-    message
-    |> Repo.preload([:contact])
-    |> Communications.publish_data(
-      :update_wa_message_status,
-      message.organization_id
-    )
+        message
+        |> Repo.preload([:contact])
+        |> Communications.publish_data(
+          :update_wa_message_status,
+          message.organization_id
+        )
 
-    {:ok, message}
+        {:ok, message}
+
+      {:error, _} ->
+        Glific.log_error(
+          "Maytapi non-JSON 2xx response: #{Glific.SafeLog.safe_inspect(response.body)}"
+        )
+
+        handle_error_response(response, message)
+    end
   end
 
   @spec handle_error_response(Tesla.Env.t() | map(), WAMessage.t()) :: {:error, String.t()}
@@ -99,7 +109,14 @@ defmodule Glific.Providers.Maytapi.ResponseHandler do
         errors: build_error(response.body)
       })
 
-    error_msg = Jason.decode!(response.body)
+    # Maytapi (or an intermediary like Cloudflare) can return a non-JSON
+    # plaintext body on infra-level failures (e.g. "error code: 522"),
+    # so decode leniently instead of crashing the Oban job.
+    error_msg =
+      case Jason.decode(response.body) do
+        {:ok, decoded} -> decoded
+        {:error, _} -> %{"message" => Glific.SafeLog.safe_inspect(response.body)}
+      end
 
     Notifications.create_notification(%{
       category: "WA Group",

--- a/test/glific/providers/gupshup_enterprise/response_handler_test.exs
+++ b/test/glific/providers/gupshup_enterprise/response_handler_test.exs
@@ -1,0 +1,110 @@
+defmodule Glific.Providers.Gupshup.Enterprise.ResponseHandlerTest do
+  use Glific.DataCase
+
+  alias Glific.{
+    Fixtures,
+    Messages.Message,
+    Providers.Gupshup.Enterprise.ResponseHandler,
+    Repo
+  }
+
+  # Mirror the worker: the send-time message is the Oban-serialised minimal map
+  # (string keys), built from a persisted message so the success/error handlers
+  # have a row to update.
+  defp send_message(attrs \\ %{}) do
+    Fixtures.message_fixture(Map.merge(%{flow: :outbound}, attrs))
+    |> Message.to_minimal_map()
+    |> Jason.encode!()
+    |> Jason.decode!()
+  end
+
+  defp reload(message), do: Repo.get!(Message, message["id"])
+
+  describe "handle_response/2 — Tesla responses" do
+    test "4xx marks the message errored and is not retried (returns :ok)" do
+      message = send_message()
+
+      body =
+        Jason.encode!(%{"response" => %{"details" => "invalid destination address"}})
+
+      assert :ok =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 400, body: body}},
+                 message
+               )
+
+      reloaded = reload(message)
+      assert reloaded.bsp_status == :error
+      assert reloaded.errors["payload"]["payload"]["reason"] == "invalid destination address"
+    end
+
+    test "5xx (catch-all) returns an error tuple built from the error payload" do
+      message = send_message()
+
+      body =
+        Jason.encode!(%{"response" => %{"details" => "internal server error"}})
+
+      assert {:error, %{"payload" => %{"payload" => %{"reason" => "internal server error"}}}} =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 500, body: body}},
+                 message
+               )
+
+      assert reload(message).bsp_status == :error
+    end
+
+    # Regression for AppSignal incident #363 (sibling bug found via blast-radius
+    # grep on the Maytapi fix): Gupshup Enterprise (or an intermediary like
+    # Cloudflare) can return a non-JSON plaintext body on infra-level failures,
+    # which used to crash the Oban send job with a Jason.DecodeError.
+    test "4xx with a non-JSON (plaintext) body does not crash and still errors the message" do
+      message = send_message()
+      body = "error code: 522\n"
+
+      assert :ok =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 400, body: body}},
+                 message
+               )
+
+      reloaded = reload(message)
+      assert reloaded.bsp_status == :error
+
+      assert reloaded.errors["payload"]["payload"]["reason"] =~ "error code: 522"
+    end
+
+    test "non-2xx/4xx (catch-all) with a non-JSON (plaintext) body does not crash" do
+      message = send_message()
+      body = "error code: 522\n"
+
+      assert {:error, %{"payload" => %{"payload" => %{"reason" => reason}}}} =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 522, body: body}},
+                 message
+               )
+
+      assert reason =~ "error code: 522"
+      assert reload(message).bsp_status == :error
+    end
+
+    # Regression for AppSignal incident #363 (round 2): Gupshup Enterprise can
+    # also send a non-JSON plaintext 2xx body, which used to crash
+    # check_message_status/1 with a Jason.DecodeError before add_success_payload
+    # or add_error_payload were ever reached. It now treats the body as an
+    # error and routes through the (already-guarded) error path.
+    test "2xx with a non-JSON (plaintext) body does not crash and is routed to the error path" do
+      message = send_message()
+      body = "error code: 522\n"
+
+      assert :ok =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 200, body: body}},
+                 message
+               )
+
+      reloaded = reload(message)
+      assert reloaded.bsp_status == :error
+      assert reloaded.errors["payload"]["payload"]["reason"] =~ "error code: 522"
+    end
+  end
+end

--- a/test/glific/providers/maytapi/response_handler_test.exs
+++ b/test/glific/providers/maytapi/response_handler_test.exs
@@ -3,8 +3,11 @@ defmodule Glific.Providers.Maytapi.ResponseHandlerTest do
   # persist and reload a WAMessage. `phone_level_error?/1` stays pure.
   use Glific.DataCase
 
+  import Ecto.Query
+
   alias Glific.{
     Fixtures,
+    Notifications.Notification,
     Providers.Maytapi.ResponseHandler,
     Repo,
     WAGroup.WAMessage
@@ -23,6 +26,13 @@ defmodule Glific.Providers.Maytapi.ResponseHandlerTest do
   end
 
   defp reload(message), do: Repo.get!(WAMessage, message["id"])
+
+  defp critical_notification_exists?(ctx, substring) do
+    Notification
+    |> where([n], n.organization_id == ^ctx.organization_id)
+    |> Repo.all()
+    |> Enum.any?(fn n -> n.severity == "Critical" and String.contains?(n.message, substring) end)
+  end
 
   describe "phone_level_error?/1" do
     test "returns true for any 5xx response" do
@@ -118,6 +128,57 @@ defmodule Glific.Providers.Maytapi.ResponseHandlerTest do
                )
 
       assert reload(message).bsp_status == :error
+    end
+
+    # Regression for AppSignal incident #363: Maytapi (or an intermediary like
+    # Cloudflare) can return a non-JSON plaintext body on infra-level failures,
+    # which used to crash the WAWorker Oban job with a Jason.DecodeError.
+    test "4xx with a non-JSON (plaintext) body does not crash and still notifies", attrs do
+      message = send_message(attrs)
+      body = "error code: 522\n"
+
+      assert :ok =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 400, body: body}},
+                 message
+               )
+
+      assert reload(message).bsp_status == :error
+      assert critical_notification_exists?(attrs, "error code: 522")
+    end
+
+    test "non-2xx/4xx (catch-all) with a non-JSON (plaintext) body does not crash and still notifies",
+         attrs do
+      message = send_message(attrs)
+      body = "error code: 522\n"
+
+      assert {:error, ^body} =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 522, body: body}},
+                 message
+               )
+
+      assert reload(message).bsp_status == :error
+      assert critical_notification_exists?(attrs, "error code: 522")
+    end
+
+    # Regression for AppSignal incident #363 (round 2): Maytapi can also send
+    # a non-JSON plaintext 2xx body (e.g. after an infra-level hiccup), which
+    # used to crash handle_success_response/2 with a Jason.DecodeError. It now
+    # falls back to the same error path as a real error response.
+    test "2xx with a non-JSON (plaintext) body does not crash and falls back to the error path",
+         attrs do
+      message = send_message(attrs)
+      body = "error code: 522\n"
+
+      assert {:error, ^body} =
+               ResponseHandler.handle_response(
+                 {:ok, %Tesla.Env{status: 200, body: body}},
+                 message
+               )
+
+      assert reload(message).bsp_status == :error
+      assert critical_notification_exists?(attrs, "error code: 522")
     end
   end
 


### PR DESCRIPTION
## AppSignal incident

[#363](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/363) — `ErlangError` wrapping `Jason.DecodeError`, raised inside `Oban Glific.Providers.Maytapi.WAWorker#perform`. 708 total occurrences, 2 in the last 7 days. Source: AppSignal.

## Root cause

`Glific.Providers.Maytapi.ResponseHandler.handle_error_response/2` (`lib/glific/providers/maytapi/response_handler.ex`) used a bare `Jason.decode!(response.body)` on a vendor HTTP response body. This function is reached from `handle_response/2`'s 400-499 branch **and** its catch-all `_` branch (covering 5xx / infra-level responses). Maytapi (or an intermediary like Cloudflare) sometimes returns a non-JSON plaintext body for infra-level failures — e.g. `"error code: 522\n"` for a Cloudflare 522 — which raised `Jason.DecodeError` and crashed the Oban `WAWorker` job.

## Fix

- `handle_error_response/2`: `Jason.decode!` → `case Jason.decode(...) do {:ok, decoded} -> decoded; {:error, _} -> %{"message" => SafeLog.safe_inspect(response.body)} end`, matching the lenient-decode convention already used elsewhere in this same file (`phone_level_error?/1`).

**Blast radius (found via grep, not guessed):**
- `lib/glific/providers/gupshup_enterprise/response_handler.ex`'s `add_error_payload/1` had the identical bug (same three response-handling branches, same vendor-body decode) — fixed the same way in this PR.
- The adversarial review round then found the *success*-path (200-299) siblings in these same two files were **also** unguarded: Maytapi's `handle_success_response/2`, and Gupshup Enterprise's `add_success_payload/1` and `check_message_status/1`. All three fixed the same way in this PR (a malformed 2xx body — proxy/WAF interstitial, truncated response — crashed identically).
- Every remaining `Jason.decode!` call in both files (end-to-end re-read, confirmed by review) operates only on data Glific itself constructed (safe by construction) — no more vendor-body bang-decodes remain in either file.
- Other providers/files with the same *pattern* (`gupshup/partner/partner_api.ex`, `third_party/dialogflow/dialogflow.ex`, `third_party/navanatech/navanatech.ex`, `erp.ex`, `clients/avanti.ex`, `clients/bandhu.ex`, `clients/reap_benefit.ex`) were deliberately **not** touched here — different provider/incident surface, flagged as a documented follow-up rather than folded into this PR's scope.

## Verification

⚠️ **This sandbox has no Elixir/Erlang toolchain** (no `mix`, no `erl`) — `mix format`, `mix compile --warnings-as-errors`, `mix test`, and the `make-branch-ready-for-review` finalize step could not be run/invoked in this session. The fix and its regression tests were produced by a `backend-engineer` agent and a `test-automator` agent, then adversarially reviewed by a `code-reviewer` agent across two review rounds (round 1 caught the success-path blast-radius gap above; round 2 cleared with no blocking issues) — all via careful hand-tracing against the actual pre-fix (`origin/master`) and post-fix source, confirming each new test genuinely fails without the fix and passes with it. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.**

One non-blocking follow-up the reviewer flagged: Maytapi's malformed-2xx-body path now returns `{:error, response.body}` (Oban-retryable), while Gupshup Enterprise's equivalent forces `:ok` (no retry) — a pre-existing asymmetry between the two providers' conventions, not a regression from this fix, worth a separate consistency pass.

## Tests

- `test/glific/providers/maytapi/response_handler_test.exs` — 3 new cases (400 / catch-all / 2xx with a non-JSON body), each hand-verified to crash pre-fix and pass post-fix.
- `test/glific/providers/gupshup_enterprise/response_handler_test.exs` — new file, 4 cases (2 baseline + 2 regression), same verification standard. One theoretically-unreachable branch (`add_success_payload/1`'s decode-failure arm, provably dead code through the real entry point since `check_message_status/1` always decodes the identical body first and would already route away from it) was deliberately left untested rather than faking coverage — reviewer independently verified this reachability claim and confirmed it's safe even in the hypothetical case.

---
Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017phtbWd5wCY5wvmwMCHmkW)_