### PR TITLE
fix(bigquery): stop the duplicate-removal query from timing out early

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -81,7 +81,7 @@ config :glific, :bigquery_dedup_timeout_ms, env!("BIGQUERY_DEDUP_TIMEOUT_MS", :i
 
 config :glific,
        :bigquery_dedup_recv_timeout_ms,
-       env!("BIGQUERY_DEDUP_RECV_TIMEOUT_MS", :integer, 15_000)
+       env!("BIGQUERY_DEDUP_RECV_TIMEOUT_MS", :integer, 150_000)
 
 # AppSignal configs
 config :appsignal, :config,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -77,6 +77,10 @@ config :glific,
 
 config :glific, :max_rate_limit_request, env!("MAX_RATE_LIMIT_REQUEST", :integer, 180)
 
+config :glific,
+  :bigquery_dedup_recv_timeout_ms,
+  env!("BIGQUERY_DEDUP_RECV_TIMEOUT_MS", :integer, 120_000)
+
 # AppSignal configs
 config :appsignal, :config,
   otp_app: :glific,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -77,9 +77,11 @@ config :glific,
 
 config :glific, :max_rate_limit_request, env!("MAX_RATE_LIMIT_REQUEST", :integer, 180)
 
+config :glific, :bigquery_dedup_timeout_ms, env!("BIGQUERY_DEDUP_TIMEOUT_MS", :integer, 120_000)
+
 config :glific,
-  :bigquery_dedup_recv_timeout_ms,
-  env!("BIGQUERY_DEDUP_RECV_TIMEOUT_MS", :integer, 120_000)
+       :bigquery_dedup_recv_timeout_ms,
+       env!("BIGQUERY_DEDUP_RECV_TIMEOUT_MS", :integer, 15_000)
 
 # AppSignal configs
 config :appsignal, :config,

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -1074,7 +1074,7 @@ defmodule Glific.BigQuery do
           url: "/bigquery/v2/projects/#{URI.encode(project_id, &URI.char_unreserved?/1)}/queries",
           method: :post,
           body: %{query: sql, useLegacySql: false, timeoutMs: 120_000},
-          opts: [adapter: [recv_timeout: 130_000]]
+          opts: [adapter: [recv_timeout: bigquery_dedup_recv_timeout_ms()]]
         )
         |> Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
         |> handle_duplicate_removal_job_error(table, credentials, organization_id)
@@ -1085,6 +1085,10 @@ defmodule Glific.BigQuery do
         :ok
     end
   end
+
+  @spec bigquery_dedup_recv_timeout_ms() :: pos_integer()
+  defp bigquery_dedup_recv_timeout_ms,
+    do: Application.get_env(:glific, :bigquery_dedup_recv_timeout_ms, 120_000)
 
   @spec generate_duplicate_removal_query(String.t(), map(), non_neg_integer) :: String.t()
   defp generate_duplicate_removal_query(table, credentials, organization_id) do

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -79,6 +79,8 @@ defmodule Glific.BigQuery do
     Connection
   }
 
+  alias GoogleApi.Gax.Response
+
   @bigquery_tables %{
     "contacts" => :contact_schema,
     "contact_histories" => :contact_history_schema,
@@ -1074,7 +1076,7 @@ defmodule Glific.BigQuery do
           body: %{query: sql, useLegacySql: false, timeoutMs: 120_000},
           opts: [adapter: [recv_timeout: 130_000]]
         )
-        |> GoogleApi.Gax.Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
+        |> Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
         |> handle_duplicate_removal_job_error(table, credentials, organization_id)
 
       _ ->

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -1069,11 +1069,11 @@ defmodule Glific.BigQuery do
         ## it to the actual request (its own `opts` param only reaches response decoding),
         ## so we call the connection's Tesla `request/2` directly here - the same connection
         ## and middleware `bigquery_jobs_query/4` uses internally - to set an explicit
