### PR TITLE
feat(web-channel): add per-org web_channel_enabled feature flag

### DIFF
--- a/assets/gql/organizations/get_services.gql
+++ b/assets/gql/organizations/get_services.gql
@@ -18,6 +18,7 @@ query organizationServices {
     template_v2_enabled
     template_library_enabled
     glific_ai_enabled
+    web_channel_enabled
     errors {
       key
       message

--- a/lib/glific/misc/flags.ex
+++ b/lib/glific/misc/flags.ex
@@ -528,7 +528,8 @@ defmodule Glific.Flags do
       :is_prompt_generator_enabled,
       :is_template_v2_enabled,
       :is_template_library_enabled,
-      :glific_ai_enabled
+      :glific_ai_enabled,
+      :web_channel_enabled
     ]
     |> Enum.each(fn flag ->
       if !FunWithFlags.enabled?(

--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -598,6 +598,7 @@ defmodule Glific.Partners do
       |> Flags.set_flag_enabled(:is_template_v2_enabled)
       |> Flags.set_flag_enabled(:is_template_library_enabled)
       |> Flags.set_flag_enabled(:glific_ai_enabled)
+      |> Flags.set_flag_enabled(:web_channel_enabled)
 
     Caches.set(
       @global_organization_id,
@@ -1502,7 +1503,8 @@ defmodule Glific.Partners do
       "template_v2_enabled" => Flags.get_flag_enabled(:is_template_v2_enabled, organization),
       "template_library_enabled" =>
         Flags.get_flag_enabled(:is_template_library_enabled, organization),
-      "glific_ai_enabled" => Flags.get_flag_enabled(:glific_ai_enabled, organization)
+      "glific_ai_enabled" => Flags.get_flag_enabled(:glific_ai_enabled, organization),
+      "web_channel_enabled" => Flags.get_flag_enabled(:web_channel_enabled, organization)
     }
   end
 

--- a/lib/glific/partners/organization.ex
+++ b/lib/glific/partners/organization.ex
@@ -208,6 +208,9 @@ defmodule Glific.Partners.Organization do
     # A virtual field to conditionally enable Glific AI for an organization
     field(:glific_ai_enabled, :boolean, default: false, virtual: true)
 
+    # A virtual field to conditionally enable the web channel for an organization
+    field(:web_channel_enabled, :boolean, default: false, virtual: true)
+
     timestamps(type: :utc_datetime)
   end
 

--- a/lib/glific_web/schema/organization_types.ex
+++ b/lib/glific_web/schema/organization_types.ex
@@ -38,6 +38,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:template_v2_enabled, :boolean)
     field(:template_library_enabled, :boolean)
     field(:glific_ai_enabled, :boolean)
+    field(:web_channel_enabled, :boolean)
   end
 
   object :organization_export_result do
@@ -154,6 +155,7 @@ defmodule GlificWeb.Schema.OrganizationTypes do
     field(:is_template_v2_enabled, :boolean)
     field(:is_template_library_enabled, :boolean)
     field(:glific_ai_enabled, :boolean)
+    field(:web_channel_enabled, :boolean)
 
     field(:inserted_at, :datetime)
 

--- a/test/glific_web/schema/organization_test.exs
+++ b/test/glific_web/schema/organization_test.exs
@@ -646,6 +646,7 @@ defmodule GlificWeb.Schema.OrganizationTest do
     assert services["template_library_enabled"] == false
     assert services["ai_evaluation_v2_enabled"] == false
     assert services["glific_ai_enabled"] == false
+    assert services["web_channel_enabled"] == false
   end
 
   test "update an organization with organization settings", %{user: user} do


### PR DESCRIPTION
Part of #5660 · Epic #5659

## What this does

Adds a per-organisation feature flag, `web_channel_enabled`, so the web channel can be turned on
one organisation at a time. **Nothing reads the flag yet** — later PRs in #5660 do. No behaviour
changes for anyone.

This is the feature-flag half of #5660; the `messages.channel` / `flow_contexts.channel` columns
and their migrations ship separately so the schema change can be deployed and soaked on its own.

## Approach

Wired exactly like `glific_ai_enabled` (703a9574c) — same six files, same shape, same diff size:

| File | Change |
|---|---|
| `lib/glific/misc/flags.ex` | flag added to `init_fun_with_flags/1` so it initialises disabled for every org |
| `lib/glific/partners.ex` | `set_flag_enabled(:web_channel_enabled)` in the `fill_cache/1` pipeline; `"web_channel_enabled"` in `get_org_services_by_id/1` |
| `lib/glific/partners/organization.ex` | virtual boolean field, `default: false` |
| `lib/glific_web/schema/organization_types.ex` | field on `:organization_services` and `:organization` |
| `assets/gql/organizations/get_services.gql` | field added to the services query |
| `test/glific_web/schema/organization_test.exs` | asserts the service reads `false` by default |

The flag is **off by default in every environment** and is enabled per organisation, explicitly.
There is no `trusted_env?`-style auto-enable and no per-flag wrapper: per `lib/glific/CLAUDE.md`,
a function that only forwards to `get_flag_enabled`/`set_flag_enabled` is redundant, so the
generic helpers are called inline at both call sites.

## Testing

- `mix compile --warnings-as-errors` clean
- `mix credo --strict` on the changed files — no issues
- `mix format --check-formatted` clean
- `mix test test/glific_web/schema/organization_test.exs test/glific/flags_test.exs test/glific/partners/partners_test.exs` — **138 tests, 0 failures**

> Note for anyone running the suite from a cold database: plain `mix test` fails everything with
> `Ecto.NoResultsError` on org 1 because it does not seed. `mix test_full` is what to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JqHf9PqoGCW27fcNbQnnT
