### PR TITLE
Bump version from 8.11.0 to 8.12.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Glific.MixProject do
   def project do
     [
       app: :glific,
-      version: "8.11.0",
+      version: "8.12.0",
       elixir: "~> 1.18.3",
       elixirc_paths: elixirc_paths(Mix.env()),
       dialyzer: [


### PR DESCRIPTION
Version bump 8.11.0 -> 8.12.0, opened by bin/gigalixir-release.sh.