### PR TITLE
feat(evals): categorise Kaapi models as recommended/all/deprecated

### DIFF
--- a/assets/gql/ai_evaluations/list_kaapi_models.gql
+++ b/assets/gql/ai_evaluations/list_kaapi_models.gql
@@ -7,5 +7,8 @@ query KaapiModels {
     inputModalities
     outputModalities
     pricing
+    category
+    badge
+    isDefault
   }
 }

--- a/assets/gql/ai_evaluations/list_kaapi_models.gql
+++ b/assets/gql/ai_evaluations/list_kaapi_models.gql
@@ -9,6 +9,5 @@ query KaapiModels {
     pricing
     category
     badge
-    isDefault
   }
 }

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -29,8 +29,6 @@ defmodule Glific.Assistants do
     defexception [:message, :reason, :organization_id]
   end
 
-  @default_model "gpt-4o"
-
   @timeout_hours 1
 
   # https://platform.openai.com/docs/assistants/tools/file-search#supported-files
@@ -838,7 +836,7 @@ defmodule Glific.Assistants do
 
     config = %{
       settings: build_settings(user_params),
-      model: user_params[:model] || @default_model,
+      model: user_params[:model] || Kaapi.default_model(),
       organization_id: user_params[:organization_id],
       name: generate_assistant_name(user_params[:name]),
       description: description,

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -321,7 +321,7 @@ defmodule Glific.ThirdParty.Kaapi do
 
   @spec build_config_blob(map(), list(String.t()), non_neg_integer()) :: map()
   defp build_config_blob(params, knowledge_base_ids, organization_id) do
-    model = params.model || "gpt-4o"
+    model = params.model || default_model()
 
     base_params = %{
       "model" => model,
@@ -989,8 +989,7 @@ defmodule Glific.ThirdParty.Kaapi do
   def default_model, do: @default_model
 
   @doc """
-  List active Kaapi models annotated with `category` and `badge`, ordered recommended first,
-  then the rest alphabetically, then the ones NGOs should migrate off.
+  List active Kaapi models annotated with `category` and `badge`, in dropdown display order.
   """
   @spec list_models_with_metadata(non_neg_integer()) :: {:ok, list(map())} | {:error, any()}
   def list_models_with_metadata(organization_id) do
@@ -1021,7 +1020,7 @@ defmodule Glific.ThirdParty.Kaapi do
     Enum.sort_by(models, fn %{model_name: model_name, category: category} ->
       case category do
         "recommended" ->
-          {0, Enum.find_index(@recommended_models, &(elem(&1, 0) == model_name)), ""}
+          {0, recommended_index(model_name), ""}
 
         "all" ->
           {1, 0, model_name}
@@ -1030,6 +1029,12 @@ defmodule Glific.ThirdParty.Kaapi do
           {2, 0, model_name}
       end
     end)
+  end
+
+  @spec recommended_index(String.t()) :: non_neg_integer()
+  defp recommended_index(model_name) do
+    Enum.find_index(@recommended_models, &(elem(&1, 0) == model_name)) ||
+      length(@recommended_models)
   end
 
   @spec fetch_and_cache_models(non_neg_integer(), tuple()) :: {:ok, list(map())} | {:error, any()}

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -975,18 +975,22 @@ defmodule Glific.ThirdParty.Kaapi do
     {"gpt-5.6-terra", "All-rounder"},
     {"gpt-5.4", "All-rounder"}
   ]
-  @deprecated_models ~w(gpt-4o gpt-4o-mini)
-  @default_model "gpt-5.6-luna"
+  @to_be_deprecated_models ~w(gpt-4o gpt-4o-mini)
+
+  # Deliberately still gpt-4o. Moving the default to gpt-5.6-luna changes the model every
+  # assistant created without an explicit one is persisted with, so it is held back from
+  # the dropdown categorisation change.
+  @default_model "gpt-4o"
 
   @doc """
-  The model preselected in the model dropdown and used when none is supplied.
+  The model an assistant is created with when the caller supplies none.
   """
   @spec default_model() :: String.t()
   def default_model, do: @default_model
 
   @doc """
-  List active Kaapi models annotated with `category`, `badge` and `is_default`, ordered
-  recommended first, then the rest alphabetically, then the ones being deprecated.
+  List active Kaapi models annotated with `category` and `badge`, ordered recommended first,
+  then the rest alphabetically, then the ones NGOs should migrate off.
   """
   @spec list_models_with_metadata(non_neg_integer()) :: {:ok, list(map())} | {:error, any()}
   def list_models_with_metadata(organization_id) do
@@ -1000,17 +1004,13 @@ defmodule Glific.ThirdParty.Kaapi do
     metadata =
       cond do
         entry = List.keyfind(@recommended_models, model_name, 0) ->
-          %{
-            category: "recommended",
-            badge: elem(entry, 1),
-            is_default: model_name == @default_model
-          }
+          %{category: "recommended", badge: elem(entry, 1)}
 
-        model_name in @deprecated_models ->
-          %{category: "deprecated", badge: "Deprecating", is_default: false}
+        model_name in @to_be_deprecated_models ->
+          %{category: "to_be_deprecated", badge: "Deprecating"}
 
         true ->
-          %{category: "all", badge: nil, is_default: false}
+          %{category: "all", badge: nil}
       end
 
     Map.merge(model, metadata)

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -975,13 +975,7 @@ defmodule Glific.ThirdParty.Kaapi do
     {"gpt-5.6-terra", "All-rounder"},
     {"gpt-5.4", "All-rounder"}
   ]