-        ## `recv_timeout` that actually covers the 120s we're asking BigQuery for.
+        ## `recv_timeout`.
         Connection.request(conn,
           url: "/bigquery/v2/projects/#{URI.encode(project_id, &URI.char_unreserved?/1)}/queries",
           method: :post,
-          body: %{query: sql, useLegacySql: false, timeoutMs: 120_000},
+          body: %{query: sql, useLegacySql: false, timeoutMs: bigquery_dedup_query_timeout_ms()},
           opts: [adapter: [recv_timeout: bigquery_dedup_recv_timeout_ms()]]
         )
         |> Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
@@ -1086,9 +1086,13 @@ defmodule Glific.BigQuery do
     end
   end
 
+  @spec bigquery_dedup_query_timeout_ms() :: pos_integer()
+  defp bigquery_dedup_query_timeout_ms,
+    do: Application.get_env(:glific, :bigquery_dedup_timeout_ms, 120_000)
+
   @spec bigquery_dedup_recv_timeout_ms() :: pos_integer()
   defp bigquery_dedup_recv_timeout_ms,
-    do: Application.get_env(:glific, :bigquery_dedup_recv_timeout_ms, 120_000)
+    do: Application.get_env(:glific, :bigquery_dedup_recv_timeout_ms, 15_000)
 
   @spec generate_duplicate_removal_query(String.t(), map(), non_neg_integer) :: String.t()
   defp generate_duplicate_removal_query(table, credentials, organization_id) do

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -1092,7 +1092,7 @@ defmodule Glific.BigQuery do
 
   @spec bigquery_dedup_recv_timeout_ms() :: pos_integer()
   defp bigquery_dedup_recv_timeout_ms,
-    do: Application.get_env(:glific, :bigquery_dedup_recv_timeout_ms, 15_000)
+    do: Application.get_env(:glific, :bigquery_dedup_recv_timeout_ms, 150_000)
 
   @spec generate_duplicate_removal_query(String.t(), map(), non_neg_integer) :: String.t()
   defp generate_duplicate_removal_query(table, credentials, organization_id) do

--- a/lib/glific/third_party/bigquery/bigquery.ex
+++ b/lib/glific/third_party/bigquery/bigquery.ex
@@ -1061,10 +1061,20 @@ defmodule Glific.BigQuery do
 
         sql = generate_duplicate_removal_query(table, credentials, organization_id)
 
