### PR TITLE
autofix: stop MatchError crashes when a cached flow's revision is gone (incident #4)

### DIFF
--- a/lib/glific/flows.ex
+++ b/lib/glific/flows.ex
@@ -433,15 +433,26 @@ defmodule Glific.Flows do
   end
 
   @doc """
-  Helper function to get the flow along with the revision and processing
+  Helper function to get the flow along with the revision and processing.
+  Returns nil (and logs) when the flow row or its matching revision can no
+  longer be found, e.g. the flow was deleted, unpublished, or its revision
+  reassigned since being referenced.
   """
-  @spec get_complete_flow(non_neg_integer(), non_neg_integer(), String.t()) :: Flow.t()
+  @spec get_complete_flow(non_neg_integer(), non_neg_integer(), String.t()) :: Flow.t() | nil
   def get_complete_flow(organization_id, flow_id, status \\ "draft") do
     # note that draft gives us the most recent one (revision_number = 0), so it
     # could be published also. this is what we want!
-    {:ok, flow} = Repo.fetch_by(Flow, %{id: flow_id, organization_id: organization_id})
+    case Repo.fetch_by(Flow, %{id: flow_id, organization_id: organization_id}) do
+      {:ok, flow} ->
+        Flow.get_flow(organization_id, flow.uuid, status)
 
-    Flow.get_flow(organization_id, flow.uuid, status)
+      {:error, error} ->
+        Glific.log_error(
+          "Flows.get_complete_flow: failed to load flow #{flow_id} for org #{organization_id}: #{SafeLog.safe_inspect(error)}"
+        )
+
+        nil
+    end
   end
 
   @spec get_user(nil | String.t()) :: map()
@@ -796,10 +807,15 @@ defmodule Glific.Flows do
           {:ok, Flow.t()} | {:error, String.t()}
   def start_group_flow(flow, group_ids, default_results \\ %{}, opts \\ []) do
     # the flow returned is the expanded version
-    {:ok, flow} = get_cached_flow(flow.organization_id, {:flow_id, flow.id, @status})
+    case get_cached_flow(flow.organization_id, {:flow_id, flow.id, @status}) do
+      {:ok, flow} ->
+        with {:ok, _} <-
+               Broadcast.broadcast_flow_to_group(flow, group_ids, default_results, opts) do
+          {:ok, flow}
+        end
 
-    with {:ok, _} <- Broadcast.broadcast_flow_to_group(flow, group_ids, default_results, opts) do
-      {:ok, flow}
+      {:error, _error} ->
+        {:error, ["Flow", dgettext("errors", "Flow not found")]}
     end
   end
 

--- a/lib/glific/flows/broadcast.ex
+++ b/lib/glific/flows/broadcast.ex
@@ -221,13 +221,18 @@ defmodule Glific.Flows.Broadcast do
 
     contacts = unprocessed_contacts(message_broadcast)
 
-    {:ok, flow} =
-      Flows.get_cached_flow(
-        message_broadcast.organization_id,
-        {:flow_id, message_broadcast.flow_id, @status}
-      )
+    case Flows.get_cached_flow(
+           message_broadcast.organization_id,
+           {:flow_id, message_broadcast.flow_id, @status}
+         ) do
+      {:ok, flow} ->
+        broadcast_for_contacts(%{flow: flow, type: :flow}, contacts, opts)
 
-    broadcast_for_contacts(%{flow: flow, type: :flow}, contacts, opts)
+      {:error, error} ->
+        Glific.log_error(
+          "Broadcast.process_broadcast_group: failed to load cached flow for flow_id #{message_broadcast.flow_id}, org #{message_broadcast.organization_id}: #{Glific.SafeLog.safe_inspect(error)}"
+        )
+    end
 
     :ok
   end

--- a/lib/glific/flows/flow.ex
+++ b/lib/glific/flows/flow.ex
@@ -21,6 +21,7 @@ defmodule Glific.Flows.Flow do
     Flows.Node,
     Partners.Organization,
     Repo,
+    SafeLog,
     Settings,
     Tags.Tag
   }
@@ -281,31 +282,45 @@ defmodule Glific.Flows.Flow do
           {:ok, FlowContext.t(), [String.t()]} | {:error, String.t()}
   def start_sub_flow(context, uuid, parent_id) do
     # we might want to put the current one under some sort of pause status