-  @recommended_badges Map.new(@recommended_models)
-  @recommended_order @recommended_models
-                     |> Enum.map(&elem(&1, 0))
-                     |> Enum.with_index()
-                     |> Map.new()
   @deprecated_models ~w(gpt-4o gpt-4o-mini)
-  @deprecated_badge "Deprecating"
   @default_model "gpt-5.6-luna"
 
   @doc """
@@ -1005,11 +999,15 @@ defmodule Glific.ThirdParty.Kaapi do
   defp annotate_model(%{model_name: model_name} = model) do
     metadata =
       cond do
-        badge = @recommended_badges[model_name] ->
-          %{category: "recommended", badge: badge, is_default: model_name == @default_model}
+        entry = List.keyfind(@recommended_models, model_name, 0) ->
+          %{
+            category: "recommended",
+            badge: elem(entry, 1),
+            is_default: model_name == @default_model
+          }
 
         model_name in @deprecated_models ->
-          %{category: "deprecated", badge: @deprecated_badge, is_default: false}
+          %{category: "deprecated", badge: "Deprecating", is_default: false}
 
         true ->
           %{category: "all", badge: nil, is_default: false}
@@ -1020,13 +1018,16 @@ defmodule Glific.ThirdParty.Kaapi do
 
   @spec sort_models(list(map())) :: list(map())
   defp sort_models(models) do
-    Enum.sort_by(models, fn model ->
-      model_name = Map.get(model, :model_name)
+    Enum.sort_by(models, fn %{model_name: model_name, category: category} ->
+      case category do
+        "recommended" ->
+          {0, Enum.find_index(@recommended_models, &(elem(&1, 0) == model_name)), ""}
 
-      case model[:category] do
-        "recommended" -> {0, @recommended_order[model_name], ""}
-        "all" -> {1, 0, to_string(model_name)}
-        _ -> {2, 0, to_string(model_name)}
+        "all" ->
+          {1, 0, model_name}
+
+        _ ->
+          {2, 0, model_name}
       end
     end)
   end

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -968,6 +968,69 @@ defmodule Glific.ThirdParty.Kaapi do
     end
   end
 
+  @recommended_models [
+    {"gpt-5.6-luna", "Best value"},
+    {"gpt-5-nano", "Fastest"},
+    {"gpt-5-mini", "Budget"},
+    {"gpt-5.6-terra", "All-rounder"},
+    {"gpt-5.4", "All-rounder"}
+  ]
+  @recommended_badges Map.new(@recommended_models)
+  @recommended_order @recommended_models
+                     |> Enum.map(&elem(&1, 0))
+                     |> Enum.with_index()
+                     |> Map.new()
+  @deprecated_models ~w(gpt-4o gpt-4o-mini)
+  @deprecated_badge "Deprecating"
+  @default_model "gpt-5.6-luna"
+
+  @doc """
+  The model preselected in the model dropdown and used when none is supplied.
+  """
+  @spec default_model() :: String.t()
+  def default_model, do: @default_model
+
+  @doc """
+  List active Kaapi models annotated with `category`, `badge` and `is_default`, ordered
+  recommended first, then the rest alphabetically, then the ones being deprecated.
+  """
+  @spec list_models_with_metadata(non_neg_integer()) :: {:ok, list(map())} | {:error, any()}
+  def list_models_with_metadata(organization_id) do
+    with {:ok, models} <- list_models(organization_id) do
+      {:ok, models |> Enum.map(&annotate_model/1) |> sort_models()}
+    end
+  end
+
+  @spec annotate_model(map()) :: map()
+  defp annotate_model(%{model_name: model_name} = model) do
+    metadata =
+      cond do
+        badge = @recommended_badges[model_name] ->
+          %{category: "recommended", badge: badge, is_default: model_name == @default_model}
+
+        model_name in @deprecated_models ->
+          %{category: "deprecated", badge: @deprecated_badge, is_default: false}
+
+        true ->
+          %{category: "all", badge: nil, is_default: false}
+      end
+
+    Map.merge(model, metadata)
+  end
+
+  @spec sort_models(list(map())) :: list(map())
+  defp sort_models(models) do
+    Enum.sort_by(models, fn model ->
+      model_name = Map.get(model, :model_name)
+
+      case model[:category] do
+        "recommended" -> {0, @recommended_order[model_name], ""}
+        "all" -> {1, 0, to_string(model_name)}
+        _ -> {2, 0, to_string(model_name)}
+      end
+    end)
+  end
+
   @spec fetch_and_cache_models(non_neg_integer(), tuple()) :: {:ok, list(map())} | {:error, any()}
   defp fetch_and_cache_models(organization_id, cache_key) do
     with {:ok, secrets} <- fetch_kaapi_creds(organization_id),

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -52,7 +52,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   """
   @spec list_kaapi_models(map(), map(), map()) :: {:ok, list(map())} | {:error, any()}
   def list_kaapi_models(_, _args, %{context: %{current_user: user}}) do
