### PR TITLE
  fix(poolboy): raise message pool overflow/checkout timeout and make them configurable

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -58,6 +58,11 @@ config :glific, Glific.RepoReplica,
 
 config :glific, :hackney_pool, max_connections: env!("HACKNEY_POOL_SIZE", :integer, 50)
 
+config :glific, Poolboy,
+  size: env!("MESSAGE_POOL_SIZE", :integer, 10),
+  max_overflow: env!("MESSAGE_POOL_MAX_OVERFLOW", :integer, 20),
+  checkout_timeout: env!("MESSAGE_POOL_CHECKOUT_TIMEOUT", :integer, 30_000)
+
 check_origin = [env!("REQUEST_ORIGIN", :string!), env!("REQUEST_ORIGIN_WILDCARD", :string!)]
 
 # Glific endpoint configs

--- a/lib/glific/application.ex
+++ b/lib/glific/application.ex
@@ -99,8 +99,8 @@ defmodule Glific.Application do
     [
       name: {:local, message_poolname()},
       worker_module: worker,
-      size: 10,
-      max_overflow: 10,
+      size: opts[:size] || 10,
+      max_overflow: opts[:max_overflow] || 20,
       # we are using the fifo strategy, so the state of all the consumer workers
       # are filled when the load gets high
       strategy: :fifo

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -406,7 +406,8 @@ defmodule Glific.Communications.Message do
   defp publish_simulator(message, _type), do: message
 
   # how long to wait for a free worker from the poolboy pool before giving up
-  @poolboy_checkout_timeout 25_000
+  defp poolboy_checkout_timeout,
+    do: Application.get_env(:glific, Poolboy)[:checkout_timeout] || 30_000
 
   # time budget for the genserver worker to process a single message through its flow
   # steps; chained flows via enter_flow can legitimately take more than a few seconds
@@ -464,7 +465,7 @@ defmodule Glific.Communications.Message do
           fn pid ->
             GenServer.call(pid, {message, process_state, self}, @genserver_call_timeout)
           end,
-          @poolboy_checkout_timeout
+          poolboy_checkout_timeout()
         )
       catch
         # A poolboy checkout timeout means every worker was busy — the pool is the bottleneck.

--- a/lib/glific/communications/message.ex
+++ b/lib/glific/communications/message.ex
@@ -407,7 +407,7 @@ defmodule Glific.Communications.Message do
 
   # how long to wait for a free worker from the poolboy pool before giving up
   defp poolboy_checkout_timeout,
-    do: Application.get_env(:glific, Poolboy)[:checkout_timeout] || 30_000
+    do: Application.get_env(:glific, Poolboy)[:checkout_timeout]
 
   # time budget for the genserver worker to process a single message through its flow
   # steps; chained flows via enter_flow can legitimately take more than a few seconds


### PR DESCRIPTION
### Changes
- `config/runtime.exs` — new `config :glific, Poolboy` block reading the three env vars. Deep-merges with the existing `config/test.exs` entry, so `worker: ConsumerWorkerMock` is  untouched in test.
- `lib/glific/application.ex` — `size:`/`max_overflow:` now read from that config (nil-safe, so the existing unset-key path still works).
- `lib/glific/communications/message.ex` — `@poolboy_checkout_timeout` replaced by a private function reading the config; a module attribute can never see runtime config.