-    flow = get_flow(context.flow.organization_id, uuid, context.status)
+    case get_flow(context.flow.organization_id, uuid, context.status) do
+      nil ->
+        {:error, "Could not find flow with uuid #{uuid} to start as a sub flow"}
 
-    parent =
-      Glific.delete_multiple(
-        context.results,
-        ["parent", :parent, "child", :child]
-      )
+      flow ->
+        parent =
+          Glific.delete_multiple(
+            context.results,
+            ["parent", :parent, "child", :child]
+          )
 
-    FlowContext.init_context(flow, context.contact, context.status,
-      parent_id: parent_id,
-      delay: context.delay,
-      uuids_seen: context.uuids_seen,
-      # lets keep only one level of results, rather than a lot of them
-      results: %{"parent" => parent}
-    )
+        FlowContext.init_context(flow, context.contact, context.status,
+          parent_id: parent_id,
+          delay: context.delay,
+          uuids_seen: context.uuids_seen,
+          # lets keep only one level of results, rather than a lot of them
+          results: %{"parent" => parent}
+        )
+    end
   end
 
   @doc """
-  Return a flow for a specific uuid. Cache is not present in cache
+  Return a flow for a specific uuid. Cache is not present in cache.
+  Returns nil (and logs) when the flow/revision can no longer be found,
+  e.g. it was deleted, unpublished, or its revision reassigned after being cached.
   """
-  @spec get_flow(non_neg_integer, Ecto.UUID.t(), String.t()) :: map()
+  @spec get_flow(non_neg_integer, Ecto.UUID.t(), String.t()) :: map() | nil
   def get_flow(organization_id, uuid, status) do
-    {:ok, flow} = Flows.get_cached_flow(organization_id, {:flow_uuid, uuid, status})
+    case Flows.get_cached_flow(organization_id, {:flow_uuid, uuid, status}) do
+      {:ok, flow} ->
+        flow
 