-    Kaapi.list_models(user.organization_id)
+    Kaapi.list_models_with_metadata(user.organization_id)
   end
 
   # 1MB

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -113,10 +113,9 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :output_modalities, list_of(:string)
     field :pricing, :json
 
-    @desc "One of: recommended, all, deprecated"
+    @desc "One of: recommended, all, to_be_deprecated"
     field :category, :string
     field :badge, :string
-    field :is_default, :boolean
   end
 
   object :improve_prompt do

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -112,6 +112,11 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :input_modalities, list_of(:string)
     field :output_modalities, list_of(:string)
     field :pricing, :json
+
+    @desc "One of: recommended, all, deprecated"
+    field :category, :string
+    field :badge, :string
+    field :is_default, :boolean
   end
 
   object :improve_prompt do

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -13,6 +13,7 @@ defmodule Glific.AssistantsTest do
   alias Glific.Notifications.Notification
   alias Glific.Partners
   alias Glific.Repo
+  alias Glific.ThirdParty.Kaapi
 
   defp enable_kaapi(attrs) do
     Fixtures.kaapi_credential_fixture(%{organization_id: attrs.organization_id})
@@ -1354,7 +1355,7 @@ defmodule Glific.AssistantsTest do
                })
 
       assert String.starts_with?(assistant.name, "Assistant-")