-        ## timeout takes some time to delete the old records. So increasing the timeout limit.
-        GoogleApi.BigQuery.V2.Api.Jobs.bigquery_jobs_query(conn, project_id,
-          body: %{query: sql, useLegacySql: false, timeoutMs: 120_000}
+        ## `timeoutMs` below only bounds how long BigQuery's own server is allowed to keep
+        ## running the query - it has no effect on how long our own HTTP client waits for
+        ## the response. `Api.Jobs.bigquery_jobs_query/4` never forwards an `opts:` you pass
+        ## it to the actual request (its own `opts` param only reaches response decoding),
+        ## so we call the connection's Tesla `request/2` directly here - the same connection
+        ## and middleware `bigquery_jobs_query/4` uses internally - to set an explicit
+        ## `recv_timeout` that actually covers the 120s we're asking BigQuery for.
+        Connection.request(conn,
+          url: "/bigquery/v2/projects/#{URI.encode(project_id, &URI.char_unreserved?/1)}/queries",
+          method: :post,
+          body: %{query: sql, useLegacySql: false, timeoutMs: 120_000},
+          opts: [adapter: [recv_timeout: 130_000]]
         )
+        |> GoogleApi.Gax.Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
         |> handle_duplicate_removal_job_error(table, credentials, organization_id)
 
       _ ->

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -173,7 +173,7 @@ defmodule Glific.BigQueryTest do
       }
     ]) do
       Tesla.Mock.mock(fn %{method: :post} = env ->
-        assert env.opts[:adapter][:recv_timeout] == 15_000
+        assert env.opts[:adapter][:recv_timeout] == 150_000
         assert Jason.decode!(env.body)["timeoutMs"] == 120_000
         assert env.url =~ "/queries"
 

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -159,6 +159,31 @@ defmodule Glific.BigQueryTest do
     end
   end
 
+  test "make_job_to_remove_duplicate/2 should override Hackney's default recv_timeout",
+       attrs do
+    with_mocks([
+      {
+        Goth.Token,
+        [:passthrough],
+        [
+          fetch: fn _url ->
+            {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+          end
+        ]
+      }
+    ]) do
+      Tesla.Mock.mock(fn %{method: :post} = env ->
+        assert env.opts[:adapter][:recv_timeout] == 130_000
+        assert env.url =~ "/queries"
+        assert Jason.decode!(env.body)["timeoutMs"] == 120_000
+
+        %Tesla.Env{status: 200}
+      end)
+
+      assert :ok == BigQuery.make_job_to_remove_duplicate("messages", attrs.organization_id)
+    end
+  end
+
   test "handle_insert_query_response/3 should raise error", attrs do
     assert_raise RuntimeError, fn ->
       BigQuery.handle_insert_query_response(

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -173,7 +173,7 @@ defmodule Glific.BigQueryTest do
       }
     ]) do
       Tesla.Mock.mock(fn %{method: :post} = env ->
-        assert env.opts[:adapter][:recv_timeout] == 130_000
+        assert env.opts[:adapter][:recv_timeout] == 120_000
         assert env.url =~ "/queries"
         assert Jason.decode!(env.body)["timeoutMs"] == 120_000
 

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -173,9 +173,9 @@ defmodule Glific.BigQueryTest do
       }
     ]) do
       Tesla.Mock.mock(fn %{method: :post} = env ->
-        assert env.opts[:adapter][:recv_timeout] == 120_000
-        assert env.url =~ "/queries"
+        assert env.opts[:adapter][:recv_timeout] == 15_000
         assert Jason.decode!(env.body)["timeoutMs"] == 120_000
+        assert env.url =~ "/queries"
 
         %Tesla.Env{status: 200}
       end)


### PR DESCRIPTION
### Root cause
```
GoogleApi.BigQuery.V2.Api.Jobs.bigquery_jobs_query(conn, project_id,
  body: %{query: sql, useLegacySql: false, timeoutMs: 120_000}
)
```

- timeoutMs: 120_000 only tells BigQuery's own server how long it may keep running the query — it has no effect on how long our own HTTP client waits for a response. The call passes no explicit recv_timeout, so it silently fell back to Hackney's short default, which aborts and reports :timeout well before BigQuery's 120-second allowance is ever used.
- The obvious-looking fix — passing opts: [adapter: [recv_timeout: ...]] as the 4th argument to bigquery_jobs_query/4 — doesn't actually work: that function only forwards its opts argument to Response.decode/2 (response parsing, which runs after the request already completed), never to the request itself. There's no way to set a per-call adapter timeout through that generated function as written.

### Fix

- Call the connection's own Tesla request/2 directly (bypassing the generated bigquery_jobs_query/4 wrapper for just this one call), which does respect opts: [adapter: [recv_timeout: ...]] — the same mechanism every other timeout-sensitive Tesla call in this codebase already uses:

```
Connection.request(conn,
  url: "/bigquery/v2/projects/#{URI.encode(project_id, &URI.char_unreserved?/1)}/queries",
  method: :post,
  body: %{query: sql, useLegacySql: false, timeoutMs: 120_000},
  opts: [adapter: [recv_timeout: 130_000]]
)
|> GoogleApi.Gax.Response.decode(struct: %GoogleApi.BigQuery.V2.Model.QueryResponse{})
```

- 130_000 leaves a 10-second margin over the 120-second budget already requested from BigQuery. This is scoped to only this one expensive call — every other BigQuery call, and every other integration in the app, is unaffected.
