### PR TITLE
fix: Encode structured profile field values for BigQuery

### DIFF
--- a/lib/glific/third_party/bigquery/bigquery_worker.ex
+++ b/lib/glific/third_party/bigquery/bigquery_worker.ex
@@ -1077,15 +1077,7 @@ defmodule Glific.BigQuery.BigQueryWorker do
             language: row.language.label,
             is_default: row.is_default,
             is_active: row.is_active,
-            fields:
-              Enum.map(row.fields, fn {_key, field} ->
-                %{
-                  label: field["label"],
-                  inserted_at: BigQuery.format_date(field["inserted_at"], organization_id),
-                  type: field["type"],
-                  value: field["value"]
-                }
-              end)
+            fields: process_row(row, organization_id)
           }
           |> Map.merge(bq_fields(organization_id))
           |> then(&%{json: &1})

--- a/test/glific/bigquery_test.exs
+++ b/test/glific/bigquery_test.exs
@@ -702,6 +702,103 @@ defmodule Glific.BigQueryTest do
     end
   end
 
+  test "queue_table_data/3 encodes structured profile field values", %{
+    organization_id: organization_id
+  } do
+    field_inserted_at = "2026-09-02T12:34:56Z"
+
+    profile =
+      profile_fixture(%{
+        "fields" => %{
+          "interests" => %{
+            "label" => "Interests",
+            "inserted_at" => field_inserted_at,
+            "type" => "array",
+            "value" => ["health", "education"]
+          },
+          "preferences" => %{
+            "label" => "Preferences",
+            "inserted_at" => field_inserted_at,
+            "type" => "object",
+            "value" => %{"enabled" => true, "level" => 3}
+          },
+          "nickname" => %{
+            "label" => "Nickname",
+            "inserted_at" => field_inserted_at,
+            "type" => "string",
+            "value" => "Max"
+          }
+        }
+      })
+
+    test_pid = self()
+
+    with_mocks([
+      {
+        Goth.Token,
+        [:passthrough],
+        [
+          fetch: fn _url ->
+            {:ok, %{token: "0xFAKETOKEN_Q=", expires: System.system_time(:second) + 120}}
+          end
+        ]
+      }
+    ]) do
+      url =
+        "https://bigquery.googleapis.com/bigquery/v2/projects/DEFAULTPROJECTID/datasets/917834811114/tables/profiles/insertAll"
+
+      Tesla.Mock.mock(fn
+        %Tesla.Env{method: :post, url: ^url} = env ->
+          send(test_pid, {:profiles_insert_body, Jason.decode!(env.body)})
+
+          %Tesla.Env{
+            status: 200,
+            body:
+              Poison.encode!(%GoogleApi.BigQuery.V2.Model.TableDataInsertAllResponse{
+                kind: "bigquery#tableDataInsertAllResponse",
+                insertErrors: nil
+              })
+          }
+      end)
+
+      assert :ok ==
+               BigQueryWorker.queue_table_data("profiles", organization_id, %{
+                 some_attr: "value"
+               })
+
+      assert_receive {:profiles_insert_body, body}
+
+      profile_payload =
+        Enum.find(body["rows"], fn row -> row["json"]["id"] == profile.id end)["json"]
+
+      fields = Map.new(profile_payload["fields"], &{&1["label"], &1})
+      formatted_inserted_at = BigQuery.format_date(field_inserted_at, organization_id)
+
+      assert fields["Interests"] == %{
+               "inserted_at" => formatted_inserted_at,
+               "label" => "Interests",
+               "type" => "array",
+               "value" => ~s(["health","education"])
+             }
+
+      assert fields["Preferences"]["inserted_at"] == formatted_inserted_at
+      assert fields["Preferences"]["type"] == "object"
+      assert is_binary(fields["Preferences"]["value"])
+
+      assert Jason.decode!(fields["Preferences"]["value"]) == %{
+               "enabled" => true,
+               "level" => 3
+             }
+
+      assert fields["Nickname"] == %{
+               "inserted_at" => formatted_inserted_at,
+               "label" => "Nickname",
+               "type" => "string",
+               "value" => "Max"
+             }
+    end
+  end
+
   test "queue_table_data/3 should process and skip simulator contacts, ensuring table_id should be updated for flow_results table" do
     with_mocks([
       {


### PR DESCRIPTION
## Summary

Replace the duplicated inline field mapping in `queue_table_data("profiles", ...)` with the existing `process_row/2` helper so profile and contact fields share identical value normalization without adding a new abstraction. Extend `test/glific/bigquery_test.exs` with a profile containing list- and map-valued fields, drive the publicized queue path with the existing BigQuery HTTP mock pattern, and assert that the captured `profiles` insert payload contains JSON strings while scalar values remain unchanged. Keep the BigQuery schema unchanged because its `value` field is intentionally a scalar string and structured application values belong in that string as JSON.

The BigQuery `profiles` serializer currently copies each profile field's raw `value` into a non-repeated `STRING` column. List and map values therefore cause row-level insert errors and prevent the profile sync checkpoint from advancing, while scalar values already match the schema. The contacts serializer avoids this failure by routing fields through `process_row/2`, which preserves the same field map shape and JSON-encodes structured values through `format_value/1`. The fix should bring profiles onto that existing production path and add regression coverage for the generated BigQuery payload.

Fixes #5676

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

## Notes

Nothing beyond what is described above.