-      assert config_version.model == "gpt-4o"
+      assert config_version.model == Kaapi.default_model()
       assert config_version.prompt == "You are a helpful assistant"
       assert config_version.description == "Assistant configuration"
 

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -341,6 +341,80 @@ defmodule Glific.ThirdParty.KaapiTest do
     end
   end
 
+  describe "list_models_with_metadata/1" do
+    setup [:enable_kaapi_credential]
+
+    setup do
+      Cachex.del(:glific_cache, {:global, {:kaapi_models, "openai"}})
+      :ok
+    end
+
+    defp mock_models(model_names) do
+      mock(fn %Tesla.Env{method: :get} ->
+        %Tesla.Env{
+          status: 200,
+          body: %{
+            data: %{data: Enum.map(model_names, &%{provider: "openai", model_name: &1})}
+          }
+        }
+      end)
+    end
+
+    test "annotates recommended, all and deprecated models" do
+      mock_models(["gpt-4o", "gpt-4.1", "gpt-5-nano", "gpt-5.6-luna"])
+
+      assert {:ok, models} = Kaapi.list_models_with_metadata(1)
+
+      assert Enum.map(models, &{&1.model_name, &1.category, &1.badge, &1.is_default}) == [
+               {"gpt-5.6-luna", "recommended", "Best value", true},
+               {"gpt-5-nano", "recommended", "Fastest", false},
+               {"gpt-4.1", "all", nil, false},
+               {"gpt-4o", "deprecated", "Deprecating", false}
+             ]
+    end
+
+    test "orders recommended by the curated order, then all alphabetically, then deprecated" do
+      mock_models([
+        "gpt-4o-mini",
+        "o3",
+        "gpt-4o",
+        "gpt-5.4",
+        "gpt-5.2-pro",
+        "gpt-5-mini",
+        "gpt-5.6-luna"
+      ])
+
+      assert {:ok, models} = Kaapi.list_models_with_metadata(1)
+
+      assert Enum.map(models, & &1.model_name) == [
+               "gpt-5.6-luna",
+               "gpt-5-mini",
+               "gpt-5.4",
+               "gpt-5.2-pro",
+               "o3",
+               "gpt-4o",
+               "gpt-4o-mini"
+             ]
+    end
+
+    test "does not inject curated models that Kaapi did not return" do
+      mock_models(["gpt-4.1"])
+
+      assert {:ok, models} = Kaapi.list_models_with_metadata(1)
+      assert Enum.map(models, & &1.model_name) == ["gpt-4.1"]
+      refute Enum.any?(models, & &1.is_default)
+    end
+
+    test "propagates the error when the model list cannot be fetched" do
+      mock(fn %Tesla.Env{method: :get} ->
+        %Tesla.Env{status: 200, body: %{unexpected: "shape"}}
+      end)
+
+      assert {:error, reason} = Kaapi.list_models_with_metadata(1)
+      assert reason =~ "Unexpected Kaapi list_models response"
+    end
+  end
+
   describe "list_models/1 without kaapi configured" do
     test "returns error when Kaapi is not active for the organization" do
       Cachex.del(:glific_cache, {:global, {:kaapi_models, "openai"}})

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -386,14 +386,14 @@ defmodule Glific.ThirdParty.KaapiTest do
 
       assert {:ok, models} = Kaapi.list_models_with_metadata(1)
 