-    flow
+      {:error, error} ->
+        Glific.log_error(
+          "Flow.get_flow: failed to load cached flow for uuid #{uuid}, status #{status}, org #{organization_id}: #{SafeLog.safe_inspect(error)}"
+        )
+
+        nil
+    end
   end
 
   @doc """

--- a/lib/glific/flows/flow_context.ex
+++ b/lib/glific/flows/flow_context.ex
@@ -327,19 +327,25 @@ defmodule Glific.Flows.FlowContext do
       # ensure the parent is still active. If the parent completed (or was terminated)
       # we don't get back a valid parent
       if parent do
-        Logger.info(
-          "Resuming Parent Flow: id: '#{parent.flow_id}', contact_id: '#{context.contact_id}'"
-        )
+        parent_flow = Flow.get_flow(context.organization_id, parent.flow_uuid, context.status)
 
-        ## add delay so that it does not execute the message before sub flows
-        ## adding this line separately so that we can easily identify this in different cases.
+        # ensure the parent's flow can still be loaded. If it was deleted or
+        # unpublished since the parent context was created, we cannot resume it
+        if parent_flow do
+          Logger.info(
+            "Resuming Parent Flow: id: '#{parent.flow_id}', contact_id: '#{context.contact_id}'"
+          )
 
-        parent = Map.put(parent, :delay, max(context.delay + @min_delay, @min_delay))
+          ## add delay so that it does not execute the message before sub flows
+          ## adding this line separately so that we can easily identify this in different cases.
 
-        parent
-        |> load_context(Flow.get_flow(context.organization_id, parent.flow_uuid, context.status))
-        |> merge_child_results(context)
-        |> step_forward(Messages.create_temp_message(context.organization_id, "completed"))
+          parent = Map.put(parent, :delay, max(context.delay + @min_delay, @min_delay))
+
+          parent
+          |> load_context(parent_flow)
+          |> merge_child_results(context)
+          |> step_forward(Messages.create_temp_message(context.organization_id, "completed"))
+        end
       end
     end
 
@@ -967,20 +973,27 @@ defmodule Glific.Flows.FlowContext do
       }
     )
 
-    {:ok, flow} =
-      Flows.get_cached_flow(
-        context.organization_id,
-        {:flow_uuid, context.flow_uuid, context.status}
-      )
+    case Flows.get_cached_flow(
+           context.organization_id,
+           {:flow_uuid, context.flow_uuid, context.status}
+         ) do
+      {:ok, flow} ->
+        message = message || handle_nil_message(flow, context)
 
-    message = message || handle_nil_message(flow, context)
+        context
+        |> FlowContext.load_context(flow)
+        |> FlowContext.step_forward(message)
+        |> case do
+          {:ok, context} -> {:ok, context, []}
+          {:error, message} -> {:error, message}
+        end
 
-    context
-    |> FlowContext.load_context(flow)
-    |> FlowContext.step_forward(message)
-    |> case do
-      {:ok, context} -> {:ok, context, []}
-      {:error, message} -> {:error, message}
+      {:error, error} ->
+        Glific.log_error(
+          "FlowContext.wakeup_one: failed to load cached flow for flow_uuid #{context.flow_uuid}, status #{context.status}, org #{context.organization_id}: #{Glific.SafeLog.safe_inspect(error)}"
+        )
+
+        {:error, "Could not find flow to wake up context #{context.id}"}
     end
   end
 

--- a/lib/glific/processor/consumer_flow.ex
+++ b/lib/glific/processor/consumer_flow.ex
@@ -167,39 +167,46 @@ defmodule Glific.Processor.ConsumerFlow do
         ) ::
           {Message.t(), map()}
   def continue_current_context(context, message, _body, state) do
-    {:ok, flow} =
-      Flows.get_cached_flow(
-        message.organization_id,
-        {:flow_uuid, context.flow_uuid, context.status}
-      )
+    case Flows.get_cached_flow(
+           message.organization_id,
+           {:flow_uuid, context.flow_uuid, context.status}
+         ) do
+      {:ok, flow} ->
+        {:ok, message} =
+          message
+          |> Messages.update_message(%{flow_id: context.flow_id})
 
-    {:ok, message} =
-      message
-      |> Messages.update_message(%{flow_id: context.flow_id})
+        context
+        |> maybe_update_current_node(flow, message)
+        |> Map.merge(%{last_message: message})
+        |> FlowContext.load_context(flow)
+        # we are using message.body here since we want to use the original message
+        # not the stripped version
+        # I'm not sure why we are creating a message here instead of reusing the existing
+        # message. We'll switch this to using message in the next release (1.0.1)
+        |> FlowContext.step_forward(
+          Messages.create_temp_message(
+            message.organization_id,
+            message.body,
+            type: message.type,
+            id: message.id,
+            media: message.media,
+            media_id: message.media_id,
+            location: message.location,
+            interactive_content: message.interactive_content,
+            whatsapp_form_response: message.whatsapp_form_response
+          )
+        )
 
-    context
-    |> maybe_update_current_node(flow, message)
-    |> Map.merge(%{last_message: message})
-    |> FlowContext.load_context(flow)
-    # we are using message.body here since we want to use the original message
-    # not the stripped version
-    # I'm not sure why we are creating a message here instead of reusing the existing
-    # message. We'll switch this to using message in the next release (1.0.1)
-    |> FlowContext.step_forward(
-      Messages.create_temp_message(
-        message.organization_id,
-        message.body,
-        type: message.type,
-        id: message.id,
-        media: message.media,
-        media_id: message.media_id,
-        location: message.location,
-        interactive_content: message.interactive_content,
-        whatsapp_form_response: message.whatsapp_form_response
-      )
-    )
+        {message, state}
 
-    {message, state}
+      {:error, error} ->
+        Glific.log_error(
+          "ConsumerFlow.continue_current_context: failed to load cached flow for flow_uuid #{context.flow_uuid}, status #{context.status}, org #{message.organization_id}: #{Glific.SafeLog.safe_inspect(error)}"
+        )
+
+        {message, state}
+    end
   end
 
   @spec draft_keyword?(map(), String.t()) :: boolean()

--- a/lib/glific_web/resolvers/flows.ex
+++ b/lib/glific_web/resolvers/flows.ex
@@ -74,7 +74,7 @@ defmodule GlificWeb.Resolvers.Flows do
 
   @doc false
   @spec export_flow_localization(Absinthe.Resolution.t(), %{id: integer}, %{context: map()}) ::
-          {:ok, %{export_data: String.t()}}
+          {:ok, %{export_data: String.t()}} | {:error, any}
   def export_flow_localization(_, %{id: flow_id} = args, %{
         context: %{current_user: user}
       }) do
@@ -84,18 +84,22 @@ defmodule GlificWeb.Resolvers.Flows do
       do: Glific.Metrics.increment("Export with auto translate"),
       else: Glific.Metrics.increment("Export without auto translate")
 
-    # load the flow
-    {rows, _errors} =
-      user.organization_id
-      |> Flows.get_complete_flow(flow_id)
-      |> Export.export_localization(add_translation)
+    # this result type has no `errors` field, so a not-found flow surfaces as
+    # a plain top-level GraphQL error instead
+    case Flows.get_complete_flow(user.organization_id, flow_id) do
+      nil ->
+        {:error, dgettext("errors", "Flow not found")}
 
-    data =
-      rows
-      |> CSV.encode(delimiter: "\n")
-      |> Enum.join("")
+      flow ->
+        {rows, _errors} = Export.export_localization(flow, add_translation)
 
-    {:ok, %{export_data: data}}
+        data =
+          rows
+          |> CSV.encode(delimiter: "\n")
+          |> Enum.join("")
+
+        {:ok, %{export_data: data}}
+    end
   end
 
   @doc false
@@ -112,17 +116,22 @@ defmodule GlificWeb.Resolvers.Flows do
         context: %{current_user: user}
       }) do
     Glific.Metrics.increment("Import translations")
-    flow = Flows.get_complete_flow(user.organization_id, flow_id)
 
-    {:ok, stream} = StringIO.open(data)
+    case Flows.get_complete_flow(user.organization_id, flow_id) do
+      nil ->
+        {:error, ["Flow", dgettext("errors", "Flow not found")]}
 
-    stream
-    |> IO.binstream(:line)
-    |> CSV.decode!(escape_max_lines: 50)
-    |> Enum.into([])
-    |> Import.import_localization(flow)
+      flow ->
+        {:ok, stream} = StringIO.open(data)
 
-    {:ok, %{success: true}}
+        stream
+        |> IO.binstream(:line)
+        |> CSV.decode!(escape_max_lines: 50)
+        |> Enum.into([])
+        |> Import.import_localization(flow)
+
+        {:ok, %{success: true}}
+    end
   end
 
   @doc false
@@ -131,11 +140,12 @@ defmodule GlificWeb.Resolvers.Flows do
   def inline_flow_localization(_, %{id: flow_id}, %{
         context: %{current_user: user}
       }) do
-    with {:ok, _result} <-
-           user.organization_id
-           |> Flows.get_complete_flow(flow_id)
-           |> Export.translate() do
+    with flow when not is_nil(flow) <- Flows.get_complete_flow(user.organization_id, flow_id),
+         {:ok, _result} <- Export.translate(flow) do
       {:ok, %{success: true}}
+    else
+      nil -> {:error, ["Flow", dgettext("errors", "Flow not found")]}
+      {:error, _} = error -> error
     end
   end
 

--- a/test/glific/flows/flow_context_test.exs
+++ b/test/glific/flows/flow_context_test.exs
@@ -82,6 +82,52 @@ defmodule Glific.Flows.FlowContextTest do
     FlowContext.reset_context(context_2)
   end
 
+  test "reset_context/1 leaves the parent untouched when its flow can no longer be loaded",
+       attrs do
+    contact = Fixtures.contact_fixture(attrs)
+
+    # parent_flow only has a draft revision (never published); the child
+    # context's status defaults to "published", so Flow.get_flow/3 will not
+    # find a matching revision when reset_context/1 tries to resume the parent
+    parent_flow =
+      Fixtures.flow_fixture(
+        Map.merge(attrs, %{name: "Reset Context Parent", keywords: ["resetctxparent"]})
+      )
+
+    child_flow =
+      Fixtures.flow_fixture(
+        Map.merge(attrs, %{name: "Reset Context Child", keywords: ["resetctxchild"]})
+      )
+
+    {:ok, parent_context} =
+      FlowContext.create_flow_context(%{
+        contact_id: contact.id,
+        organization_id: attrs.organization_id,
+        flow_id: parent_flow.id,
+        flow_uuid: parent_flow.uuid,
+        node_uuid: Ecto.UUID.generate(),
+        uuid_map: %{}
+      })
+
+    {:ok, child_context} =
+      FlowContext.create_flow_context(%{
+        contact_id: contact.id,
+        organization_id: attrs.organization_id,
+        flow_id: child_flow.id,
+        flow_uuid: child_flow.uuid,
+        node_uuid: Ecto.UUID.generate(),
+        uuid_map: %{},
+        parent_id: parent_context.id
+      })
+
+    assert %FlowContext{} = FlowContext.reset_context(child_context)
+
+    # the parent could not be resumed (its flow can no longer be loaded), so
+    # it should remain active/incomplete rather than being advanced
+    assert {:ok, reloaded_parent} = Repo.fetch_by(FlowContext, %{id: parent_context.id})
+    assert reloaded_parent.completed_at == nil
+  end
+
   test "update_flow_context/2 will update the UUID for the current context node" do
     flow_context = flow_context_fixture()
     uuid = Ecto.UUID.generate()
@@ -299,6 +345,30 @@ defmodule Glific.Flows.FlowContextTest do
 
     assert {:ok, _context, []} = FlowContext.wakeup_one(flow_context, message)
 
+    flow_context = Repo.get!(FlowContext, flow_context.id)
+    assert flow_context.wakeup_at == nil
+    assert flow_context.is_background_flow == false
+  end
+
+  test "wakeup_one/2 returns an error instead of crashing when the flow can no longer be loaded",
+       %{organization_id: organization_id} = _attrs do
+    message = Messages.create_temp_message(organization_id, "1")
+    wakeup_at = Timex.shift(Timex.now(), minutes: -3)
+
+    # flow_context_fixture/1's default flow_uuid (from @valid_attrs) matches no
+    # flow at all, so get_cached_flow/2 fails to load it (Repo.one!/1 raises,
+    # Cachex wraps it) and returns {:error, _} instead of {:ok, flow}
+    flow_context =
+      flow_context_fixture(%{
+        wakeup_at: wakeup_at,
+        is_background_flow: true
+      })
+
+    assert {:error, error_message} = FlowContext.wakeup_one(flow_context, message)
+    assert error_message == "Could not find flow to wake up context #{flow_context.id}"
+
+    # the context should still be marked as woken (wakeup_at cleared) even
+    # though the flow itself could not be resumed
     flow_context = Repo.get!(FlowContext, flow_context.id)
     assert flow_context.wakeup_at == nil
     assert flow_context.is_background_flow == false

--- a/test/glific/flows_test.exs
+++ b/test/glific/flows_test.exs
@@ -733,6 +733,40 @@ defmodule Glific.FLowsTest do
     assert message == "Group ID is empty"
   end
 
+  test "start_group_flow/4 returns an error instead of crashing when the flow cannot be loaded",
+       %{organization_id: organization_id} = _attrs do
+    group = Fixtures.group_fixture()
+    default_results = %{key: "value"}
+
+    # id 9999 does not correspond to any flow, so get_cached_flow/2 fails to
+    # load it from the DB (Repo.one!/1 raises, Cachex wraps it) and returns
+    # {:error, _} instead of {:ok, flow}
+    flow = %Flow{id: 9999, organization_id: organization_id}
+
+    assert {:error, error} = Flows.start_group_flow(flow, [group.id], default_results)
+    assert get_in(error, [Access.at(1)]) == "Flow not found"
+  end
+
+  test "Broadcast.process_broadcast_group/1 returns :ok instead of crashing when the flow cannot be loaded",
+       %{organization_id: organization_id} = _attrs do
+    group = Fixtures.group_fixture()
+
+    # id 9999 does not correspond to any flow, so get_cached_flow/2 fails to
+    # load it from the DB (Repo.one!/1 raises, Cachex wraps it) and returns
+    # {:error, _} instead of {:ok, flow}. The broadcast is not persisted, so
+    # unprocessed_contacts/1 simply finds no matching contacts to process.
+    message_broadcast = %MessageBroadcast{
+      id: nil,
+      organization_id: organization_id,
+      flow_id: 9999,
+      group_id: group.id,
+      type: "flow",
+      default_results: %{}
+    }
+
+    assert :ok = Broadcast.process_broadcast_group(message_broadcast)
+  end
+
   test "copy_flow/2 with valid data makes a copy of a template flow",
        %{organization_id: organization_id} = _attrs do
     user = Repo.get_current_user()
@@ -800,6 +834,44 @@ defmodule Glific.FLowsTest do
       Flows.get_cached_flow(organization_id, {:flow_uuid, flow.uuid, "published"})
 
     assert loaded_flow.skip_validation == true
+  end
+
+  test "get_flow/3 returns nil instead of raising when no revision matches the given status",
+       %{organization_id: organization_id} = attrs do
+    # flow_fixture/1 only creates a "draft" revision, so there is no
+    # "published" revision to find; Repo.one!/1 raises Ecto.NoResultsError,
+    # Cachex wraps it, and get_cached_flow/2 returns {:error, _} instead of
+    # {:ok, flow}
+    flow =
+      flow_fixture(
+        Map.merge(attrs, %{name: "Unpublished get_flow Test", keywords: ["unpubgetflow"]})
+      )
+
+    assert Flow.get_flow(organization_id, flow.uuid, "published") == nil
+  end
+
+  test "start_sub_flow/3 returns an error instead of crashing when the sub flow cannot be loaded",
+       %{organization_id: organization_id} = attrs do
+    # give the context a real, existing flow (so context.flow preloads to a
+    # concrete row) and use a uuid that does not correspond to any flow at all
+    parent_flow =
+      flow_fixture(
+        Map.merge(attrs, %{name: "Sub Flow Parent Context", keywords: ["subflowparentctx"]})
+      )
+
+    context =
+      Fixtures.flow_context_fixture(%{
+        organization_id: organization_id,
+        flow_id: parent_flow.id,
+        flow_uuid: parent_flow.uuid
+      })
+
+    missing_flow_uuid = Ecto.UUID.generate()
+
+    assert {:error, message} = Flow.start_sub_flow(context, missing_flow_uuid, context.id)
+
+    assert message ==
+             "Could not find flow with uuid #{missing_flow_uuid} to start as a sub flow"
   end
 
   test "publish_flow/1 handles invalid expression errors",

--- a/test/glific/processor/consumer_flow_test.exs
+++ b/test/glific/processor/consumer_flow_test.exs
@@ -683,4 +683,17 @@ defmodule Glific.Processor.ConsumerFlowTest do
     assert new_context.results["result_1"]["screen_0_Choose_one_0"] == "0_Yes"
     assert new_context.results["result_1"]["screen_1_Customer_service_2"] == "0_Excellent"
   end
+
+  test "continue_current_context/4 returns the message/state tuple unchanged instead of crashing when the flow can no longer be loaded",
+       attrs do
+    # flow_context_fixture/1 defaults to a random flow_uuid that matches no
+    # flow at all, so get_cached_flow/2 fails to load it and returns
+    # {:error, _} instead of {:ok, flow}
+    flow_context = Fixtures.flow_context_fixture(%{organization_id: attrs.organization_id})
+    message = Fixtures.message_fixture(%{organization_id: attrs.organization_id})
+    state = ConsumerFlow.load_state(attrs.organization_id)
+
+    assert {^message, ^state} =
+             ConsumerFlow.continue_current_context(flow_context, message, "body", state)
+  end
 end

--- a/test/glific_web/schema/flow_l10n_test.exs
+++ b/test/glific_web/schema/flow_l10n_test.exs
@@ -2,7 +2,12 @@ defmodule GlificWeb.Schema.FlowL10NTest do
   use GlificWeb.ConnCase
   use Wormwood.GQLCase
 
+  import Ecto.Query, warn: false
+
   alias Glific.{
+    Fixtures,
+    Flows.FlowRevision,
+    Repo,
     Seeds.SeedsDev
   }
 
@@ -14,6 +19,20 @@ defmodule GlificWeb.Schema.FlowL10NTest do
   load_gql(:export_l10n, GlificWeb.Schema, "assets/gql/flows/export_l10n.gql")
   load_gql(:import_l10n, GlificWeb.Schema, "assets/gql/flows/import_l10n.gql")
   load_gql(:inline_l10n, GlificWeb.Schema, "assets/gql/flows/inline_l10n.gql")
+
+  # Creates a flow with its only revision immediately deleted, so
+  # Flows.get_complete_flow/3 fails to load a revision for it (the same
+  # condition as a flow deleted/unpublished/revision-reassigned after being
+  # cached) and returns nil instead of crashing.
+  defp flow_with_no_revision(attrs) do
+    flow = Fixtures.flow_fixture(attrs)
+
+    FlowRevision
+    |> where([fr], fr.flow_id == ^flow.id)
+    |> Repo.delete_all()
+
+    flow
+  end
 
   @help_export """
   Type,UUID,en,hi,Node_uuid
