### PR TITLE
feet: Partition the gupshup outbound queue by organization

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -50,7 +50,14 @@ oban_queues = [
     ]
   ],
   gcs: 10,
-  gupshup: 10,
+  gupshup: [
+    local_limit: 20,
+    global_limit: [
+      allowed: 10,
+      burst: false,
+      partition: [args: :organization_id]
+    ]
+  ],
   webhook: [
     local_limit: 20,
     global_limit: [

--- a/lib/glific/providers/gupshup/message.ex
+++ b/lib/glific/providers/gupshup/message.ex
@@ -304,7 +304,14 @@ defmodule Glific.Providers.Gupshup.Message do
   defp create_oban_job(message, request_body, attrs) do
     attrs = to_minimal_map(attrs)
     worker_module = Communications.provider_worker(message.organization_id)
-    worker_args = %{message: Message.to_minimal_map(message), payload: request_body, attrs: attrs}
+    # organization_id is duplicated at the top level because Oban Pro builds the
+    # queue's partition key from top level arg keys only
+    worker_args = %{
+      message: Message.to_minimal_map(message),
+      payload: request_body,
+      attrs: attrs,
+      organization_id: message.organization_id
+    }
 
     worker_module.create_changeset(worker_args, scheduled_at: message.send_at)
     |> Oban.insert()

--- a/test/glific/communications_test.exs
+++ b/test/glific/communications_test.exs
@@ -407,6 +407,18 @@ defmodule Glific.CommunicationsTest do
     end
   end
 
+  test "outbound job args carry organization_id at the top level for queue partitioning",
+       %{global_schema: global_schema} = attrs do
+    message = message_fixture(attrs)
+
+    Communications.Message.send_message(message)
+
+    assert [job] = all_enqueued(queue: :gupshup, worker: Worker, prefix: global_schema)
+    assert job.args["organization_id"] == message.organization_id
+
+    assert job.args["organization_id"] == job.args["message"]["organization_id"]
+  end
+
   test "send message in high tps queue if flag enabled for the org",
        %{global_schema: global_schema} = attrs do
     FunWithFlags.enable(:high_trigger_tps_enabled,


### PR DESCRIPTION

## Summary

### Changes

**1. Partition the queue by organization** (`config/config.exs`)

```elixir
gupshup: [
  local_limit: 20,
  global_limit: [
    allowed: 10,
    burst: false,
    partition: [args: :organization_id]
  ]
],
```

-  Under contention each org is capped at 10 concurrent sends cluster-wide, so a surge queues behind its own allowance instead of the shared pool. `local_l orgs can run at full allowance without contending.