-      assert Enum.map(models, & &1.model_name) == [
-               "gpt-5.6-luna",
-               "gpt-5-mini",
-               "gpt-5.4",
-               "gpt-5.2-pro",
-               "o3",
-               "gpt-4o",
-               "gpt-4o-mini"
+      assert Enum.map(models, &{&1.model_name, &1.category, &1.badge}) == [
+               {"gpt-5.6-luna", "recommended", "Best value"},
+               {"gpt-5-mini", "recommended", "Budget"},
+               {"gpt-5.4", "recommended", "All-rounder"},
+               {"gpt-5.2-pro", "all", nil},
+               {"o3", "all", nil},
+               {"gpt-4o", "to_be_deprecated", "Deprecating"},
+               {"gpt-4o-mini", "to_be_deprecated", "Deprecating"}
              ]
     end
 
@@ -551,6 +551,51 @@ defmodule Glific.ThirdParty.KaapiTest do
       }
 
       assert {:ok, %{success: true, data: %{id: "asst_3", version: %{version: 1}}}} =
+               Kaapi.create_assistant_config(params, 1)
+    end
+
+    test "falls back to the default model when the caller supplies none" do
+      Cachex.del(:glific_cache, {:global, {:kaapi_models, "openai"}})
+
+      mock(fn
+        %Tesla.Env{method: :get} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              data: %{
+                data: [
+                  %{
+                    provider: "openai",
+                    model_name: Kaapi.default_model(),
+                    config: %{temperature: %{default: 1}}
+                  }
+                ]
+              }
+            }
+          }
+
+        %Tesla.Env{method: :post, body: body} ->
+          decoded_body = Jason.decode!(body)
+
+          assert decoded_body["config_blob"]["completion"]["params"]["model"] ==
+                   Kaapi.default_model()
+
+          %Tesla.Env{
+            status: 200,
+            body: %{success: true, data: %{id: "asst_6", version: %{version: 1}}, metadata: %{}}
+          }
+      end)
+
+      params = %{
+        name: "Default Model Assistant",
+        model: nil,
+        prompt: "You are a helpful assistant",
+        description: "Assistant configuration",
+        knowledge_base_ids: [],
+        settings: %{}
+      }
+
+      assert {:ok, %{success: true, data: %{id: "asst_6", version: %{version: 1}}}} =
                Kaapi.create_assistant_config(params, 1)
     end
 

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -360,20 +360,20 @@ defmodule Glific.ThirdParty.KaapiTest do
       end)
     end
 
-    test "annotates recommended, all and deprecated models" do
+    test "annotates recommended, all and to-be-deprecated models" do
       mock_models(["gpt-4o", "gpt-4.1", "gpt-5-nano", "gpt-5.6-luna"])
 
       assert {:ok, models} = Kaapi.list_models_with_metadata(1)
 