@@ -54,5 +73,48 @@ defmodule GlificWeb.Schema.FlowL10NTest do
     result = auth_query_gql_by(:inline_l10n, user, variables: %{"id" => 1})
     assert {:ok, query_data} = result
     assert get_in(query_data, [:data, "inlineFlowLocalization", "success"]) == true
+  end
+
+  test "export flow localization returns a GraphQL error instead of crashing when the flow has no revision to load",
+       %{manager: user} do
+    flow = flow_with_no_revision(%{organization_id: user.organization_id})
+
+    result = auth_query_gql_by(:export_l10n, user, variables: %{"id" => flow.id})
+    assert {:ok, query_data} = result
+
+    # :export_flow_localization has no `errors` field, so this surfaces as a
+    # top-level GraphQL error rather than under `data`
+    message = get_in(query_data, [:errors, Access.at(0), :message])
+    assert message == "Flow not found"
+  end
+
+  test "import flow localization returns a GraphQL error instead of crashing when the flow has no revision to load",
+       %{manager: user} do
+    flow = flow_with_no_revision(%{organization_id: user.organization_id})
+
+    result =
+      auth_query_gql_by(:import_l10n, user,
+        variables: %{"localization" => @help_export, "id" => flow.id}
+      )
+
+    assert {:ok, query_data} = result
+
+    message =
+      get_in(query_data, [:data, "importFlowLocalization", "errors", Access.at(0), "message"])
+
+    assert message == "Flow not found"
+  end
+
+  test "inline flow localization returns a GraphQL error instead of crashing when the flow has no revision to load",
+       %{manager: user} do
+    flow = flow_with_no_revision(%{organization_id: user.organization_id})
+
+    result = auth_query_gql_by(:inline_l10n, user, variables: %{"id" => flow.id})
+    assert {:ok, query_data} = result
+
+    message =
+      get_in(query_data, [:data, "inlineFlowLocalization", "errors", Access.at(0), "message"])
+
+    assert message == "Flow not found"
   end
 end


