### PR TITLE
Remove max_attempts limit from WakeupWorker

### DIFF
--- a/lib/glific/flows/wakeup_worker.ex
+++ b/lib/glific/flows/wakeup_worker.ex
@@ -8,7 +8,6 @@ defmodule Glific.Flows.WakeupWorker do
 
   use Oban.Worker,
     queue: :flow_wakeup,
-    max_attempts: 3,
     unique: [
       period: :infinity,
       fields: [:args, :worker],


### PR DESCRIPTION
## Summary
Removes the `max_attempts: 3` cap from `Glific.Flows.WakeupWorker`'s Oban job config, so wakeup-flow jobs fall back to Oban's default retry limit instead of being capped at 3 attempts.

## Checklist
- [ ] Ran `mix setup` in the repository root and test.
- [ ] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [ ] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

## Notes
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)