### PR TITLE
Add rate limiting configuration for gupshup Oban queue

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,14 @@ oban_queues = [
     ]
   ],
   gcs: 10,
-  gupshup: 10,
+  gupshup: [
+    local_limit: 30,
+    global_limit: [
+      allowed: 5,
+      burst: false,
+      partition: [args: :organization_id]
+    ]
+  ],
   webhook: [
     local_limit: 20,
     global_limit: [


### PR DESCRIPTION
Replace simple worker limit with local and global rate limiting, partitioned by organization_id to prevent one org from starving others.