-      assert Enum.map(models, &{&1.model_name, &1.category, &1.badge, &1.is_default}) == [
-               {"gpt-5.6-luna", "recommended", "Best value", true},
-               {"gpt-5-nano", "recommended", "Fastest", false},
-               {"gpt-4.1", "all", nil, false},
-               {"gpt-4o", "deprecated", "Deprecating", false}
+      assert Enum.map(models, &{&1.model_name, &1.category, &1.badge}) == [
+               {"gpt-5.6-luna", "recommended", "Best value"},
+               {"gpt-5-nano", "recommended", "Fastest"},
+               {"gpt-4.1", "all", nil},
+               {"gpt-4o", "to_be_deprecated", "Deprecating"}
              ]
     end
 
-    test "orders recommended by the curated order, then all alphabetically, then deprecated" do
+    test "orders recommended by the curated order, then all alphabetically, then to-be-deprecated" do
       mock_models([
         "gpt-4o-mini",
         "o3",
@@ -402,7 +402,10 @@ defmodule Glific.ThirdParty.KaapiTest do
 
       assert {:ok, models} = Kaapi.list_models_with_metadata(1)
       assert Enum.map(models, & &1.model_name) == ["gpt-4.1"]
-      refute Enum.any?(models, & &1.is_default)
+    end
+
+    test "keeps the default model unchanged until the recommended list is adopted" do
+      assert Kaapi.default_model() == "gpt-4o"
     end
 
     test "propagates the error when the model list cannot be fetched" do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1491,9 +1491,8 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       assert {:ok, [model]} = AIEvaluations.list_kaapi_models(nil, %{}, resolution)
       assert model.model_name == "gpt-4o"
-      assert model.category == "deprecated"
+      assert model.category == "to_be_deprecated"
       assert model.badge == "Deprecating"
-      refute model.is_default
     end
   end
 

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -1491,6 +1491,9 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       assert {:ok, [model]} = AIEvaluations.list_kaapi_models(nil, %{}, resolution)
       assert model.model_name == "gpt-4o"
+      assert model.category == "deprecated"
+      assert model.badge == "Deprecating"
+      refute model.is_default
     end
   end
 


### PR DESCRIPTION
## Summary
 Target issue is #5634

The model dropdown currently lists the entire Kaapi catalog as a flat list, which makes it hard for NGOs to choose a model. This annotates each model returned by Kaapi so the frontend can partition the dropdown into **Recommended**, **All models** and **To be deprecated**.

| Category | Models | Badge |
|---|---|---|
| Recommended | `gpt-5.6-luna` | Best value |
| | `gpt-5-nano` | Fastest |
| | `gpt-5-mini` | Budget |
| | `gpt-5.6-terra` | All-rounder |
| | `gpt-5.4` | All-rounder |
| To be deprecated | `gpt-4o`, `gpt-4o-mini` | Deprecating |
| All models | everything else Kaapi returns | — |

`kaapiModels` gains exactly two fields — `category` (`recommended` / `all` / `to_be_deprecated`) and `badge` — with models ordered recommended (curated order) → all (alphabetical) → to-be-deprecated, so the frontend can group consecutive runs without sorting.

`to_be_deprecated` rather than `deprecated`: these models still work, and the badge is a prompt to migrate soon rather than a statement that they have already been removed.

### Design notes

- **`list_models/1` is unchanged.** It has a second caller (`kaapi.ex:355`, deriving effort/temperature defaults) and it backs a 6h global cache. Enrichment happens on read via a new `list_models_with_metadata/1`, so changing the curated list takes effect without a cache flush.
- **Annotate only, never inject.** A curated model that Kaapi does not return will not appear in the dropdown, so a stale curated name fails safe rather than offering a model the provider will not serve.
- **No `isDefault` field.** A boolean that is true on exactly one row models a scalar as a column. The list is already ordered with the recommended models first, so the frontend picks the preselection from it.

### The default model is deliberately unchanged

Requirement 5 (make `gpt-5.6-luna` the default selection) is **not** implemented here. `Glific.Assistants` had a hardcoded `@default_model "gpt-4o"` used whenever a caller supplies no model, and changing it would alter what every such assistant is persisted with — a breaking change that does not belong in a dropdown-presentation PR.

Instead the constant moved to `Kaapi.default_model/0`, still returning `gpt-4o`, so making the switch later is a one-line change in one file. Runtime behaviour is identical to `master`.

Note the visible consequence: until that switch, the preselected model is one the dropdown also badges "Deprecating".

### Not included

- **Requirement 5** — default selection, deferred as above.
- **Requirement 6** (link to the model compare page) is a single static URL rather than per-model data, so it belongs in the frontend as a constant — no backend field added.
- **Requirement 1's helper text** ("where the model is best suited for"): the designs show badges only, so this ships badge-only. Send the five helper strings and I'll add a field for them.

## Checklist
  Before submitting a pull request, please ensure that you mark these task.

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Notes

No new API — this extends the existing `kaapiModels` query, and `assets/gql/ai_evaluations/list_kaapi_models.gql` is updated to match.

Verification: 216 tests pass across `assistants_test.exs`, `kaapi_test.exs` and `ai_evaluations_test.exs`; `mix format --check-formatted` and `mix credo --strict` are clean (the one remaining strict suggestion pre-exists on `master` in an unrelated file).

New tests cover category annotation, ordering across all three buckets, curated-but-absent models not being injected, the default model staying at `gpt-4o`, and error propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)