### PR DESCRIPTION
## AppSignal incident

[#4](https://appsignal.com/project-tech4dev/sites/5f480c425ac13f7330101f30/exceptions/incidents/4) — `MatchError`, 24,377 total occurrences, 31 in the last 7 days. Source: AppSignal.

## Root cause

`Glific.Flows.Flow.get_flow/3` used a bare `{:ok, flow} = Flows.get_cached_flow(...)` match. `Flows.get_cached_flow/2` returns `{:error, %Cachex.ExecutionError{}}` whenever a flow's published revision can no longer be found (deleted, unpublished, or its revision reassigned after being cached) — the underlying `Repo.one!()` in `get_loaded_flow/3` raises `Ecto.NoResultsError`, which Cachex's fetch wraps. The bare match then raised `MatchError`, crashing the `ConsumerWorker` processing that contact's message.

**Prior precedent**: a previous autofix run (**merged PR #5528**) fixed the identical bug in a sibling function, `Glific.Flows.Periodic.init_common_flow/3`, and its own description explicitly deferred `flow.ex:306`/`get_flow/3` as a follow-up ("different function, different callers, different raise contract... needs its own investigation"). This PR is that follow-up, plus its full blast radius.

## Fix — every caller of `Flows.get_cached_flow/2` across the codebase now handles the error instead of bare-matching

- `Glific.Flows.Flow.get_flow/3` — logs via `Glific.log_error/1` + `SafeLog.safe_inspect/1`, returns `nil` instead of raising. `@spec` widened to `map() | nil`.
- `Glific.Flows.Flow.start_sub_flow/3` — `nil` → `{:error, "Could not find flow with uuid ... to start as a sub flow"}` (already within its existing `@spec`).
- `Glific.Flows.FlowContext.reset_context/1` — nil-guards the parent-flow resume path (since `get_flow/3` can now return `nil` for the parent too).
- `Glific.Flows.start_group_flow/4` — fixed an independently-discovered sibling bare match, matching how its 3 neighbors (`start_wa_group_flow/2,3`, `start_contact_flow/3`) already handle it.
- `Glific.Processor.ConsumerFlow.continue_current_context/4` — falls back to `{message, state}` unchanged, matching this function's own sibling early-return branches for the same "can't continue" condition.
- `Glific.Flows.Broadcast.process_broadcast_group/1` — skips the broadcast for that group and returns `:ok` (matches its `@spec`); the broadcast is not silently dropped — it stays "in progress" and is retried on the next `execute_broadcasts/1` cron tick.
- `Glific.Flows.FlowContext.wakeup_one/2` — `{:error, "Could not find flow to wake up context ..."}`, fitting its already-declared `@spec`; every current caller (`webhook.ex`, `dialogflow/sessions.ex`, `wakeup_worker.ex`) already discards/ignores the return value.
- `Glific.Flows.get_complete_flow/3` — kept its bare-struct return convention (switching to a tuple would have broken 9 existing call sites in `test/glific/flows/translate_test.exs`) but widened `@spec` to `Flow.t() | nil`; also fixed an adjacent bare match (`{:ok, flow} = Repo.fetch_by(...)`) in the same function, same failure class. The 3 GraphQL resolvers that call it (`export_flow_localization`, `import_flow_localization`, `inline_flow_localization` in `lib/glific_web/resolvers/flows.ex`) now branch on `nil` and surface a "Flow not found" GraphQL error via this schema's existing error-shape conventions (the same `{:error, ["Flow", "..."]}` shape already used by `start_wa_group_flow`/`start_contact_flow`, or a top-level `{:error, "..."}` for the one query field with no `errors` field in its result type) instead of crashing.

Every remaining call site of `get_cached_flow/2`, `Flow.get_flow/3`, and `get_complete_flow/3` across `lib/` and `lib/glific_web/` was grepped and confirmed already safe (either pre-existing `case`-handling, or a caller that already discards the return value).

## Heads up for whoever merges this

**Open PR #5220** rewrites `Glific.Flows.get_cached_flow/2`'s internals (swaps the caching/error-wrapping mechanism, changes the inner error term shape). This PR's callers only ever pattern-match on the outer `{:ok, _}`/`{:error, _}` tuple and log the inner term opaquely, so it isn't semantically broken by #5220 — but whichever of these two PRs merges second will need a straightforward rebase on `lib/glific/flows.ex`.

## Verification

⚠️ **This sandbox has no Elixir/Erlang toolchain** (no `mix`, no `erl`) — `mix format`, `mix compile --warnings-as-errors`, `mix test`, and the `make-branch-ready-for-review` finalize step could not be run/invoked in this session. The fix and its regression tests were produced by a `backend-engineer` agent across 2 rounds, tested by a `test-automator` agent, and adversarially reviewed by a `code-reviewer` agent across 2 full review rounds — round 1 caught the incomplete blast radius (3 more crash sites, plus a `nil`-cascade into 3 GraphQL resolvers) and required a second implementation pass; round 2 re-traced the entire call graph end-to-end (every caller of `get_cached_flow/2`, `get_flow/3`, and `get_complete_flow/3`), re-verified all 3 new fallback shapes against their functions' actual contracts and callers, verified the GraphQL error-shape reasoning against the actual Absinthe middleware source (`query_errors.ex`/`changeset_errors.ex`), and hand-traced several tests against pre-fix state — and cleared with **no blocking issues**. **CI must be the real gate here — please don't merge until `code-quality`/`tests` are green.**

## Tests

- `test/glific/flows_test.exs` — new tests for `get_flow/3`, `start_sub_flow/3`, `start_group_flow/4`, and `Broadcast.process_broadcast_group/1`.
- `test/glific/flows/flow_context_test.exs` — new tests for `reset_context/1` and `wakeup_one/2`.
- `test/glific/processor/consumer_flow_test.exs` — new test for `continue_current_context/4`.
- `test/glific_web/schema/flow_l10n_test.exs` — 3 new GraphQL-level tests for the 3 resolvers, using a new `flow_with_no_revision/1` helper that deletes a flow's only `FlowRevision` row to force the exact `Repo.one! → Ecto.NoResultsError → Cachex-wrapped error → nil` path this PR fixes.

All new/changed tests were hand-verified (by the implementing and reviewing agents, independently) to fail with `MatchError` against the pre-fix code and pass against the post-fix code.

---
Source: AppSignal · Autofix pass from the Glific monitoring routine · Never auto-merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_017phtbWd5wCY5wvmwMCHmkW)_