### PR TITLE
feat(evaluationv2): filter evaluation history by dataset

### DIFF
--- a/lib/glific/ai_evaluations.ex
+++ b/lib/glific/ai_evaluations.ex
@@ -241,6 +241,9 @@ defmodule Glific.AIEvaluations do
     Enum.reduce(filter, query, fn
       {:name, name}, query ->
         where(query, [e], ilike(e.name, ^"%#{name}%"))
+
+      {:golden_qa_id, golden_qa_id}, query ->
+        where(query, [e], e.golden_qa_id == ^golden_qa_id)
     end)
   end
 

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -52,6 +52,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
 
   input_object :ai_evaluation_filter do
     field :name, :string
+    field :golden_qa_id, :id
   end
 
   input_object :golden_qa_filter do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -37,6 +37,18 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert {:ok, evaluations} = AIEvaluations.list_ai_evaluations(nil, args, resolution)
       assert Enum.any?(evaluations, fn e -> e.id == evaluation.id end)
     end
+
+    test "filters by golden_qa_id", %{staff: user, evaluation: evaluation} do
+      resolution = %{context: %{current_user: user}}
+      args = %{filter: %{golden_qa_id: to_string(evaluation.golden_qa_id)}}
+
+      assert {:ok, evaluations} = AIEvaluations.list_ai_evaluations(nil, args, resolution)
+      assert Enum.any?(evaluations, fn e -> e.id == evaluation.id end)
+
+      other_args = %{filter: %{golden_qa_id: evaluation.golden_qa_id + 1}}
+
+      assert {:ok, []} = AIEvaluations.list_ai_evaluations(nil, other_args, resolution)
+    end
   end
 
   describe "count_ai_evaluations/3" do


### PR DESCRIPTION
## Summary

Evaluation history could only be filtered by name. Kaapi's `GET /api/v1/evaluations` supports `dataset_id`, but Glific's `aiEvaluations` / `countAiEvaluations` had no equivalent — so the frontend cannot scope the history list to a single dataset.

Adds `golden_qa_id` to `AiEvaluationFilter`:

```elixir
# lib/glific_web/schema/ai_evaluation_types.ex
input_object :ai_evaluation_filter do
  field :name, :string
  field :golden_qa_id, :id
end

# lib/glific/ai_evaluations.ex — filter_with/2
{:golden_qa_id, golden_qa_id}, query ->
  where(query, [e], e.golden_qa_id == ^golden_qa_id)
```

**Why `golden_qa_id` and not Kaapi's `dataset_id`:** `ai_evaluations` is a local table with a `golden_qa_id` FK, so this is a plain indexed equality on the table already being queried — no join, no proxy call to Kaapi. `evaluation_input` already takes `golden_qa_id`, so the frontend has the value in hand.

`list_ai_evaluations` and `count_ai_evaluations` both route through the same `filter_with/2`, so list and count stay consistent with one clause. No `.gql` changes needed — both operations already declare `$filter: AiEvaluationFilter`.

No migration: FK equality on a small org-scoped table, and `Repo.prepare_query/3` already blocks a cross-org `golden_qa_id` from returning rows.

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.