### PR TITLE
Refactor contact import process to use BulkImportWorker

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -74,7 +74,13 @@ oban_queues = [
       partition: [args: :organization_id]
     ]
   ],
-  contact_import: 10,
+  contact_import: [
+    local_limit: 10,
+    global_limit: [
+      allowed: 2,
+      partition: [args: :organization_id]
+    ]
+  ],
   gupshup_high_tps: 10,
   clone_assistant: 5,
   gupshup_inbound: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -81,7 +81,8 @@ oban_queues = [
       partition: [args: :organization_id]
     ]
   ],
-  contact_import: [
+  contact_import: 10,
+  contact_import_bulk: [
     local_limit: 10,
     global_limit: [
       allowed: 5,

--- a/config/config.exs
+++ b/config/config.exs
@@ -77,7 +77,7 @@ oban_queues = [
   contact_import: [
     local_limit: 10,
     global_limit: [
-      allowed: 2,
+      allowed: 5,
       partition: [args: :organization_id]
     ]
   ],

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -1,0 +1,492 @@
+defmodule Glific.Contacts.BulkImport do
+  @moduledoc """
+  Batched contact import.
+
+  Processes a whole chunk of CSV rows with a fixed number of SQL statements, rather than
+  one write per contact field. The previous path issued six to nine statements for every
+  field of every contact — an `UPDATE contacts`, a `contacts_fields` lookup, a
+  `contact_histories` insert and the two row triggers that insert fires — which row-locked
+  the contacts table for the duration of an import.
+
+  Everything here is expressed as a batch: one lookup of the existing contacts, one upsert,
+  one field-registry upsert, one history insert and one collection insert per chunk.
+  """
+  import Ecto.Query
+
+  alias Glific.{
+    Contacts,
+    Contacts.Contact,
+    Contacts.ContactHistory,
+    Contacts.ContactsField,
+    Contacts.Import,
+    Groups,
+    Groups.ContactGroup,
+    Repo,
+    Settings.Language
+  }
+
+  alias GlificWeb.Schema.Middleware.Authorize
+
+  @default_language "english"
+  @field_type "string"
+
+  @doc """
+  Import one chunk of CSV rows, returning a map of phone => error message for the rows
+  that could not be processed.
+  """
+  @spec process_chunk([map()], map()) :: map()
+  def process_chunk(rows, params) do
+    {errors, rows} = Import.validate_contacts(rows)
+    {deletes, rows} = Enum.split_with(rows, &(&1["delete"] == "1"))
+
+    errors = Enum.reduce(deletes, errors, &delete_contact(&1, params, &2))
+
+    existing = load_existing(rows)
+    {errors, rows} = reject_missing(rows, existing, errors, params.type)
+
+    languages = language_index()
+    params = Map.put(params, :language_labels, languages.labels)
+    now = DateTime.utc_now()
+
+    prepared =
+      rows
+      |> Enum.map(&prepare(&1, existing, languages, params))
+      |> dedupe()
+
+    saved = upsert_contacts(prepared, params, now)
+
+    upsert_field_registry(prepared, params, now)
+    insert_histories(prepared, saved, params, now)
+    link_collections(prepared, saved, params, now)
+
+    errors
+  end
+
+  @spec load_existing([map()]) :: map()
+  defp load_existing([]), do: %{}
+
+  defp load_existing(rows) do
+    phones = Enum.map(rows, & &1["phone"])
+
+    Contact
+    |> where([c], c.phone in ^phones)
+    |> select([c], %{
+      id: c.id,
+      phone: c.phone,
+      language_id: c.language_id,
+      optin_time: c.optin_time,
+      optout_time: c.optout_time,
+      last_message_at: c.last_message_at
+    })
+    |> Repo.all()
+    |> Map.new(&{&1.phone, &1})
+  end
+
+  @spec reject_missing([map()], map(), map(), String.t()) :: {map(), [map()]}
+  defp reject_missing(rows, existing, errors, "move_contact") do
+    Enum.reduce(rows, {errors, []}, fn row, {errors, keep} ->
+      phone = row["phone"]
+
+      if Map.has_key?(existing, phone),
+        do: {errors, [row | keep]},
+        else: {Map.put(errors, phone, "Contact #{phone} was not found and hence not added"), keep}
+    end)
+  end
+
+  defp reject_missing(rows, _existing, errors, _type), do: {errors, rows}
+
+  @spec language_index() :: map()
+  defp language_index do
+    languages =
+      Language
+      |> where([l], l.is_active == true)
+      |> order_by([l], asc: l.id)
+      |> select([l], %{id: l.id, label: l.label, locale: l.locale})
+      |> Repo.all(skip_organization_id: true)
+
+    lookup =
+      Enum.reduce(languages, %{}, fn language, acc ->
+        acc
+        |> put_new_downcased(language.label, language.id)
+        |> put_new_downcased(language.locale, language.id)
+      end)
+
+    %{
+      lookup: lookup,
+      labels: Map.new(languages, &{&1.id, &1.label}),
+      default_id: Map.fetch!(lookup, @default_language)
+    }
+  end
+
+  @spec put_new_downcased(map(), String.t() | nil, non_neg_integer()) :: map()
+  defp put_new_downcased(acc, nil, _id), do: acc
+  defp put_new_downcased(acc, key, id), do: Map.put_new(acc, String.downcase(key), id)
+
+  @spec prepare(map(), map(), map(), map()) :: map()
+  defp prepare(row, existing, languages, params) do
+    phone = row["phone"]
+    contact = Map.get(existing, phone)
+    fields = build_fields(row["contact_fields"])
+
+    %{
+      phone: phone,
+      name: row["name"],
+      language_id: language_id(row["language"], contact, languages),
+      fields: fields,
+      collections: collections(row["collection"]),
+      previous_language_id: contact && contact.language_id,
+      optin?: optin?(params, contact),
+      bsp_status: bsp_status(contact)
+    }
+  end
+
+  # Postgres rejects an ON CONFLICT DO UPDATE that touches the same row twice, so a csv
+  # listing a phone more than once has to be folded into a single row first. Merging the
+  # field maps in row order reproduces what the old per-row path did: the later row wins.
+  @spec dedupe([map()]) :: [map()]
+  defp dedupe(prepared) do
+    prepared
+    |> Enum.reduce(%{}, fn row, acc ->
+      Map.update(acc, row.phone, row, fn seen ->
+        %{
+          row
+          | fields: Map.merge(seen.fields, row.fields),
+            collections: Enum.uniq(seen.collections ++ row.collections)
+        }
+      end)
+    end)
+    |> Map.values()
+  end
+
+  @spec build_fields(map() | nil) :: map()
+  defp build_fields(nil), do: %{}
+
+  defp build_fields(fields) do
+    inserted_at = DateTime.utc_now()
+
+    fields
+    |> Enum.reject(fn {_label, value} -> value in [nil, ""] end)
+    |> Map.new(fn {label, value} ->
+      shortcode = Glific.string_snake_case(label) |> String.trim()
+
+      {shortcode,
+       %{
+         value: value,
+         label: shortcode,
+         type: @field_type,
+         inserted_at: inserted_at
+       }}
+    end)
+  end
+
+  @spec collections(String.t() | nil) :: [String.t()]
+  defp collections(collection) when collection in [nil, ""], do: []
+
+  defp collections(collection) do
+    collection
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+  end
+
+  @spec language_id(String.t() | nil, map() | nil, map()) :: non_neg_integer()
+  defp language_id(language, contact, languages) when language in [nil, ""] do
+    if contact, do: contact.language_id, else: languages.default_id
+  end
+
+  defp language_id(language, contact, languages) do
+    term = language |> String.trim() |> String.downcase()
+
+    case Map.get(languages.lookup, term) do
+      nil -> match_language_prefix(term, languages.lookup) || language_id(nil, contact, languages)
+      id -> id
+    end
+  end
+
+  @spec match_language_prefix(String.t(), map()) :: non_neg_integer() | nil
+  defp match_language_prefix(term, lookup) do
+    Enum.find_value(lookup, fn {key, id} ->
+      if String.starts_with?(key, term), do: id
+    end)
+  end
+
+  @spec optin?(map(), map() | nil) :: boolean()
+  defp optin?(%{type: "move_contact"}, _contact), do: false
+
+  defp optin?(params, contact) do
+    cond do
+      contact && contact.optin_time != nil -> false
+      contact && contact.optout_time != nil -> false
+      Authorize.valid_role?(params.user.roles, :manager) -> true
+      params.user.upload_contacts -> true
+      true -> false
+    end
+  end
+
+  @spec bsp_status(map() | nil) :: atom()
+  defp bsp_status(nil), do: :hsm
+
+  defp bsp_status(%{last_message_at: nil}), do: :hsm
+
+  defp bsp_status(%{last_message_at: last_message_at}) do
+    if Timex.compare(last_message_at, Glific.go_back_time(24)) > 0,
+      do: :session_and_hsm,
+      else: :hsm
+  end
+
+  @spec upsert_contacts([map()], map(), DateTime.t()) :: %{String.t() => non_neg_integer()}
+  defp upsert_contacts([], _params, _now), do: %{}
+
+  defp upsert_contacts(prepared, params, now) do
+    {optin, plain} = Enum.split_with(prepared, & &1.optin?)
+
+    Map.merge(
+      do_upsert(plain, params, now, false),
+      do_upsert(optin, params, now, true)
+    )
+  end
+
+  @spec do_upsert([map()], map(), DateTime.t(), boolean()) :: %{String.t() => non_neg_integer()}
+  defp do_upsert([], _params, _now, _optin?), do: %{}
+
+  defp do_upsert(rows, params, now, optin?) do
+    entries = Enum.map(rows, &contact_entry(&1, params, now, optin?))
+
+    {_count, saved} =
+      Repo.insert_all(Contact, entries,
+        on_conflict: on_conflict(optin?),
+        conflict_target: [:phone, :organization_id],
+        returning: [:id, :phone]
+      )
+
+    Map.new(saved, &{&1.phone, &1.id})
+  end
+
+  @spec contact_entry(map(), map(), DateTime.t(), boolean()) :: map()
+  defp contact_entry(row, params, now, false) do
+    %{
+      phone: row.phone,
+      name: row.name,
+      language_id: row.language_id,
+      fields: row.fields,
+      organization_id: params.organization_id,
+      inserted_at: now,
+      updated_at: now
+    }
+  end
+
+  defp contact_entry(row, params, now, true) do
+    row
+    |> contact_entry(params, now, false)
+    |> Map.merge(%{
+      optin_time: DateTime.truncate(now, :second),
+      optin_status: true,
+      optin_method: "Import",
+      optout_time: nil,
+      status: :valid,
+      bsp_status: row.bsp_status
+    })
+  end
+
+  @spec on_conflict(boolean()) :: Ecto.Query.t()
+  defp on_conflict(false) do
+    from(c in Contact,
+      update: [
+        set: [
+          name: fragment("EXCLUDED.name"),
+          language_id: fragment("EXCLUDED.language_id"),
+          fields: fragment("? || EXCLUDED.fields", c.fields),
+          updated_at: fragment("EXCLUDED.updated_at")
+        ]
+      ]
+    )
+  end
+
+  defp on_conflict(true) do
+    from(c in Contact,
+      update: [
+        set: [
+          name: fragment("EXCLUDED.name"),
+          language_id: fragment("EXCLUDED.language_id"),
+          fields: fragment("? || EXCLUDED.fields", c.fields),
+          updated_at: fragment("EXCLUDED.updated_at"),
+          optin_time: fragment("EXCLUDED.optin_time"),
+          optin_status: fragment("EXCLUDED.optin_status"),
+          optin_method: fragment("EXCLUDED.optin_method"),
+          optout_time: fragment("EXCLUDED.optout_time"),
+          status: fragment("EXCLUDED.status"),
+          bsp_status: fragment("EXCLUDED.bsp_status")
+        ]
+      ]
+    )
+  end
+
+  @spec upsert_field_registry([map()], map(), DateTime.t()) :: :ok
+  defp upsert_field_registry(prepared, params, now) do
+    now = DateTime.truncate(now, :second)
+
+    entries =
+      prepared
+      |> Enum.flat_map(&Map.keys(&1.fields))
+      |> Enum.uniq()
+      |> Enum.map(
+        &%{
+          name: &1,
+          shortcode: &1,
+          value_type: :text,
+          scope: :contact,
+          organization_id: params.organization_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      )
+
+    Repo.insert_all(ContactsField, entries, on_conflict: :nothing)
+    :ok
+  end
+
+  @spec insert_histories([map()], map(), map(), DateTime.t()) :: :ok
+  defp insert_histories(prepared, saved, params, now) do
+    entries = Enum.flat_map(prepared, &history_entries(&1, saved, params, now))
+
+    Repo.insert_all(ContactHistory, entries)
+    :ok
+  end
+
+  @spec history_entries(map(), map(), map(), DateTime.t()) :: [map()]
+  defp history_entries(row, saved, params, now) do
+    case Map.get(saved, row.phone) do
+      nil ->
+        []
+
+      contact_id ->
+        [
+          fields_history(row, contact_id, params, now),
+          language_history(row, contact_id, params, now),
+          optin_history(row, contact_id, params, now)
+        ]
+        |> Enum.reject(&is_nil/1)
+    end
+  end
+
+  @spec fields_history(map(), non_neg_integer(), map(), DateTime.t()) :: map() | nil
+  defp fields_history(%{fields: fields}, _contact_id, _params, _now) when map_size(fields) == 0,
+    do: nil
+
+  defp fields_history(row, contact_id, params, now) do
+    shortcodes = Map.keys(row.fields)
+
+    history(contact_id, params, now, "contact_fields_updated", %{
+      event_label:
+        "Updated #{length(shortcodes)} fields via import: #{Enum.join(shortcodes, ", ")}",
+      event_meta: %{
+        fields:
+          Map.new(row.fields, fn {shortcode, field} ->
+            {shortcode, %{label: field.label, value: field.value}}
+          end)
+      }
+    })
+  end
+
+  @spec language_history(map(), non_neg_integer(), map(), DateTime.t()) :: map() | nil
+  defp language_history(%{previous_language_id: previous, language_id: current}, _id, _p, _now)
+       when is_nil(previous) or previous == current,
+       do: nil
+
+  defp language_history(row, contact_id, params, now) do
+    labels = params.language_labels
+    old_label = Map.get(labels, row.previous_language_id)
+    new_label = Map.get(labels, row.language_id)
+
+    history(contact_id, params, now, "contact_language_updated", %{
+      event_label: "Changed contact language to #{new_label} from #{old_label}, via import.",
+      event_meta: %{
+        language: %{
+          id: row.language_id,
+          label: new_label,
+          old_language: row.previous_language_id
+        }
+      }
+    })
+  end
+
+  @spec optin_history(map(), non_neg_integer(), map(), DateTime.t()) :: map() | nil
+  defp optin_history(%{optin?: false}, _contact_id, _params, _now), do: nil
+
+  defp optin_history(_row, contact_id, params, now) do
+    history(contact_id, params, now, "contact_opted_in", %{
+      event_label: "contact opted in, via Import",
+      event_meta: %{method: "Import", utc_time: now}
+    })
+  end
+
+  @spec history(non_neg_integer(), map(), DateTime.t(), String.t(), map()) :: map()
+  defp history(contact_id, params, now, event_type, attrs) do
+    %{
+      contact_id: contact_id,
+      event_type: event_type,
+      event_datetime: DateTime.truncate(now, :second),
+      organization_id: params.organization_id,
+      inserted_at: now,
+      updated_at: now
+    }
+    |> Map.merge(attrs)
+  end
+
+  @spec link_collections([map()], map(), map(), DateTime.t()) :: :ok
+  defp link_collections(prepared, saved, params, now) do
+    now = DateTime.truncate(now, :second)
+
+    groups =
+      prepared
+      |> Enum.flat_map(& &1.collections)
+      |> Enum.uniq()
+      |> ensure_groups(params.organization_id)
+
+    entries =
+      for row <- prepared,
+          label <- row.collections,
+          group_id = Map.get(groups, label),
+          contact_id = Map.get(saved, row.phone),
+          not is_nil(group_id) and not is_nil(contact_id) do
+        %{
+          contact_id: contact_id,
+          group_id: group_id,
+          organization_id: params.organization_id,
+          inserted_at: now,
+          updated_at: now
+        }
+      end
+
+    Repo.insert_all(ContactGroup, Enum.uniq(entries), on_conflict: :nothing)
+    :ok
+  end
+
+  @spec ensure_groups([String.t()], non_neg_integer()) :: %{String.t() => non_neg_integer()}
+  defp ensure_groups(labels, organization_id) do
+    Enum.reduce(labels, %{}, fn label, acc ->
+      case Groups.get_or_create_group_by_label(label, organization_id) do
+        {:ok, group} -> Map.put(acc, label, group.id)
+        _error -> acc
+      end
+    end)
+  end
+
+  @spec delete_contact(map(), map(), map()) :: map()
+  defp delete_contact(row, params, errors) do
+    phone = row["phone"]
+
+    if Authorize.valid_role?(params.user.roles, :manager) || params.user.upload_contacts do
+      case Repo.get_by(Contact, %{phone: phone}) do
+        nil ->
+          Map.put(errors, phone, "Contact does not exist")
+
+        contact ->
+          {:ok, _contact} = Contacts.delete_contact(contact)
+          errors
+      end
+    else
+      Map.put(errors, phone, "This user #{params.user.name} doesn't have enough permission")
+    end
+  end
+end

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -31,7 +31,9 @@ defmodule Glific.Contacts.BulkImport do
   @default_language "english"
   @field_type "string"
 
-  @doc "Import one chunk of csv rows, returning a map of phone => error message."
+  @doc """
+  Import one chunk of csv rows, returning a map of phone => error message.
+  """
   @spec process_chunk([map()], map()) :: map()
   def process_chunk(rows, params) do
     {errors, rows} = Import.validate_contacts(rows)

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -96,13 +96,17 @@ defmodule Glific.Contacts.BulkImport do
 
   @spec reject_missing([map()], map(), map(), String.t()) :: {map(), [map()]}
   defp reject_missing(rows, existing, errors, "move_contact") do
-    Enum.reduce(rows, {errors, []}, fn row, {errors, keep} ->
-      phone = row["phone"]
+    {errors, keep} =
+      Enum.reduce(rows, {errors, []}, fn row, {errors, keep} ->
+        phone = row["phone"]
 
-      if Map.has_key?(existing, phone),
-        do: {errors, [row | keep]},
-        else: {Map.put(errors, phone, "Contact #{phone} was not found and hence not added"), keep}
-    end)
+        if Map.has_key?(existing, phone),
+          do: {errors, [row | keep]},
+          else:
+            {Map.put(errors, phone, "Contact #{phone} was not found and hence not added"), keep}
+      end)
+
+    {errors, Enum.reverse(keep)}
   end
 
   defp reject_missing(rows, _existing, errors, _type), do: {errors, rows}

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -21,6 +21,7 @@ defmodule Glific.Contacts.BulkImport do
     Contacts.Import,
     Groups,
     Groups.ContactGroup,
+    Profiles,
     Repo,
     Settings.Language
   }
@@ -36,8 +37,6 @@ defmodule Glific.Contacts.BulkImport do
     {errors, rows} = Import.validate_contacts(rows)
     {deletes, rows} = Enum.split_with(rows, &(&1["delete"] == "1"))
 
-    errors = Enum.reduce(deletes, errors, &delete_contact(&1, params, &2))
-
     existing = load_existing(rows)
     {errors, rows} = reject_missing(rows, existing, errors, params.type)
 
@@ -47,12 +46,14 @@ defmodule Glific.Contacts.BulkImport do
 
     prepared =
       rows
-      |> Enum.map(&prepare(&1, existing, languages, params))
+      |> Enum.map(&prepare(&1, existing, languages, params, now))
       |> dedupe()
 
     {:ok, _} = Repo.transaction(fn -> write(prepared, params, now) end)
 
-    errors
+    delete_errors = Enum.reduce(deletes, %{}, &delete_contact(&1, params, &2))
+
+    Map.merge(errors, delete_errors)
   end
 
   # one transaction so a chunk that dies half way cannot leave the history rows behind:
@@ -66,6 +67,7 @@ defmodule Glific.Contacts.BulkImport do
     upsert_field_registry(prepared, params, now)
     insert_histories(prepared, saved, params, now)
     link_collections(prepared, saved, params, now)
+    sync_profiles(prepared, saved)
   end
 
   @spec load_existing([map()]) :: map()
@@ -82,7 +84,9 @@ defmodule Glific.Contacts.BulkImport do
       language_id: c.language_id,
       optin_time: c.optin_time,
       optout_time: c.optout_time,
-      last_message_at: c.last_message_at
+      last_message_at: c.last_message_at,
+      status: c.status,
+      active_profile_id: c.active_profile_id
     })
     |> Repo.all()
     |> Map.new(&{&1.phone, &1})
@@ -117,10 +121,15 @@ defmodule Glific.Contacts.BulkImport do
         |> put_new_downcased(language.locale, language.id)
       end)
 
+    default_id =
+      Map.get(lookup, @default_language) ||
+        raise "contact import needs an active #{@default_language} language to fall back on"
+
     %{
       lookup: lookup,
+      ordered: Enum.sort_by(lookup, fn {key, id} -> {id, key} end),
       labels: Map.new(languages, &{&1.id, &1.label}),
-      default_id: Map.fetch!(lookup, @default_language)
+      default_id: default_id
     }
   end
 
@@ -128,19 +137,19 @@ defmodule Glific.Contacts.BulkImport do
   defp put_new_downcased(acc, nil, _id), do: acc
   defp put_new_downcased(acc, key, id), do: Map.put_new(acc, String.downcase(key), id)
 
-  @spec prepare(map(), map(), map(), map()) :: map()
-  defp prepare(row, existing, languages, params) do
+  @spec prepare(map(), map(), map(), map(), DateTime.t()) :: map()
+  defp prepare(row, existing, languages, params, now) do
     phone = row["phone"]
     contact = Map.get(existing, phone)
-    fields = build_fields(row["contact_fields"])
 
     %{
       phone: phone,
       name: row["name"],
       language_id: language_id(row["language"], contact, languages),
-      fields: fields,
+      fields: build_fields(row["contact_fields"], now),
       collections: collections(row["collection"]),
       previous_language_id: contact && contact.language_id,
+      active_profile_id: contact && contact.active_profile_id,
       optin?: optin?(params, contact),
       bsp_status: bsp_status(contact)
     }
@@ -164,12 +173,10 @@ defmodule Glific.Contacts.BulkImport do
     |> Map.values()
   end
 
-  @spec build_fields(map() | nil) :: map()
-  defp build_fields(nil), do: %{}
+  @spec build_fields(map() | nil, DateTime.t()) :: map()
+  defp build_fields(nil, _now), do: %{}
 
-  defp build_fields(fields) do
-    inserted_at = DateTime.utc_now()
-
+  defp build_fields(fields, now) do
     fields
     |> Enum.reject(fn {_label, value} -> value in [nil, ""] end)
     |> Map.new(fn {label, value} ->
@@ -180,7 +187,7 @@ defmodule Glific.Contacts.BulkImport do
          value: value,
          label: shortcode,
          type: @field_type,
-         inserted_at: inserted_at
+         inserted_at: now
        }}
     end)
   end
@@ -204,14 +211,18 @@ defmodule Glific.Contacts.BulkImport do
     term = language |> String.trim() |> String.downcase()
 
     case Map.get(languages.lookup, term) do
-      nil -> match_language_prefix(term, languages.lookup) || language_id(nil, contact, languages)
-      id -> id
+      nil ->
+        match_language_prefix(term, languages.ordered) || language_id(nil, contact, languages)
+
+      id ->
+        id
     end
   end
 
-  @spec match_language_prefix(String.t(), map()) :: non_neg_integer() | nil
-  defp match_language_prefix(term, lookup) do
-    Enum.find_value(lookup, fn {key, id} ->
+  @spec match_language_prefix(String.t(), [{String.t(), non_neg_integer()}]) ::
+          non_neg_integer() | nil
+  defp match_language_prefix(term, ordered) do
+    Enum.find_value(ordered, fn {key, id} ->
       if String.starts_with?(key, term), do: id
     end)
   end
@@ -219,14 +230,18 @@ defmodule Glific.Contacts.BulkImport do
   @spec optin?(map(), map() | nil) :: boolean()
   defp optin?(%{type: "move_contact"}, _contact), do: false
 
-  defp optin?(params, contact) do
-    cond do
-      contact && contact.optin_time != nil -> false
-      contact && contact.optout_time != nil -> false
-      Authorize.valid_role?(params.user.roles, :manager) -> true
-      params.user.upload_contacts -> true
-      true -> false
-    end
+  defp optin?(params, contact), do: optin_allowed?(contact) and may_optin?(params.user)
+
+  @spec optin_allowed?(map() | nil) :: boolean()
+  defp optin_allowed?(nil), do: true
+
+  defp optin_allowed?(contact) do
+    contact.status != :blocked and is_nil(contact.optin_time) and is_nil(contact.optout_time)
+  end
+
+  @spec may_optin?(map()) :: boolean()
+  defp may_optin?(user) do
+    Authorize.valid_role?(user.roles, :manager) or user.upload_contacts == true
   end
 
   @spec bsp_status(map() | nil) :: atom()
@@ -262,10 +277,10 @@ defmodule Glific.Contacts.BulkImport do
       Repo.insert_all(Contact, entries,
         on_conflict: on_conflict(optin?),
         conflict_target: [:phone, :organization_id],
-        returning: [:id, :phone]
+        returning: [:id, :phone, :fields]
       )
 
-    Map.new(saved, &{&1.phone, &1.id})
+    Map.new(saved, &{&1.phone, %{id: &1.id, fields: &1.fields}})
   end
 
   @spec contact_entry(map(), map(), DateTime.t(), boolean()) :: map()
@@ -275,6 +290,8 @@ defmodule Glific.Contacts.BulkImport do
       name: row.name,
       language_id: row.language_id,
       fields: row.fields,
+      contact_type: "WABA",
+      last_communication_at: DateTime.truncate(now, :second),
       organization_id: params.organization_id,
       inserted_at: now,
       updated_at: now
@@ -327,6 +344,18 @@ defmodule Glific.Contacts.BulkImport do
     )
   end
 
+  @spec sync_profiles([map()], map()) :: :ok
+  defp sync_profiles(prepared, saved) do
+    prepared
+    |> Enum.filter(&(is_integer(&1.active_profile_id) and &1.fields != %{}))
+    |> Enum.each(fn row ->
+      with %{fields: fields} <- Map.get(saved, row.phone),
+           {:ok, profile} <- Repo.fetch_by(Profiles.Profile, %{id: row.active_profile_id}) do
+        Profiles.update_profile(profile, %{fields: fields})
+      end
+    end)
+  end
+
   @spec upsert_field_registry([map()], map(), DateTime.t()) :: :ok
   defp upsert_field_registry(prepared, params, now) do
     now = DateTime.truncate(now, :second)
@@ -365,7 +394,7 @@ defmodule Glific.Contacts.BulkImport do
       nil ->
         []
 
-      contact_id ->
+      %{id: contact_id} ->
         [
           fields_history(row, contact_id, params, now),
           language_history(row, contact_id, params, now),
@@ -451,12 +480,13 @@ defmodule Glific.Contacts.BulkImport do
 
     entries =
       for row <- prepared,
+          saved_row = Map.get(saved, row.phone),
+          not is_nil(saved_row),
           label <- row.collections,
           group_id = Map.get(groups, label),
-          contact_id = Map.get(saved, row.phone),
-          not is_nil(group_id) and not is_nil(contact_id) do
+          not is_nil(group_id) do
         %{
-          contact_id: contact_id,
+          contact_id: saved_row.id,
           group_id: group_id,
           organization_id: params.organization_id,
           inserted_at: now,
@@ -470,11 +500,9 @@ defmodule Glific.Contacts.BulkImport do
 
   @spec ensure_groups([String.t()], non_neg_integer()) :: %{String.t() => non_neg_integer()}
   defp ensure_groups(labels, organization_id) do
-    Enum.reduce(labels, %{}, fn label, acc ->
-      case Groups.get_or_create_group_by_label(label, organization_id) do
-        {:ok, group} -> Map.put(acc, label, group.id)
-        _error -> acc
-      end
+    Map.new(labels, fn label ->
+      {:ok, group} = Groups.get_or_create_group_by_label(label, organization_id)
+      {label, group.id}
     end)
   end
 

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -30,10 +30,7 @@ defmodule Glific.Contacts.BulkImport do
   @default_language "english"
   @field_type "string"
 
-  @doc """
-  Import one chunk of CSV rows, returning a map of phone => error message for the rows
-  that could not be processed.
-  """
+  @doc "Import one chunk of csv rows, returning a map of phone => error message."
   @spec process_chunk([map()], map()) :: map()
   def process_chunk(rows, params) do
     {errors, rows} = Import.validate_contacts(rows)
@@ -53,13 +50,22 @@ defmodule Glific.Contacts.BulkImport do
       |> Enum.map(&prepare(&1, existing, languages, params))
       |> dedupe()
 
+    {:ok, _} = Repo.transaction(fn -> write(prepared, params, now) end)
+
+    errors
+  end
+
+  # one transaction so a chunk that dies half way cannot leave the history rows behind:
+  # the contact, field and collection writes are idempotent on retry, the history insert
+  # is not. The user job progress deliberately stays outside this, since it takes a
+  # FOR UPDATE lock on a single row that every worker shares.
+  @spec write([map()], map(), DateTime.t()) :: :ok
+  defp write(prepared, params, now) do
     saved = upsert_contacts(prepared, params, now)
 
     upsert_field_registry(prepared, params, now)
     insert_histories(prepared, saved, params, now)
     link_collections(prepared, saved, params, now)
-
-    errors
   end
 
   @spec load_existing([map()]) :: map()

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -209,16 +209,12 @@ defmodule Glific.Contacts.BulkImport do
     if contact, do: contact.language_id, else: languages.default_id
   end
 
-  defp language_id(language, contact, languages) do
+  defp language_id(language, _contact, languages) do
     term = language |> String.trim() |> String.downcase()
 
-    case Map.get(languages.lookup, term) do
-      nil ->
-        match_language_prefix(term, languages.ordered) || language_id(nil, contact, languages)
-
-      id ->
-        id
-    end
+    Map.get(languages.lookup, term) ||
+      match_language_prefix(term, languages.ordered) ||
+      languages.default_id
   end
 
   @spec match_language_prefix(String.t(), [{String.t(), non_neg_integer()}]) ::

--- a/lib/glific/contacts/bulk_import.ex
+++ b/lib/glific/contacts/bulk_import.ex
@@ -69,7 +69,7 @@ defmodule Glific.Contacts.BulkImport do
     upsert_field_registry(prepared, params, now)
     insert_histories(prepared, saved, params, now)
     link_collections(prepared, saved, params, now)
-    sync_profiles(prepared, saved)
+    sync_profiles(prepared, saved, now)
   end
 
   @spec load_existing([map()]) :: map()
@@ -87,6 +87,7 @@ defmodule Glific.Contacts.BulkImport do
       optin_time: c.optin_time,
       optout_time: c.optout_time,
       last_message_at: c.last_message_at,
+      fields: c.fields,
       status: c.status,
       active_profile_id: c.active_profile_id
     })
@@ -155,6 +156,7 @@ defmodule Glific.Contacts.BulkImport do
       fields: build_fields(row["contact_fields"], now),
       collections: collections(row["collection"]),
       previous_language_id: contact && contact.language_id,
+      previous_fields: (contact && contact.fields) || %{},
       active_profile_id: contact && contact.active_profile_id,
       optin?: optin?(params, contact),
       bsp_status: bsp_status(contact)
@@ -346,16 +348,26 @@ defmodule Glific.Contacts.BulkImport do
     )
   end
 
-  @spec sync_profiles([map()], map()) :: :ok
-  defp sync_profiles(prepared, saved) do
-    prepared
-    |> Enum.filter(&(is_integer(&1.active_profile_id) and &1.fields != %{}))
-    |> Enum.each(fn row ->
-      with %{fields: fields} <- Map.get(saved, row.phone),
-           {:ok, profile} <- Repo.fetch_by(Profiles.Profile, %{id: row.active_profile_id}) do
-        Profiles.update_profile(profile, %{fields: fields})
-      end
-    end)
+  @spec sync_profiles([map()], map(), DateTime.t()) :: :ok
+  defp sync_profiles(prepared, saved, now) do
+    contact_ids =
+      prepared
+      |> Enum.filter(&(is_integer(&1.active_profile_id) and &1.fields != %{}))
+      |> Enum.map(&Map.get(saved, &1.phone))
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(& &1.id)
+
+    if contact_ids != [] do
+      from(p in Profiles.Profile,
+        join: c in Contact,
+        on: c.active_profile_id == p.id,
+        where: c.id in ^contact_ids,
+        update: [set: [fields: c.fields, updated_at: ^DateTime.truncate(now, :second)]]
+      )
+      |> Repo.update_all([])
+    end
+
+    :ok
   end
 
   @spec upsert_field_registry([map()], map(), DateTime.t()) :: :ok
@@ -397,32 +409,33 @@ defmodule Glific.Contacts.BulkImport do
         []
 
       %{id: contact_id} ->
-        [
-          fields_history(row, contact_id, params, now),
-          language_history(row, contact_id, params, now),
-          optin_history(row, contact_id, params, now)
-        ]
-        |> Enum.reject(&is_nil/1)
+        fields_history(row, contact_id, params, now) ++
+          Enum.reject(
+            [
+              language_history(row, contact_id, params, now),
+              optin_history(row, contact_id, params, now)
+            ],
+            &is_nil/1
+          )
     end
   end
 
-  @spec fields_history(map(), non_neg_integer(), map(), DateTime.t()) :: map() | nil
-  defp fields_history(%{fields: fields}, _contact_id, _params, _now) when map_size(fields) == 0,
-    do: nil
-
+  @spec fields_history(map(), non_neg_integer(), map(), DateTime.t()) :: [map()]
   defp fields_history(row, contact_id, params, now) do
-    shortcodes = Map.keys(row.fields)
-
-    history(contact_id, params, now, "contact_fields_updated", %{
-      event_label:
-        "Updated #{length(shortcodes)} fields via import: #{Enum.join(shortcodes, ", ")}",
-      event_meta: %{
-        fields:
-          Map.new(row.fields, fn {shortcode, field} ->
-            {shortcode, %{label: field.label, value: field.value}}
-          end)
-      }
-    })
+    Enum.map(row.fields, fn {shortcode, field} ->
+      history(contact_id, params, now, "contact_fields_updated", %{
+        event_label: "Value for #{field.label} is updated to #{field.value}",
+        event_meta: %{
+          field: %{
+            data: shortcode,
+            label: field.label,
+            value: field.value,
+            old_value: Map.get(row.previous_fields, shortcode),
+            new_value: field.value
+          }
+        }
+      })
+    end)
   end
 
   @spec language_history(map(), non_neg_integer(), map(), DateTime.t()) :: map() | nil
@@ -518,11 +531,25 @@ defmodule Glific.Contacts.BulkImport do
           Map.put(errors, phone, "Contact does not exist")
 
         contact ->
-          {:ok, _contact} = Contacts.delete_contact(contact)
-          errors
+          delete_one(contact, phone, errors)
       end
     else
       Map.put(errors, phone, "This user #{params.user.name} doesn't have enough permission")
     end
+  end
+  @spec delete_one(Contact.t(), String.t(), map()) :: map()
+  defp delete_one(contact, phone, errors) do
+    case Contacts.delete_contact(contact) do
+      {:ok, _contact} -> errors
+      {:error, reason} -> Map.put(errors, phone, to_string(reason))
+    end
+  catch
+    kind, reason ->
+      Glific.log_error(
+        "Deleting #{phone} during import failed: " <>
+          Glific.SafeLog.safe_inspect({kind, reason})
+      )
+
+      Map.put(errors, phone, "Could not delete this contact, please retry it on its own")
   end
 end

--- a/lib/glific/contacts/bulk_import_worker.ex
+++ b/lib/glific/contacts/bulk_import_worker.ex
@@ -19,7 +19,9 @@ defmodule Glific.Contacts.BulkImportWorker do
 
   @chunk_failed "Import failed for this batch, please retry these rows"
 
-  @doc "Creating new job for each chunk of contacts."
+  @doc """
+  Creating new job for each chunk of contacts.
+  """
   @spec make_job(list(), map(), non_neg_integer(), non_neg_integer()) ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
   def make_job(chunk, params, user_job_id, delay) do
@@ -35,7 +37,9 @@ defmodule Glific.Contacts.BulkImportWorker do
     |> Oban.insert()
   end
 
-  @doc "Standard perform method to use Oban worker."
+  @doc """
+  Standard perform method to use Oban worker.
+  """
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: :ok
   def perform(

--- a/lib/glific/contacts/bulk_import_worker.ex
+++ b/lib/glific/contacts/bulk_import_worker.ex
@@ -1,0 +1,56 @@
+defmodule Glific.Contacts.BulkImportWorker do
+  @moduledoc """
+  Worker for processing contact chunks with batched writes.
+
+  Replaces the per-field write path in `Glific.Contacts.ImportWorker`, which issued six to
+  nine statements per field per contact. `organization_id` is a top-level job arg so the
+  `contact_import` queue can partition its global limit on it.
+  """
+  use Oban.Worker,
+    queue: :contact_import,
+    max_attempts: 2,
+    priority: 1
+
+  alias Glific.{
+    Contacts.BulkImport,
+    Contacts.Import,
+    Repo
+  }
+
+  @doc """
+  Creating new job for each chunk of contacts.
+  """
+  @spec make_job(list(), map(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
+  def make_job(chunk, params, user_job_id, delay) do
+    __MODULE__.new(
+      %{
+        contacts: chunk,
+        params: params,
+        user_job_id: user_job_id,
+        organization_id: params.organization_id
+      },
+      schedule_in: delay
+    )
+    |> Oban.insert()
+  end
+
+  @doc """
+  Standard perform method to use Oban worker.
+  """
+  @impl Oban.Worker
+  def perform(%Oban.Job{
+        args: %{
+          "contacts" => contacts,
+          "params" => params,
+          "user_job_id" => user_job_id,
+          "organization_id" => organization_id
+        }
+      }) do
+    Repo.put_process_state(organization_id)
+
+    contacts
+    |> BulkImport.process_chunk(Import.parse_worker_params(params, organization_id))
+    |> then(&Import.update_user_job_progress(user_job_id, &1))
+  end
+end

--- a/lib/glific/contacts/bulk_import_worker.ex
+++ b/lib/glific/contacts/bulk_import_worker.ex
@@ -3,11 +3,13 @@ defmodule Glific.Contacts.BulkImportWorker do
   Worker for processing contact chunks with batched writes.
 
   Replaces the per-field write path in `Glific.Contacts.ImportWorker`, which issued six to
-  nine statements per field per contact. `organization_id` is a top-level job arg so the
-  `contact_import` queue can partition its global limit on it.
+  nine statements per field per contact. It runs on its own queue so that
+  `contact_import` can stay unpartitioned while the old worker drains: partitioning is a
+  queue level setting, and jobs enqueued before this shipped have no `meta.partition_key`.
+  `organization_id` is a top level job arg so this queue can partition its global limit on it.
   """
   use Oban.Worker,
-    queue: :contact_import,
+    queue: :contact_import_bulk,
     max_attempts: 2,
     priority: 1
 

--- a/lib/glific/contacts/bulk_import_worker.ex
+++ b/lib/glific/contacts/bulk_import_worker.ex
@@ -17,9 +17,7 @@ defmodule Glific.Contacts.BulkImportWorker do
     Repo
   }
 
-  @doc """
-  Creating new job for each chunk of contacts.
-  """
+  @doc "Creating new job for each chunk of contacts."
   @spec make_job(list(), map(), non_neg_integer(), non_neg_integer()) ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
   def make_job(chunk, params, user_job_id, delay) do
@@ -35,10 +33,9 @@ defmodule Glific.Contacts.BulkImportWorker do
     |> Oban.insert()
   end
 
-  @doc """
-  Standard perform method to use Oban worker.
-  """
+  @doc "Standard perform method to use Oban worker."
   @impl Oban.Worker
+  @spec perform(Oban.Job.t()) :: :ok
   def perform(%Oban.Job{
         args: %{
           "contacts" => contacts,

--- a/lib/glific/contacts/bulk_import_worker.ex
+++ b/lib/glific/contacts/bulk_import_worker.ex
@@ -17,6 +17,8 @@ defmodule Glific.Contacts.BulkImportWorker do
     Repo
   }
 
+  @chunk_failed "Import failed for this batch, please retry these rows"
+
   @doc "Creating new job for each chunk of contacts."
   @spec make_job(list(), map(), non_neg_integer(), non_neg_integer()) ::
           {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
@@ -36,18 +38,37 @@ defmodule Glific.Contacts.BulkImportWorker do
   @doc "Standard perform method to use Oban worker."
   @impl Oban.Worker
   @spec perform(Oban.Job.t()) :: :ok
-  def perform(%Oban.Job{
-        args: %{
-          "contacts" => contacts,
-          "params" => params,
-          "user_job_id" => user_job_id,
-          "organization_id" => organization_id
-        }
-      }) do
+  def perform(
+        %Oban.Job{
+          args: %{
+            "contacts" => contacts,
+            "params" => params,
+            "user_job_id" => user_job_id,
+            "organization_id" => organization_id
+          }
+        } = job
+      ) do
     Repo.put_process_state(organization_id)
 
     contacts
     |> BulkImport.process_chunk(Import.parse_worker_params(params, organization_id))
     |> then(&Import.update_user_job_progress(user_job_id, &1))
+  rescue
+    exception ->
+      handle_failure(exception, __STACKTRACE__, job, contacts, user_job_id)
+  end
+
+  @spec handle_failure(Exception.t(), Exception.stacktrace(), Oban.Job.t(), [map()], integer()) ::
+          :ok | no_return()
+  defp handle_failure(exception, stacktrace, job, contacts, user_job_id) do
+    if job.attempt < job.max_attempts do
+      reraise exception, stacktrace
+    else
+      Glific.log_exception(exception)
+
+      contacts
+      |> Map.new(&{&1["phone"] || "unknown", @chunk_failed})
+      |> then(&Import.update_user_job_progress(user_job_id, &1))
+    end
   end
 end

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -3,14 +3,13 @@ defmodule Glific.Contacts.Import do
   The Contact Importer Module
   """
   import Ecto.Query
-  alias Glific.Settings.Language
   alias GlificWeb.Schema.Middleware.Authorize
 
   alias Glific.{
     Contacts,
+    Contacts.BulkImportWorker,
     Contacts.Contact,
     Contacts.ContactHistory,
-    Contacts.ImportWorker,
     Flows.ContactField,
     Groups,
     Groups.ContactGroup,
@@ -104,6 +103,86 @@ defmodule Glific.Contacts.Import do
   end
 
   @doc """
+  Validate a chunk of raw CSV rows, returning the errors and the rows whose phone
+  number parsed cleanly. Shared by every contact import worker.
+  """
+  @spec validate_contacts([map()]) :: {map(), [map()]}
+  def validate_contacts(contacts) do
+    {errors, valid} =
+      Enum.reduce(contacts, {%{}, []}, fn contact, {errors, valid} ->
+        case validate_contact(contact) do
+          {:ok, clean_phone} -> {errors, [Map.put(contact, "phone", clean_phone) | valid]}
+          {:error, error} -> {Map.merge(errors, error), valid}
+        end
+      end)
+
+    # the accumulator prepends, so restore csv order: when a phone is listed twice it is
+    # the later row that should win
+    {errors, Enum.reverse(valid)}
+  end
+
+  @doc """
+  Validate one CSV row's phone number and name.
+  """
+  @spec validate_contact(map()) :: {:ok, String.t()} | {:error, map()}
+  def validate_contact(%{"phone" => phone}) when phone in [nil, ""],
+    do: {:error, %{"phone" => "Phone number is missing."}}
+
+  def validate_contact(%{"phone" => phone, "name" => name}) do
+    case Contacts.parse_phone_number(phone) do
+      {:ok, clean_phone} -> validate_name(name, clean_phone)
+      {:error, message} -> {:error, %{phone => message}}
+    end
+  end
+
+  def validate_contact(_contact), do: {:error, %{"error" => "Failed to parse some rows"}}
+
+  @spec validate_name(String.t() | nil, String.t()) :: {:ok, String.t()} | {:error, map()}
+  defp validate_name(name, phone) when name in [nil, ""],
+    do: {:error, %{phone => "Contact name is empty"}}
+
+  defp validate_name(_name, phone), do: {:ok, phone}
+
+  @doc """
+  Rebuild the worker params from the JSON serialized Oban args, where atoms have
+  become strings.
+  """
+  @spec parse_worker_params(map(), non_neg_integer()) :: map()
+  def parse_worker_params(params, organization_id) do
+    %{
+      organization_id: organization_id,
+      type: params["type"],
+      user: %{
+        roles: Enum.map(params["user"]["roles"], &String.to_existing_atom/1),
+        upload_contacts: params["user"]["upload_contacts"],
+        name: params["user"]["name"]
+      }
+    }
+  end
+
+  @doc """
+  Record one finished chunk against the user job, merging in any row level errors.
+  """
+  @spec update_user_job_progress(non_neg_integer(), map()) :: :ok
+  def update_user_job_progress(user_job_id, errors) do
+    errors = if errors == %{}, do: %{}, else: %{errors: errors}
+
+    Repo.transaction(fn ->
+      user_job =
+        UserJob
+        |> lock("FOR UPDATE")
+        |> Repo.get_by(id: user_job_id)
+
+      UserJob.update_user_job(user_job, %{
+        tasks_done: user_job.tasks_done + 1,
+        errors: Map.merge(user_job.errors || %{}, errors)
+      })
+    end)
+
+    :ok
+  end
+
+  @doc """
     Move the existing contacts to a group.
   """
   @spec add_contacts_to_group(integer, String.t(), [{atom(), String.t()}]) :: tuple()
@@ -190,9 +269,9 @@ defmodule Glific.Contacts.Import do
       organization_id: organization_id,
       collection: get_collection(contact_attrs.type, data, contact_attrs),
       delete: data["delete"],
+      language: data["language"],
       contact_fields: Map.drop(data, ["phone", "group", "language", "delete", "opt_in"])
     }
-    |> add_language(data["language"])
   end
 
   # Handling csv parsing errors for rows
@@ -293,7 +372,7 @@ defmodule Glific.Contacts.Import do
       |> Stream.chunk_every(@contact_job_chunk_size)
       |> Stream.with_index()
       |> Enum.map(fn {chunk, index} ->
-        ImportWorker.make_job(chunk, params, user_job.id, index * 2)
+        BulkImportWorker.make_job(chunk, params, user_job.id, index * 2)
       end)
       |> Enum.count()
 
@@ -417,28 +496,6 @@ defmodule Glific.Contacts.Import do
     end
   end
 
-  @spec add_language(map(), String.t() | nil) :: map()
-  defp add_language(results, language) when language in [nil, ""] do
-    # Check if contacts have a language other than English; if so, don't update it
-    case Repo.fetch_by(Contact, %{phone: results.phone}) do
-      {:error, _error} ->
-        add_default_language(results)
-
-      {:ok, contact} ->
-        Map.put(results, :language_id, contact.language_id)
-    end
-  end
-
-  defp add_language(results, language) do
-    case Settings.get_language_by_label_or_locale(language) do
-      [] ->
-        add_default_language(results)
-
-      [lang | _] ->
-        Map.put(results, :language_id, lang.id)
-    end
-  end
-
   @spec capture_language_history(
           Contact.t(),
           non_neg_integer() | String.t(),
@@ -462,11 +519,5 @@ defmodule Glific.Contacts.Import do
         }
       })
     end
-  end
-
-  @spec add_default_language(map()) :: map()
-  defp add_default_language(results) do
-    {:ok, en} = Repo.fetch_by(Language, %{label_locale: "English"})
-    Map.put(results, :language_id, en.id)
   end
 end

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -179,7 +179,7 @@ defmodule Glific.Contacts.Import do
   end
 
   @spec merge_errors(map() | nil, map()) :: map()
-  defp merge_errors(existing, errors) when errors == %{}, do: existing || %{}
+  defp merge_errors(existing, errors) when map_size(errors) == 0, do: existing || %{}
 
   defp merge_errors(existing, errors) do
     existing = existing || %{}

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -102,7 +102,9 @@ defmodule Glific.Contacts.Import do
     end
   end
 
-  @doc "Validate a chunk of raw csv rows, returning the errors and the rows that parsed."
+  @doc """
+  Validate a chunk of raw csv rows, returning the errors and the rows that parsed.
+  """
   @spec validate_contacts([map()]) :: {map(), [map()]}
   def validate_contacts(contacts) do
     {errors, valid} =
@@ -118,7 +120,9 @@ defmodule Glific.Contacts.Import do
     {errors, Enum.reverse(valid)}
   end
 
-  @doc "Validate one csv row's phone number and name."
+  @doc """
+  Validate one csv row's phone number and name.
+  """
   @spec validate_contact(map()) :: {:ok, String.t()} | {:error, map()}
   def validate_contact(%{"phone" => phone}) when phone in [nil, ""],
     do: {:error, %{"phone" => "Phone number is missing."}}
@@ -138,7 +142,9 @@ defmodule Glific.Contacts.Import do
 
   defp validate_name(_name, phone), do: {:ok, phone}
 
-  @doc "Rebuild the worker params from the json serialized Oban args."
+  @doc """
+  Rebuild the worker params from the json serialized Oban args.
+  """
   @spec parse_worker_params(map(), non_neg_integer()) :: map()
   def parse_worker_params(params, organization_id) do
     %{
@@ -152,7 +158,9 @@ defmodule Glific.Contacts.Import do
     }
   end
 
-  @doc "Record one finished chunk against the user job, merging in any row level errors."
+  @doc """
+  Record one finished chunk against the user job, merging in any row level errors.
+  """
   @spec update_user_job_progress(non_neg_integer(), map()) :: :ok
   def update_user_job_progress(user_job_id, errors) do
     Repo.transaction(fn ->

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -102,10 +102,7 @@ defmodule Glific.Contacts.Import do
     end
   end
 
-  @doc """
-  Validate a chunk of raw CSV rows, returning the errors and the rows whose phone
-  number parsed cleanly. Shared by every contact import worker.
-  """
+  @doc "Validate a chunk of raw csv rows, returning the errors and the rows that parsed."
   @spec validate_contacts([map()]) :: {map(), [map()]}
   def validate_contacts(contacts) do
     {errors, valid} =
@@ -121,9 +118,7 @@ defmodule Glific.Contacts.Import do
     {errors, Enum.reverse(valid)}
   end
 
-  @doc """
-  Validate one CSV row's phone number and name.
-  """
+  @doc "Validate one csv row's phone number and name."
   @spec validate_contact(map()) :: {:ok, String.t()} | {:error, map()}
   def validate_contact(%{"phone" => phone}) when phone in [nil, ""],
     do: {:error, %{"phone" => "Phone number is missing."}}
@@ -143,10 +138,7 @@ defmodule Glific.Contacts.Import do
 
   defp validate_name(_name, phone), do: {:ok, phone}
 
-  @doc """
-  Rebuild the worker params from the JSON serialized Oban args, where atoms have
-  become strings.
-  """
+  @doc "Rebuild the worker params from the json serialized Oban args."
   @spec parse_worker_params(map(), non_neg_integer()) :: map()
   def parse_worker_params(params, organization_id) do
     %{
@@ -160,9 +152,7 @@ defmodule Glific.Contacts.Import do
     }
   end
 
-  @doc """
-  Record one finished chunk against the user job, merging in any row level errors.
-  """
+  @doc "Record one finished chunk against the user job, merging in any row level errors."
   @spec update_user_job_progress(non_neg_integer(), map()) :: :ok
   def update_user_job_progress(user_job_id, errors) do
     errors = if errors == %{}, do: %{}, else: %{errors: errors}

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -183,7 +183,7 @@ defmodule Glific.Contacts.Import do
 
   defp merge_errors(existing, errors) do
     existing = existing || %{}
-    Map.put(existing, "errors", Map.merge(Map.get(existing, "errors", %{}), errors))
+    Map.update(existing, "errors", errors, &Map.merge(&1, errors))
   end
 
   @doc """

--- a/lib/glific/contacts/import.ex
+++ b/lib/glific/contacts/import.ex
@@ -155,8 +155,6 @@ defmodule Glific.Contacts.Import do
   @doc "Record one finished chunk against the user job, merging in any row level errors."
   @spec update_user_job_progress(non_neg_integer(), map()) :: :ok
   def update_user_job_progress(user_job_id, errors) do
-    errors = if errors == %{}, do: %{}, else: %{errors: errors}
-
     Repo.transaction(fn ->
       user_job =
         UserJob
@@ -165,11 +163,19 @@ defmodule Glific.Contacts.Import do
 
       UserJob.update_user_job(user_job, %{
         tasks_done: user_job.tasks_done + 1,
-        errors: Map.merge(user_job.errors || %{}, errors)
+        errors: merge_errors(user_job.errors, errors)
       })
     end)
 
     :ok
+  end
+
+  @spec merge_errors(map() | nil, map()) :: map()
+  defp merge_errors(existing, errors) when errors == %{}, do: existing || %{}
+
+  defp merge_errors(existing, errors) do
+    existing = existing || %{}
+    Map.put(existing, "errors", Map.merge(Map.get(existing, "errors", %{}), errors))
   end
 
   @doc """

--- a/lib/glific/contacts/import_worker.ex
+++ b/lib/glific/contacts/import_worker.ex
@@ -1,6 +1,10 @@
 defmodule Glific.Contacts.ImportWorker do
   @moduledoc """
-  Worker for processing contact chunks.
+  Worker for processing contact chunks one field at a time.
+
+  Superseded by `Glific.Contacts.BulkImportWorker`, which batches its writes. Nothing
+  enqueues this worker any more; it is kept only so that jobs already sitting in the
+  queue can still drain, and should be removed once they have.
   """
   require Logger
 
@@ -10,25 +14,9 @@ defmodule Glific.Contacts.ImportWorker do
     priority: 1
 
   alias Glific.{
-    Contacts,
     Contacts.Import,
-    Jobs.UserJob,
     Repo
   }
-
-  import Ecto.Query
-
-  @doc """
-  Creating new job for each chunk of contacts.
-  """
-  @spec make_job(list(), map(), non_neg_integer(), non_neg_integer()) ::
-          {:ok, Oban.Job.t()} | {:error, Ecto.Changeset.t()}
-  def make_job(chunk, params, user_job_id, delay) do
-    __MODULE__.new(%{contacts: chunk, params: params, user_job_id: user_job_id},
-      schedule_in: delay
-    )
-    |> Oban.insert()
-  end
 
   @doc """
   Standard perform method to use Oban worker.
@@ -37,82 +25,26 @@ defmodule Glific.Contacts.ImportWorker do
   def perform(%Oban.Job{
         args: %{"contacts" => contacts, "params" => params, "user_job_id" => user_job_id}
       }) do
-    params = %{
-      organization_id: params["organization_id"],
-      user: %{
-        roles: Enum.map(params["user"]["roles"], &String.to_existing_atom/1),
-        upload_contacts: params["user"]["upload_contacts"],
-        name: params["user"]["name"]
-      },
-      type: params["type"]
-    }
+    params = Import.parse_worker_params(params, params["organization_id"])
 
     Repo.put_process_state(params.organization_id)
 
-    {validation_errors, valid_contacts} =
-      Enum.reduce(contacts, {%{}, []}, fn contact, {acc, valid_contacts} ->
-        case validate_contact(contact) do
-          {:ok, clean_phone} ->
-            {acc, [Map.put(contact, "phone", clean_phone) | valid_contacts]}
-
-          {:error, errors} ->
-            {Map.update(acc, :errors, errors, &Map.merge(&1, errors)), valid_contacts}
-        end
-      end)
+    {validation_errors, valid_contacts} = Import.validate_contacts(contacts)
 
     contacts =
       Enum.map(valid_contacts, fn contact ->
         for {key, value} <- contact, into: %{}, do: {String.to_existing_atom(key), value}
       end)
 
-    errors =
-      Enum.reduce(contacts, validation_errors, fn contact, error_map ->
-        case process_contact(contact, params) do
-          {:ok, _} ->
-            error_map
-
-          {:error, error} ->
-            Map.update(error_map, :errors, error, &Map.merge(&1, error))
-        end
-      end)
-
-    Repo.transaction(fn ->
-      user_job =
-        UserJob
-        |> lock("FOR UPDATE")
-        |> Repo.get_by(id: user_job_id)
-
-      tasks_done = user_job.tasks_done + 1
-      updated_errors = Map.merge(user_job.errors || %{}, errors)
-      UserJob.update_user_job(user_job, %{tasks_done: tasks_done, errors: updated_errors})
+    contacts
+    |> Enum.reduce(validation_errors, fn contact, error_map ->
+      case process_contact(contact, params) do
+        {:ok, _} -> error_map
+        {:error, error} -> Map.merge(error_map, error)
+      end
     end)
-
-    :ok
+    |> then(&Import.update_user_job_progress(user_job_id, &1))
   end
-
-  @spec validate_contact(map()) :: {:ok, String.t()} | {:error, map()}
-  defp validate_contact(%{"phone" => phone}) when phone in [nil, ""] do
-    {:error, %{"phone" => "Phone number is missing."}}
-  end
-
-  defp validate_contact(%{"phone" => phone, "name" => name}) do
-    case Contacts.parse_phone_number(phone) do
-      {:ok, clean_phone} ->
-        validate_name(name, clean_phone)
-
-      {:error, message} ->
-        {:error, %{phone => message}}
-    end
-  end
-
-  defp validate_contact(_), do: {:error, %{"error" => "Failed to parse some rows"}}
-
-  @spec validate_name(String.t(), String.t()) :: {:ok, String.t()} | {:error, map()}
-  defp validate_name(name, phone) when name in [nil, ""] do
-    {:error, %{phone => "Contact name is empty"}}
-  end
-
-  defp validate_name(_name, phone), do: {:ok, phone}
 
   @spec process_contact(map(), map()) :: {:ok, map()} | {:error, map()}
   defp process_contact(contact, params) do

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -3,10 +3,11 @@ defmodule Glific.Contacts.BulkImportTest do
   Covers the batched import path end to end, through the same entry point the UI uses.
   These mirror the manual scenarios in import_test/harness.exs.
   """
-  use Glific.DataCase, async: true
+  use Glific.DataCase, async: false
   use Oban.Pro.Testing, repo: Glific.Repo
 
   import Ecto.Query
+  import Mock
 
   alias Glific.{
     Contacts.Contact,
@@ -129,6 +130,32 @@ defmodule Glific.Contacts.BulkImportTest do
       )
 
       assert in_group?("919876500004", "batch_a")
+    end
+  end
+
+  describe "atomicity" do
+    test "a failure on the last write rolls back the contact and its history" do
+      # link_collections/4 is the final write inside the transaction, after the contact
+      # upsert and the history insert have already run
+      result =
+        with_mock Glific.Groups, [:passthrough],
+          get_or_create_group_by_label: fn _label, _org -> raise "collection write failed" end do
+          Import.import_contacts(
+            org_id(),
+            %{user: admin(), collection: "rollback", type: :import_contact},
+            data: "name,phone,language,city\nRollback,+919876570001,english,Pune\n"
+          )
+
+          Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+        end
+
+      assert %{success: 0, failure: 1} = result
+
+      refute exists?("919876570001")
+
+      assert ContactHistory
+             |> where([h], like(h.event_label, "%city%"))
+             |> Repo.aggregate(:count, :id) == 0
     end
   end
 

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -101,7 +101,7 @@ defmodule Glific.Contacts.BulkImportTest do
       assert field(contact, "name") == "Wide"
     end
 
-    test "writes one history row per contact, not one per field" do
+    test "writes one history row per field, in the shape the history ui reads" do
       headers = Enum.map_join(1..15, ",", &"field_#{&1}")
       values = Enum.map_join(1..15, ",", &"value_#{&1}")
 
@@ -112,9 +112,36 @@ defmodule Glific.Contacts.BulkImportTest do
       rows =
         ContactHistory
         |> where([h], h.contact_id == ^contact.id and h.event_type == "contact_fields_updated")
-        |> Repo.aggregate(:count, :id)
+        |> Repo.all()
 
-      assert rows == 1
+      # 15 field_n columns plus name, which cleanup_contact_data/3 does not drop
+      assert length(rows) == 16
+
+      row = Enum.find(rows, &(&1.event_meta["field"]["data"] == "field_1"))
+
+      # contactHistory.tsx reads eventMeta.field.label / .new_value / .old_value.value
+      assert row.event_meta["field"]["label"] == "field_1"
+      assert row.event_meta["field"]["new_value"] == "value_1"
+      assert row.event_meta["field"]["old_value"] == nil
+      assert row.event_label == "Value for field_1 is updated to value_1"
+    end
+
+    test "a second import records the previous value as old_value" do
+      run("name,phone,language,city\nOld,+919876500009,english,Pune\n")
+      run("name,phone,language,city\nOld,+919876500009,english,Mumbai\n")
+
+      contact = fetch("919876500009")
+
+      row =
+        ContactHistory
+        |> where([h], h.contact_id == ^contact.id)
+        |> where([h], fragment("event_meta -> 'field' ->> 'data' = 'city'"))
+        |> order_by([h], desc: h.id)
+        |> limit(1)
+        |> Repo.one()
+
+      assert row.event_meta["field"]["new_value"] == "Mumbai"
+      assert row.event_meta["field"]["old_value"]["value"] == "Pune"
     end
 
     test "opts in a new contact and sets bsp_status" do

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -10,13 +10,18 @@ defmodule Glific.Contacts.BulkImportTest do
   import Mock
 
   alias Glific.{
+    Contacts,
     Contacts.Contact,
     Contacts.ContactHistory,
     Contacts.ContactsField,
     Contacts.Import,
+    Flows.ContactField,
+    Groups,
     Groups.ContactGroup,
     Groups.Group,
+    Jobs.UserJob,
     Partners,
+    Profiles,
     Repo,
     Seeds.SeedsDev,
     Settings.Language,
@@ -133,12 +138,171 @@ defmodule Glific.Contacts.BulkImportTest do
     end
   end
 
+  describe "columns insert_all does not get for free" do
+    test "sets contact_type so the contact is visible in chats and search" do
+      run("name,phone,language,city\nType,+919876580101,english,Pune\n")
+
+      contact = fetch("919876580101")
+
+      assert contact.contact_type == "WABA"
+      assert contact.contact_type in ["WABA", "WABA+WA"]
+    end
+
+    test "does not downgrade an existing contact_type on re-import" do
+      run("name,phone,language,city\nType,+919876580102,english,Pune\n")
+
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919876580102"})
+      Contacts.update_contact(contact, %{contact_type: "WABA+WA"})
+
+      run("name,phone,language,city\nType,+919876580102,english,Mumbai\n")
+
+      assert fetch("919876580102").contact_type == "WABA+WA"
+      assert field(fetch("919876580102"), "city") == "Mumbai"
+    end
+
+    test "sets last_communication_at so imports do not sort above real conversations" do
+      run("name,phone,language,city\nComm,+919876580103,english,Pune\n")
+
+      assert fetch("919876580103").last_communication_at != nil
+    end
+
+    test "does not bump last_communication_at on re-import" do
+      run("name,phone,language,city\nComm,+919876580104,english,Pune\n")
+      before = fetch("919876580104").last_communication_at
+
+      run("name,phone,language,city\nComm,+919876580104,english,Mumbai\n")
+
+      assert fetch("919876580104").last_communication_at == before
+    end
+  end
+
+  describe "blocked contacts" do
+    setup do
+      run("name,phone,language,city\nBlocked,+919876580201,english,Pune\n")
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919876580201"})
+
+      {:ok, _} =
+        Contacts.update_contact(contact, %{
+          status: :blocked,
+          optin_time: nil,
+          optin_status: false
+        })
+
+      :ok
+    end
+
+    test "an import does not unblock or optin a blocked contact" do
+      run("name,phone,language,city\nBlocked,+919876580201,english,Mumbai\n")
+
+      contact = fetch("919876580201")
+
+      assert contact.status == :blocked
+      assert contact.optin_time == nil
+      refute contact.optin_status
+    end
+
+    test "the contact's fields are still updated" do
+      run("name,phone,language,city\nBlocked,+919876580201,english,Mumbai\n")
+
+      assert field(fetch("919876580201"), "city") == "Mumbai"
+    end
+  end
+
+  describe "active profiles" do
+    test "writes the merged fields to the active profile" do
+      run("name,phone,language,city,age\nProf,+919876580301,english,Pune,30\n")
+      contact = fetch("919876580301")
+
+      {:ok, profile} =
+        Profiles.create_profile(%{
+          name: "Profile One",
+          type: "student",
+          contact_id: contact.id,
+          language_id: contact.language_id,
+          organization_id: org_id()
+        })
+
+      {:ok, _} = Contacts.update_contact(contact, %{active_profile_id: profile.id})
+
+      run("name,phone,language,school\nProf,+919876580301,english,SchoolA\n")
+
+      updated = Repo.get!(Profiles.Profile, profile.id)
+
+      # switch_profile/2 copies profile.fields over contact.fields, so anything missing
+      # here is silently discarded on the next profile switch
+      assert get_in(updated.fields, ["school", "value"]) == "SchoolA"
+      assert get_in(updated.fields, ["city", "value"]) == "Pune"
+    end
+  end
+
+  describe "error accounting" do
+    test "accumulates errors across chunks instead of keeping only the first" do
+      user_job =
+        UserJob.create_user_job(%{
+          status: "pending",
+          type: "contact_import",
+          total_tasks: 2,
+          tasks_done: 0,
+          organization_id: org_id(),
+          errors: %{}
+        })
+
+      Import.update_user_job_progress(user_job.id, %{"111" => "chunk one failed"})
+      Import.update_user_job_progress(user_job.id, %{"222" => "chunk two failed"})
+
+      reloaded = Repo.get!(UserJob, user_job.id)
+
+      assert reloaded.tasks_done == 2
+      assert reloaded.errors["errors"]["111"] == "chunk one failed"
+      assert reloaded.errors["errors"]["222"] == "chunk two failed"
+      assert map_size(reloaded.errors) == 1, "an atom :errors key alongside \"errors\" loses one"
+    end
+
+    test "a clean chunk leaves the accumulated errors alone" do
+      user_job =
+        UserJob.create_user_job(%{
+          status: "pending",
+          type: "contact_import",
+          total_tasks: 2,
+          tasks_done: 0,
+          organization_id: org_id(),
+          errors: %{}
+        })
+
+      Import.update_user_job_progress(user_job.id, %{"111" => "chunk one failed"})
+      Import.update_user_job_progress(user_job.id, %{})
+
+      reloaded = Repo.get!(UserJob, user_job.id)
+
+      assert reloaded.tasks_done == 2
+      assert reloaded.errors["errors"]["111"] == "chunk one failed"
+    end
+  end
+
+  describe "delete flag" do
+    test "removes the contact and reports a missing one" do
+      run("name,phone,language,city\nGone,+919876580401,english,Pune\n")
+      assert exists?("919876580401")
+
+      run("""
+      name,phone,language,delete
+      Gone,+919876580401,english,1
+      Never,+919876580402,english,1
+      """)
+
+      refute exists?("919876580401")
+
+      [user_job | _] = UserJob.list_user_jobs(%{}) |> Enum.sort_by(& &1.id, :desc)
+      assert user_job.errors["errors"]["919876580402"] == "Contact does not exist"
+    end
+  end
+
   describe "atomicity" do
     test "a failure on the last write rolls back the contact and its history" do
       # link_collections/4 is the final write inside the transaction, after the contact
       # upsert and the history insert have already run
       result =
-        with_mock Glific.Groups, [:passthrough],
+        with_mock Groups, [:passthrough],
           get_or_create_group_by_label: fn _label, _org -> raise "collection write failed" end do
           Import.import_contacts(
             org_id(),
@@ -211,6 +375,30 @@ defmodule Glific.Contacts.BulkImportTest do
       assert in_group?("919876520001", "moved")
     end
 
+    test "overwrites the name when the csv carries a different one" do
+      assert fetch("919876520001").name == "Move"
+
+      run(
+        "name,phone,language,collection,attendance\nRenamed,+919876520001,english,moved,80%\n",
+        :move_contact,
+        nil
+      )
+
+      assert fetch("919876520001").name == "Renamed"
+    end
+
+    test "rejects a row whose name is blank, so the name is never nulled" do
+      run(
+        "name,phone,language,collection,attendance\n,+919876520001,english,moved,80%\n",
+        :move_contact,
+        nil
+      )
+
+      contact = fetch("919876520001")
+      assert contact.name == "Move"
+      refute field(contact, "attendance")
+    end
+
     test "does not change the optin time" do
       before = fetch("919876520001").optin_time
 
@@ -240,7 +428,7 @@ defmodule Glific.Contacts.BulkImportTest do
         nil
       )
 
-      [user_job | _] = Glific.Jobs.UserJob.list_user_jobs(%{}) |> Enum.sort_by(& &1.id, :desc)
+      [user_job | _] = UserJob.list_user_jobs(%{}) |> Enum.sort_by(& &1.id, :desc)
 
       assert user_job.errors["errors"]["919876529999"] =~ "was not found"
     end
@@ -312,7 +500,7 @@ defmodule Glific.Contacts.BulkImportTest do
   describe "contacts_fields registry" do
     test "does not overwrite an existing human label with the snake_case header" do
       {:ok, existing} =
-        Glific.Flows.ContactField.create_contact_field(%{
+        ContactField.create_contact_field(%{
           name: "Date Of Birth",
           shortcode: "date_of_birth",
           organization_id: org_id(),

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -321,6 +321,34 @@ defmodule Glific.Contacts.BulkImportTest do
              |> where([h], like(h.event_label, "%city%"))
              |> Repo.aggregate(:count, :id) == 0
     end
+
+    test "a failed write leaves a delete row in the same chunk unapplied" do
+      run("name,phone,language,city\nDoomed,+919876570002,english,Pune\n")
+      assert exists?("919876570002")
+
+      result =
+        with_mock Groups, [:passthrough],
+          get_or_create_group_by_label: fn _label, _org -> raise "collection write failed" end do
+          Import.import_contacts(
+            org_id(),
+            %{user: admin(), collection: "rollback", type: :import_contact},
+            data: """
+            name,phone,language,city,delete
+            Fresh,+919876570003,english,Pune,
+            Doomed,+919876570002,english,,1
+            """
+          )
+
+          Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+        end
+
+      assert %{success: 0, failure: 1} = result
+
+      # deletes run after the write transaction commits, so a chunk that rolls back has
+      # not deleted anything and the retry sees the same rows it started with
+      assert exists?("919876570002")
+      refute exists?("919876570003")
+    end
   end
 
   describe "import_contact field merging" do

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -1,0 +1,342 @@
+defmodule Glific.Contacts.BulkImportTest do
+  @moduledoc """
+  Covers the batched import path end to end, through the same entry point the UI uses.
+  These mirror the manual scenarios in import_test/harness.exs.
+  """
+  use Glific.DataCase, async: true
+  use Oban.Pro.Testing, repo: Glific.Repo
+
+  import Ecto.Query
+
+  alias Glific.{
+    Contacts.Contact,
+    Contacts.ContactHistory,
+    Contacts.ContactsField,
+    Contacts.Import,
+    Groups.ContactGroup,
+    Groups.Group,
+    Partners,
+    Repo,
+    Seeds.SeedsDev,
+    Settings.Language,
+    Users
+  }
+
+  setup do
+    Tesla.Mock.mock_global(fn
+      %{method: :get} -> %Tesla.Env{status: 200}
+      %{method: :post} -> %Tesla.Env{status: 200}
+    end)
+
+    default_provider = SeedsDev.seed_providers()
+    SeedsDev.seed_organizations(default_provider)
+    SeedsDev.seed_groups()
+    SeedsDev.seed_users()
+    :ok
+  end
+
+  defp admin do
+    {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
+    Map.merge(user, %{roles: [:admin], upload_contacts: true})
+  end
+
+  defp org_id do
+    [organization | _] = Partners.list_organizations()
+    organization.id
+  end
+
+  defp run(data, type \\ :import_contact, collection \\ "harness") do
+    attrs = %{user: admin(), type: type}
+    attrs = if is_nil(collection), do: attrs, else: Map.put(attrs, :collection, collection)
+
+    Import.import_contacts(org_id(), attrs, data: data)
+    Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+  end
+
+  defp fetch(phone) do
+    {:ok, contact} = Repo.fetch_by(Contact, %{phone: phone})
+    contact
+  end
+
+  # Contacts.count_contacts filters phone with a LIKE, so exact identity needs an exact match
+  defp exists?(phone), do: match?({:ok, _}, Repo.fetch_by(Contact, %{phone: phone}))
+
+  defp count_exact(phone) do
+    Contact |> where([c], c.phone == ^phone) |> Repo.aggregate(:count, :id)
+  end
+
+  defp field(contact, key), do: get_in(contact.fields, [key, "value"])
+
+  defp in_group?(phone, label) do
+    contact = fetch(phone)
+
+    ContactGroup
+    |> join(:inner, [cg], g in Group, on: g.id == cg.group_id)
+    |> where([cg, g], cg.contact_id == ^contact.id and g.label == ^label)
+    |> Repo.aggregate(:count, :id) > 0
+  end
+
+  describe "import_contact" do
+    test "writes every field of a wide row in one pass" do
+      headers = Enum.map_join(1..15, ",", &"field_#{&1}")
+      values = Enum.map_join(1..15, ",", &"value_#{&1}")
+
+      assert %{success: 1, failure: 0} =
+               run("name,phone,language,#{headers}\nWide,+919876500001,english,#{values}\n")
+
+      contact = fetch("919876500001")
+
+      assert field(contact, "field_1") == "value_1"
+      assert field(contact, "field_15") == "value_15"
+
+      # cleanup_contact_data/3 only drops phone/group/language/delete/opt_in, so "name"
+      # lands as a contact field too. Pinning that here: it predates the batched path.
+      assert map_size(contact.fields) == 16
+      assert field(contact, "name") == "Wide"
+    end
+
+    test "writes one history row per contact, not one per field" do
+      headers = Enum.map_join(1..15, ",", &"field_#{&1}")
+      values = Enum.map_join(1..15, ",", &"value_#{&1}")
+
+      run("name,phone,language,#{headers}\nHist,+919876500002,english,#{values}\n")
+
+      contact = fetch("919876500002")
+
+      rows =
+        ContactHistory
+        |> where([h], h.contact_id == ^contact.id and h.event_type == "contact_fields_updated")
+        |> Repo.aggregate(:count, :id)
+
+      assert rows == 1
+    end
+
+    test "opts in a new contact and sets bsp_status" do
+      run("name,phone,language,city\nOptin,+919876500003,english,Pune\n")
+      contact = fetch("919876500003")
+
+      assert contact.optin_time != nil
+      assert contact.optin_status == true
+      assert contact.optin_method == "Import"
+      assert contact.bsp_status == :hsm
+    end
+
+    test "adds the contact to its collection" do
+      run(
+        "name,phone,language,city\nColl,+919876500004,english,Pune\n",
+        :import_contact,
+        "batch_a"
+      )
+
+      assert in_group?("919876500004", "batch_a")
+    end
+  end
+
+  describe "import_contact field merging" do
+    setup do
+      run("name,phone,language,city,age,school\nMerge,+919876510001,english,Pune,30,SchoolA\n")
+      :ok
+    end
+
+    test "keeps fields that the second csv does not mention" do
+      run("name,phone,language,city,village\nMerge,+919876510001,english,Mumbai,Wagholi\n")
+      contact = fetch("919876510001")
+
+      assert field(contact, "school") == "SchoolA"
+      assert field(contact, "age") == "30"
+      assert field(contact, "city") == "Mumbai"
+      assert field(contact, "village") == "Wagholi"
+    end
+
+    test "a blank cell does not erase the stored value" do
+      run("name,phone,language,city,age,school\nMerge,+919876510001,english,,,\n")
+      contact = fetch("919876510001")
+
+      assert field(contact, "city") == "Pune"
+      assert field(contact, "age") == "30"
+      assert field(contact, "school") == "SchoolA"
+    end
+
+    test "re-importing does not create a second contact" do
+      run("name,phone,language,city\nMerge,+919876510001,english,Nashik\n")
+      assert count_exact("919876510001") == 1
+    end
+  end
+
+  describe "move_contact" do
+    setup do
+      run("name,phone,language,city,school\nMove,+919876520001,english,Pune,SchoolA\n")
+      :ok
+    end
+
+    test "updates an existing contact and keeps its earlier fields" do
+      assert %{success: 1, failure: 0} =
+               run(
+                 "name,phone,language,collection,attendance\nMove,+919876520001,english,moved,80%\n",
+                 :move_contact,
+                 nil
+               )
+
+      contact = fetch("919876520001")
+
+      assert field(contact, "attendance") == "80%"
+      assert field(contact, "school") == "SchoolA"
+      assert in_group?("919876520001", "moved")
+    end
+
+    test "does not change the optin time" do
+      before = fetch("919876520001").optin_time
+
+      run(
+        "name,phone,language,collection,attendance\nMove,+919876520001,english,moved,80%\n",
+        :move_contact,
+        nil
+      )
+
+      assert fetch("919876520001").optin_time == before
+    end
+
+    test "does not create a contact that does not already exist" do
+      run(
+        "name,phone,language,collection,ghost\nGhost,+919876529999,english,moved,x\n",
+        :move_contact,
+        nil
+      )
+
+      refute exists?("919876529999")
+    end
+
+    test "records an error for a phone that does not exist" do
+      run(
+        "name,phone,language,collection,ghost\nGhost,+919876529999,english,moved,x\n",
+        :move_contact,
+        nil
+      )
+
+      [user_job | _] = Glific.Jobs.UserJob.list_user_jobs(%{}) |> Enum.sort_by(& &1.id, :desc)
+
+      assert user_job.errors["errors"]["919876529999"] =~ "was not found"
+    end
+  end
+
+  describe "rejected rows" do
+    test "a blank phone, an unparseable phone and a missing country code are all rejected" do
+      run("""
+      name,phone,language,city
+      Blank,,english,Pune
+      Bad,12345,english,Pune
+      NoCountry,9876543210,english,Pune
+      """)
+
+      refute exists?("12345")
+      refute exists?("9876543210")
+    end
+
+    test "a row with no name is rejected" do
+      run("name,phone,language,city\n,+919876530001,english,Pune\n")
+      refute exists?("919876530001")
+    end
+
+    test "one bad row does not stop the good rows in the same chunk" do
+      run("""
+      name,phone,language,city
+      Good One,+919876530002,english,Pune
+      Bad,12345,english,Pune
+      Good Two,+919876530003,english,Mumbai
+      """)
+
+      assert exists?("919876530002")
+      assert exists?("919876530003")
+    end
+  end
+
+  describe "language resolution" do
+    test "resolves a label, a locale, and falls back to english for an unknown one" do
+      run("""
+      name,phone,language,city
+      ByLabel,+919876540001,Hindi,Pune
+      ByLocale,+919876540002,ta,Pune
+      Unknown,+919876540003,klingon,Pune
+      Missing,+919876540004,,Pune
+      """)
+
+      {:ok, hindi} = Repo.fetch_by(Language, %{label: "Hindi"}, skip_organization_id: true)
+      {:ok, tamil} = Repo.fetch_by(Language, %{label: "Tamil"}, skip_organization_id: true)
+
+      {:ok, english} =
+        Repo.fetch_by(Language, %{label_locale: "English"}, skip_organization_id: true)
+
+      assert fetch("919876540001").language_id == hindi.id
+      assert fetch("919876540002").language_id == tamil.id
+      assert fetch("919876540003").language_id == english.id
+      assert fetch("919876540004").language_id == english.id
+    end
+
+    test "keeps the contact's existing language when the csv leaves it blank" do
+      run("name,phone,language,city\nLang,+919876540005,Hindi,Pune\n")
+      {:ok, hindi} = Repo.fetch_by(Language, %{label: "Hindi"}, skip_organization_id: true)
+      assert fetch("919876540005").language_id == hindi.id
+
+      run("name,phone,language,city\nLang,+919876540005,,Mumbai\n")
+      assert fetch("919876540005").language_id == hindi.id
+    end
+  end
+
+  describe "contacts_fields registry" do
+    test "does not overwrite an existing human label with the snake_case header" do
+      {:ok, existing} =
+        Glific.Flows.ContactField.create_contact_field(%{
+          name: "Date Of Birth",
+          shortcode: "date_of_birth",
+          organization_id: org_id(),
+          scope: :contact
+        })
+
+      run("name,phone,language,date_of_birth\nLabel,+919876550001,english,2010-01-01\n")
+
+      assert Repo.get!(ContactsField, existing.id).name == "Date Of Birth"
+      assert field(fetch("919876550001"), "date_of_birth") == "2010-01-01"
+    end
+
+    test "registers each csv header once, however many contacts carry it" do
+      run("""
+      name,phone,language,brand_new_field
+      One,+919876550002,english,a
+      Two,+919876550003,english,b
+      Three,+919876550004,english,c
+      """)
+
+      count =
+        ContactsField
+        |> where([f], f.shortcode == "brand_new_field")
+        |> Repo.aggregate(:count, :id)
+
+      assert count == 1
+    end
+  end
+
+  describe "special characters and size" do
+    test "keeps commas, quotes and a very long value intact" do
+      long = String.duplicate("L", 3000)
+
+      run(
+        ~s(name,phone,language,city,notes\nSpecial,+919876560001,english,"Pune, MH","has ""quotes"" and, commas"\n)
+      )
+
+      contact = fetch("919876560001")
+      assert field(contact, "city") == "Pune, MH"
+      assert field(contact, "notes") == ~s(has "quotes" and, commas)
+
+      run("name,phone,language,notes\nSpecial,+919876560001,english,#{long}\n")
+      assert String.length(field(fetch("919876560001"), "notes")) == 3000
+    end
+
+    test "normalises a phone wrapped in invisible unicode without creating a duplicate" do
+      run("name,phone,language,city\nUni,+919876560002,english,Pune\n")
+      run("name,phone,language,city\nUni,‎+919876560002‏,english,Mumbai\n")
+
+      assert count_exact("919876560002") == 1
+      assert field(fetch("919876560002"), "city") == "Mumbai"
+    end
+  end
+end

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -138,6 +138,26 @@ defmodule Glific.Contacts.BulkImportTest do
     end
   end
 
+  test "trims collection labels so a spaced csv does not create padded groups" do
+    run(
+      "name,phone,language,collection\nTrim,+919876580501,english,\"trim_one, trim_two\"\n",
+      :import_contact,
+      nil
+    )
+
+    labels =
+      Group
+      |> where([g], like(g.label, "trim_%"))
+      |> select([g], g.label)
+      |> Repo.all()
+      |> Enum.sort()
+
+    # collection_label_check/2 split on "," without trimming, so " trim_two" became a
+    # group of its own
+    assert labels == ["trim_one", "trim_two"]
+    assert in_group?("919876580501", "trim_two")
+  end
+
   describe "columns insert_all does not get for free" do
     test "sets contact_type so the contact is visible in chats and search" do
       run("name,phone,language,city\nType,+919876580101,english,Pune\n")
@@ -301,6 +321,8 @@ defmodule Glific.Contacts.BulkImportTest do
     test "a failure on the last write rolls back the contact and its history" do
       # link_collections/4 is the final write inside the transaction, after the contact
       # upsert and the history insert have already run
+      before = Repo.aggregate(ContactHistory, :count, :id)
+
       result =
         with_mock Groups, [:passthrough],
           get_or_create_group_by_label: fn _label, _org -> raise "collection write failed" end do
@@ -316,10 +338,7 @@ defmodule Glific.Contacts.BulkImportTest do
       assert %{success: 0, failure: 1} = result
 
       refute exists?("919876570001")
-
-      assert ContactHistory
-             |> where([h], like(h.event_label, "%city%"))
-             |> Repo.aggregate(:count, :id) == 0
+      assert Repo.aggregate(ContactHistory, :count, :id) == before
     end
 
     test "a failed write leaves a delete row in the same chunk unapplied" do
@@ -513,6 +532,21 @@ defmodule Glific.Contacts.BulkImportTest do
       assert fetch("919876540002").language_id == tamil.id
       assert fetch("919876540003").language_id == english.id
       assert fetch("919876540004").language_id == english.id
+    end
+
+    test "an unresolvable language resets an existing contact to the default" do
+      {:ok, hindi} = Repo.fetch_by(Language, %{label: "Hindi"}, skip_organization_id: true)
+
+      {:ok, english} =
+        Repo.fetch_by(Language, %{label_locale: "English"}, skip_organization_id: true)
+
+      run("name,phone,language,city\nLang,+919876540006,Hindi,Pune\n")
+      assert fetch("919876540006").language_id == hindi.id
+
+      # add_language/2 sent an unknown language to the default rather than keeping the
+      # contact's current one. Only a blank cell preserves it.
+      run("name,phone,language,city\nLang,+919876540006,klingon,Pune\n")
+      assert fetch("919876540006").language_id == english.id
     end
 
     test "keeps the contact's existing language when the csv leaves it blank" do

--- a/test/glific/contacts/bulk_import_test.exs
+++ b/test/glific/contacts/bulk_import_test.exs
@@ -56,7 +56,7 @@ defmodule Glific.Contacts.BulkImportTest do
     attrs = if is_nil(collection), do: attrs, else: Map.put(attrs, :collection, collection)
 
     Import.import_contacts(org_id(), attrs, data: data)
-    Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+    Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
   end
 
   defp fetch(phone) do
@@ -332,7 +332,7 @@ defmodule Glific.Contacts.BulkImportTest do
             data: "name,phone,language,city\nRollback,+919876570001,english,Pune\n"
           )
 
-          Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+          Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
         end
 
       assert %{success: 0, failure: 1} = result
@@ -358,7 +358,7 @@ defmodule Glific.Contacts.BulkImportTest do
             """
           )
 
-          Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+          Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
         end
 
       assert %{success: 0, failure: 1} = result
@@ -444,6 +444,17 @@ defmodule Glific.Contacts.BulkImportTest do
       contact = fetch("919876520001")
       assert contact.name == "Move"
       refute field(contact, "attendance")
+    end
+
+    test "folds a duplicate phone the same way import_contact does, later row winning" do
+      run(
+        "name,phone,language,collection,city\nMove,+919876520001,english,moved,FIRST\nMove,+919876520001,english,moved,SECOND\n",
+        :move_contact,
+        nil
+      )
+
+      assert count_exact("919876520001") == 1
+      assert field(fetch("919876520001"), "city") == "SECOND"
     end
 
     test "does not change the optin time" do

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -10,6 +10,7 @@ defmodule Glific.ContactsTest do
     Contacts,
     Contacts.Contact,
     Contacts.Import,
+    Contacts.BulkImportWorker,
     Contacts.ImportWorker,
     Jobs.UserJob,
     Partners,
@@ -406,8 +407,14 @@ defmodule Glific.ContactsTest do
         "type" => "import_contact"
       }
 
-      job_args = %{"contacts" => contacts, "params" => params, "user_job_id" => user_job.id}
-      assert :ok == ImportWorker.perform(%Oban.Job{args: job_args})
+      job_args = %{
+        "contacts" => contacts,
+        "params" => params,
+        "user_job_id" => user_job.id,
+        "organization_id" => organization.id
+      }
+
+      assert :ok == BulkImportWorker.perform(%Oban.Job{args: job_args})
     end
 
     test "import_contact/3 raises an exception if more than one keyword argument provided" do
@@ -475,7 +482,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -505,7 +512,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -513,6 +520,133 @@ defmodule Glific.ContactsTest do
       count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
 
       assert count == 0
+    end
+
+    test "jobs enqueued before the bulk import deploy still drain on the old worker" do
+      {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
+      [organization | _] = Partners.list_organizations()
+      {:ok, english} = Repo.fetch_by(Language, %{label_locale: "English"})
+
+      user_job =
+        UserJob.create_user_job(%{
+          status: "pending",
+          type: "contact_import",
+          total_tasks: 1,
+          tasks_done: 0,
+          organization_id: organization.id,
+          errors: %{}
+        })
+
+      # exactly the args the pre-deploy Import.decode_csv_data/3 produced: language
+      # already resolved to language_id, and organization_id nested inside params
+      old_args = %{
+        "contacts" => [
+          %{
+            "name" => "legacy_job",
+            "phone" => "919989329291",
+            "organization_id" => organization.id,
+            "collection" => "",
+            "delete" => nil,
+            "language_id" => english.id,
+            "contact_fields" => %{"city" => "Pune"}
+          }
+        ],
+        "params" => %{
+          "organization_id" => organization.id,
+          "user" => %{
+            "roles" => Enum.map(user.roles, &Atom.to_string/1),
+            "upload_contacts" => true
+          },
+          "type" => "import_contact"
+        },
+        "user_job_id" => user_job.id
+      }
+
+      assert :ok == ImportWorker.perform(%Oban.Job{args: old_args})
+
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329291"})
+      assert get_in(contact.fields, ["city", "value"]) == "Pune"
+      assert contact.language_id == english.id
+    end
+
+    test "import_contact/3 folds a phone listed twice in the same csv into one contact" do
+      {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
+      user = Map.put(user, :roles, [:admin])
+      [organization | _] = Partners.list_organizations()
+
+      data =
+        "name,phone,language,city,age\n" <>
+          "dup_one,+919989329293,english,Pune,30\n" <>
+          "dup_two,+919989329293,english,Mumbai,\n"
+
+      Import.import_contacts(
+        organization.id,
+        %{user: user, collection: "collection", type: :import_contact},
+        data: data
+      )
+
+      assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
+               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+
+      assert Contacts.count_contacts(%{filter: %{phone: "919989329293"}}) == 1
+
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329293"})
+
+      # the later row wins on a repeated field, and a field only on the first row survives
+      assert get_in(contact.fields, ["city", "value"]) == "Mumbai"
+      assert get_in(contact.fields, ["age", "value"]) == "30"
+    end
+
+    test "import_contact/3 merges new contact fields into the existing ones" do
+      {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
+      user = Map.put(user, :roles, [:admin])
+      [organization | _] = Partners.list_organizations()
+
+      import_data = fn data ->
+        Import.import_contacts(
+          organization.id,
+          %{user: user, collection: "collection", type: :import_contact},
+          data: data
+        )
+
+        Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+      end
+
+      import_data.("name,phone,language,city,age\nfield_merge,+919989329299,english,Pune,30\n")
+
+      import_data.("name,phone,language,age,state\nfield_merge,+919989329299,english,31,MH\n")
+
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329299"})
+
+      # a field only in the first csv survives the second import
+      assert get_in(contact.fields, ["city", "value"]) == "Pune"
+      # a field in both csvs takes the newer value
+      assert get_in(contact.fields, ["age", "value"]) == "31"
+      # a field only in the second csv is added
+      assert get_in(contact.fields, ["state", "value"]) == "MH"
+    end
+
+    test "import_contact/3 does not erase an existing field when the csv cell is blank" do
+      {:ok, user} = Repo.fetch_by(Users.User, %{name: "NGO Staff"})
+      user = Map.put(user, :roles, [:admin])
+      [organization | _] = Partners.list_organizations()
+
+      import_data = fn data ->
+        Import.import_contacts(
+          organization.id,
+          %{user: user, collection: "collection", type: :import_contact},
+          data: data
+        )
+
+        Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+      end
+
+      import_data.("name,phone,language,city\nblank_field,+919989329298,english,Pune\n")
+      import_data.("name,phone,language,city\nblank_field,+919989329298,english,\n")
+
+      {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329298"})
+
+      assert get_in(contact.fields, ["city", "value"]) == "Pune"
     end
 
     test "import_contact/3 with valid data from string inserts new contacts in the database" do
@@ -530,7 +664,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -555,7 +689,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -595,7 +729,7 @@ defmodule Glific.ContactsTest do
         url: "http://www.bar.com/foo.csv"
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -634,7 +768,7 @@ defmodule Glific.ContactsTest do
         url: "http://www.bar.com/foo.csv"
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -671,7 +805,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -700,7 +834,7 @@ defmodule Glific.ContactsTest do
       [organization | _] = Partners.list_organizations()
 
       Import.import_contacts(organization.id, %{user: user, type: :import_contact}, data: data)
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -729,7 +863,7 @@ defmodule Glific.ContactsTest do
       [organization | _] = Partners.list_organizations()
 
       Import.import_contacts(organization.id, %{user: user, type: :import_contact}, data: data)
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -769,7 +903,7 @@ defmodule Glific.ContactsTest do
         url: "http://www.bar.com/foo.csv"
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -807,7 +941,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -846,7 +980,7 @@ defmodule Glific.ContactsTest do
           file_path: get_tmp_path()
         )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true, with_safety: false)
@@ -885,7 +1019,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -928,7 +1062,7 @@ defmodule Glific.ContactsTest do
           file_path: get_tmp_path()
         )
 
-        assert_enqueued(worker: ImportWorker, prefix: "global")
+        assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
         assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                  Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1508,7 +1642,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1532,7 +1666,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1555,7 +1689,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1578,7 +1712,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1601,7 +1735,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1624,7 +1758,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1647,7 +1781,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1682,7 +1816,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1714,7 +1848,7 @@ defmodule Glific.ContactsTest do
         file_path: get_tmp_path()
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1809,7 +1943,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1832,7 +1966,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -1855,7 +1989,7 @@ defmodule Glific.ContactsTest do
         data: data
       )
 
-      assert_enqueued(worker: ImportWorker, prefix: "global")
+      assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
                Oban.drain_queue(queue: :contact_import, with_scheduled: true)

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -485,7 +485,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "test"}})
 
@@ -515,7 +515,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
 
@@ -586,7 +586,7 @@ defmodule Glific.ContactsTest do
       )
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       assert Contacts.count_contacts(%{filter: %{phone: "919989329293"}}) == 1
 
@@ -608,7 +608,7 @@ defmodule Glific.ContactsTest do
           data: data
         )
 
-        Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+        Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
       end
 
       import_data.("name,phone,language,city,age\nfield_merge,+919989329299,english,Pune,30\n")
@@ -634,7 +634,7 @@ defmodule Glific.ContactsTest do
           data: data
         )
 
-        Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+        Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
       end
 
       import_data.("name,phone,language,city\nblank_field,+919989329298,english,Pune\n")
@@ -663,7 +663,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919989329297"}})
 
@@ -688,7 +688,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919989329297"}})
 
@@ -728,7 +728,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "test"}})
 
@@ -767,7 +767,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "test"}})
 
@@ -804,7 +804,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "updated", phone: contact.phone}})
 
@@ -833,7 +833,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "updated", phone: contact.phone}})
 
@@ -862,7 +862,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "updated", phone: contact.phone}})
 
@@ -902,7 +902,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{name: "updated", phone: contact.phone}})
 
@@ -940,7 +940,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: contact.phone}})
 
@@ -979,7 +979,11 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true, with_safety: false)
+               Oban.drain_queue(
+                 queue: :contact_import_bulk,
+                 with_scheduled: true,
+                 with_safety: false
+               )
 
       count = Contacts.count_contacts(%{filter: %{phone: contact.phone}})
 
@@ -1018,7 +1022,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: contact.phone}})
 
@@ -1061,7 +1065,7 @@ defmodule Glific.ContactsTest do
         assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
         assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-                 Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+                 Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
         assert_not_called(Contacts.optin_contact())
       end
@@ -1641,7 +1645,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "9989329297"}})
 
@@ -1665,7 +1669,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "abcdef"}})
       assert count == 0
@@ -1688,7 +1692,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919876543210"}})
       assert count == 1
@@ -1711,7 +1715,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919876543210"}})
       assert count == 1
@@ -1734,7 +1738,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       [contact | _] = Contacts.list_contacts(%{filter: %{phone: 9_989_329_297}})
       assert contact.language_id == 1
@@ -1757,7 +1761,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       [contact | _] = Contacts.list_contacts(%{filter: %{phone: 9_989_329_297}})
       assert contact.language_id == 2
@@ -1780,7 +1784,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       [contact | _] = Contacts.list_contacts(%{filter: %{phone: 9_989_329_297}})
       assert contact.language_id == 1
@@ -1815,7 +1819,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       imported_contact = Contacts.get_contact_by_phone!(contact.phone)
 
@@ -1847,7 +1851,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       contact_history =
         Contacts.list_contact_history(Map.merge(attrs, %{filter: %{contact_id: contact.id}}))
@@ -1942,7 +1946,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919876543210"}})
       assert count == 0
@@ -1965,7 +1969,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
     end
   end
 
@@ -1988,7 +1992,7 @@ defmodule Glific.ContactsTest do
       assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
       assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-               Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+               Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       count = Contacts.count_contacts(%{filter: %{phone: "919989329297"}})
       assert count == 1
@@ -2008,7 +2012,7 @@ defmodule Glific.ContactsTest do
         data: data1
       )
 
-      Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+      Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       data2 =
         "name,phone,Language,opt_in\nunicode_contact,\u200E+919876543210\u200F,english,2021-03-09 12:34:25\n"
@@ -2019,7 +2023,7 @@ defmodule Glific.ContactsTest do
         data: data2
       )
 
-      Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+      Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
       # Should still be only 1 contact, not duplicated
       count = Contacts.count_contacts(%{filter: %{phone: "919876543210"}})

--- a/test/glific/contacts_test.exs
+++ b/test/glific/contacts_test.exs
@@ -8,9 +8,9 @@ defmodule Glific.ContactsTest do
 
   alias Glific.{
     Contacts,
+    Contacts.BulkImportWorker,
     Contacts.Contact,
     Contacts.Import,
-    Contacts.BulkImportWorker,
     Contacts.ImportWorker,
     Jobs.UserJob,
     Partners,
@@ -592,7 +592,6 @@ defmodule Glific.ContactsTest do
 
       {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329293"})
 
-      # the later row wins on a repeated field, and a field only on the first row survives
       assert get_in(contact.fields, ["city", "value"]) == "Mumbai"
       assert get_in(contact.fields, ["age", "value"]) == "30"
     end
@@ -618,11 +617,8 @@ defmodule Glific.ContactsTest do
 
       {:ok, contact} = Repo.fetch_by(Contact, %{phone: "919989329299"})
 
-      # a field only in the first csv survives the second import
       assert get_in(contact.fields, ["city", "value"]) == "Pune"
-      # a field in both csvs takes the newer value
       assert get_in(contact.fields, ["age", "value"]) == "31"
-      # a field only in the second csv is added
       assert get_in(contact.fields, ["state", "value"]) == "MH"
     end
 

--- a/test/glific_web/schema/contact_test.exs
+++ b/test/glific_web/schema/contact_test.exs
@@ -283,7 +283,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     assert Contacts.count_contacts(%{filter: %{phone: "918979120220"}}) == 0
   end
@@ -310,7 +310,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     # Will fail since contact is not a valid phone number
     assert Contacts.count_contacts(%{filter: %{phone: test_phone}}) == 0
@@ -343,7 +343,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     # Phone is stored in normalized format without + prefix
     normalized_phone = "919917443992"
@@ -380,7 +380,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     assert Contacts.count_contacts(%{filter: %{name: "#{test_name} updated"}}) == 0
     assert Contacts.count_contacts(%{filter: %{term: "#{test_name} updated"}}) == 0
@@ -413,7 +413,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     count = Contacts.count_contacts(%{filter: %{name: "uploaded_contact"}})
     assert count == 1
@@ -449,7 +449,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     count = Contacts.count_contacts(%{filter: %{name: "test"}})
     assert count == 1
@@ -485,7 +485,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     count = Contacts.count_contacts(%{filter: %{name: "test"}})
     assert count == 1
@@ -514,7 +514,7 @@ defmodule GlificWeb.Schema.ContactTest do
     assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
-             Oban.drain_queue(queue: :contact_import, with_scheduled: true)
+             Oban.drain_queue(queue: :contact_import_bulk, with_scheduled: true)
 
     count = Contacts.count_contacts(%{filter: %{name: "test"}})
     assert count == 0

--- a/test/glific_web/schema/contact_test.exs
+++ b/test/glific_web/schema/contact_test.exs
@@ -6,7 +6,7 @@ defmodule GlificWeb.Schema.ContactTest do
   alias Glific.{
     Contacts,
     Contacts.Contact,
-    Contacts.ImportWorker,
+    Contacts.BulkImportWorker,
     Fixtures,
     Flows,
     Messages.Message,
@@ -280,7 +280,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _query_data} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -307,7 +307,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -340,7 +340,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -377,7 +377,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -410,7 +410,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -446,7 +446,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -482,7 +482,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)
@@ -511,7 +511,7 @@ defmodule GlificWeb.Schema.ContactTest do
       )
 
     assert {:ok, _} = result
-    assert_enqueued(worker: ImportWorker, prefix: "global")
+    assert_enqueued(worker: BulkImportWorker, prefix: "global")
 
     assert %{success: 1, failure: 0, snoozed: 0, discard: 0, cancelled: 0} ==
              Oban.drain_queue(queue: :contact_import, with_scheduled: true)

--- a/test/glific_web/schema/contact_test.exs
+++ b/test/glific_web/schema/contact_test.exs
@@ -5,8 +5,8 @@ defmodule GlificWeb.Schema.ContactTest do
 
   alias Glific.{
     Contacts,
-    Contacts.Contact,
     Contacts.BulkImportWorker,
+    Contacts.Contact,
     Fixtures,
     Flows,
     Messages.Message,


### PR DESCRIPTION
## Why

Contact import wrote one field at a time. `ContactField.do_add_contact_field/5` ran once per field per contact, and each call was six to nine statements, not one:

| Statement | Source |
|---|---|
| `SELECT id FROM contacts WHERE id = $1` (permission scoping) | `contacts.ex:192` |
| `UPDATE contacts SET fields = $1` — row lock and a new row version, **per field** | `contacts.ex:318` |
| `SELECT + UPDATE profiles` when `active_profile_id` is set | `contact_field.ex:196` |
| `SELECT FROM contacts_fields WHERE shortcode = $1 AND scope = $2` | `contact_field.ex:178` |
| `UPDATE contacts_fields SET name = $1` when the stored label differs from the snake_case header | `contact_field.ex:227` |
| `UPDATE contacts SET fields = jsonb_set(…) WHERE organization_id = $1` — no id predicate, so every contact row in the org | `contact_field.ex:315` |
| `INSERT INTO contact_histories` | `contacts.ex:998` |
| trigger `update_profile_id_on_new_contact_history` — a further `UPDATE` plus a `SELECT` on `contacts` | `structure.sql:7227` |
| trigger `remove_old_history` — a `row_number()` window over the contact's history, then a `DELETE` | `structure.sql:7185` |

A contact with 15 fields cost roughly 112 statements and rewrote its own row 17 times (15 field updates, the name/optin update, and the `contacts_groups` `updated_at` trigger). Each rewrite takes a row lock and leaves a dead tuple, so inbound message workers queued behind the importer for `last_communication_at` updates and sends stalled.

Two further costs sat outside the loop. `decode_csv_data/3` resolved each row's language with `Repo.fetch_by(Contact, %{phone: …})` in the calling process, serially, before a single Oban job existed — lakhs of blocking round trips on the request path holding one pool connection. And the `contacts_fields` label update rewrote NGOs' human-readable field labels to snake_case as a side effect.

Measured on the same 100 contact x 15 field chunk:

| | Statements | Time |
|---|---|---|
| Before | **11,616** | **1,446ms** |
| After | **9** | **220ms** |

## What changed

New `Glific.Contacts.BulkImport` and `Glific.Contacts.BulkImportWorker`. Per 100 row chunk:

- **one** `SELECT` for the existing contacts, replacing four-plus lookups per contact (`maybe_create_contact`, `may_update_contact`, `maybe_update_contact`, `add_language`)
- **one** `SELECT` of the language table, replacing the per-row lookup and moving it off the request path
- **at most two** `INSERT … ON CONFLICT (phone, organization_id) DO UPDATE`, split by opt-in eligibility because `ON CONFLICT` permits a single update clause. Values that differ per row travel in `VALUES` and are read back through `EXCLUDED`, so one statement applies 100 different values; `returning` supplies the ids and merged fields the later writes need, without another query
- **one** `insert_all` on `contacts_fields` with `on_conflict: :nothing`, which registers new shortcodes without touching existing rows — so the org-wide `jsonb_set` never fires and human labels survive
- **one** `insert_all` on `contact_histories`
- **one** `insert_all` on `contacts_groups`
- **one** `update_all` on `profiles`, joined to contacts, for the rows that have an active profile

The writes run in a single `Repo.transaction`. The contact, field and collection writes are idempotent on retry but the history insert is not, so a chunk that failed part way could otherwise duplicate history rows when Oban retried it.

`ContactField.do_add_contact_field/5` is unchanged — it has 16 callers across `clients/` and the flow engine.

### Field merging

```elixir
fields: fragment("? || EXCLUDED.fields", c.fields)
```

`build_fields/2` sends only the columns present in the CSV and skips blank cells, and jsonb `||` is a shallow merge with the right side winning. Keys only in the database are preserved, keys only in the CSV are added, shared keys take the CSV value, and a blank cell erases nothing.

This also removes a lost-update window. The old path read `contact.fields`, put one key, and wrote the whole map back, so two workers touching the same contact could overwrite each other from a stale base. The merge now happens inside Postgres in one statement.

### Two queues, not one

`BulkImportWorker` runs on a **new** `contact_import_bulk` queue, partitioned by organisation:

```elixir
contact_import: 10,                    # old worker drains here, unpartitioned
contact_import_bulk: [
  local_limit: 10,
  global_limit: [allowed: 5, partition: [args: :organization_id]]
],
```

Partitioning is a **queue level** setting, and Oban Pro stamps `meta.partition_key` at insert time. Jobs enqueued before this ships have no such key, their generated `partition_key` column is NULL, and the partitioned fetch matches on `partition_key = key` (`smart.ex:1311`) — so a null never matches. Putting the partition on `contact_import` would have made every already-queued job permanently unfetchable: never retried, never discarded, no error, with the affected NGOs left on "Contact upload is in progress" forever. The partial index `WHERE state = 'available' AND partition_key IS NOT NULL` confirms the design intent.

Leaving `contact_import` unpartitioned means the old worker drains normally while every new import is partitioned from day one. Verified end to end — see the deploy notes.

### Columns `insert_all` does not supply

`Repo.insert_all/3` bypasses Ecto schema defaults, so two columns are set explicitly in `contact_entry/4`:

- **`contact_type`** defaults to `"WABA"` in the schema but has no database default. `searches.ex:179` and `:259` both filter `contact_type in ["WABA", "WABA+WA"]`, so a null would keep imported contacts out of the conversation list and out of search. Set on insert only, never in the `on_conflict` update, so a re-import cannot downgrade an existing `"WA"` or `"WABA+WA"` contact.
- **`last_communication_at`** is set by `Contacts.create_contact/1`. The conversation list orders by it descending and Postgres sorts nulls first on descending, so a null would place every fresh import above contacts who had just messaged. Also insert only.

### Consent

`Contacts.contact_opted_in/4` declined to optin a blocked contact through `ignore_optin?/2` (`contacts.ex:551`). `optin_allowed?/1` mirrors that guard, so an import cannot unblock or optin a contact an organisation blocked deliberately. The contact's fields are still updated. This is why `load_existing/1` selects `status`.

### Active profiles

`do_add_contact_field/5` also wrote the merged field map to the contact's active profile, and `Profiles.switch_profile/2` (`profiles.ex:150`) copies `profile.fields` back over `contact.fields`. Without that write, the first profile switch after an import would discard what the import wrote. `sync_profiles/3` restores it as a single `UPDATE profiles … FROM contacts` joined on `active_profile_id`, since the merged fields are already on the contact row. Orgs without profiles do no work at all.

### Error accounting

- `update_user_job_progress/2` merged an atom `:errors` key into a map whose existing key came back from jsonb as the string `"errors"`. Both survived in the Elixir map and one won on encode, so only the first chunk's errors reached the report. Keyed `"errors"` throughout now, with the inner maps merged.
- A chunk is one transaction, so a row that passes validation but violates a database constraint takes all 100 rows with it. The progress update was skipped in that case, `tasks_done` never reached `total_tasks`, `UserJobWorker` never marked the job successful, and `get_contact_upload_report/2` reported "in progress" indefinitely. `handle_failure/5` reraises while attempts remain and, on the final attempt, records the chunk's phones as errors and still increments progress.
- `Contacts.delete_contact/1` awaits four cascade deletes over `Task.async` with a 400s timeout. A contact with a very large message history could exhaust it, and an unhandled exit would fail the whole chunk, so `delete_one/3` records it per row instead.

### Shared helpers

`validate_contacts/1`, `validate_contact/1`, `parse_worker_params/2` and `update_user_job_progress/2` live once in `Glific.Contacts.Import` and are called by both workers, so there is a single definition of each behaviour.

`validate_contacts/1` and `reject_missing/4` both restore CSV order. Their accumulators prepend and nothing reversed them, so when a phone appeared twice the first row won — an artefact of list building rather than a decision, and it made import and move disagree with each other. Both now see rows in the order they were written, and the later row wins consistently.

### Smaller changes

- Deletes run after the write transaction rather than before it, so a chunk that rolls back has not deleted anything. They cannot run inside it: `Contacts.delete_contact/1` fans out over `Task.async` on separate connections.
- `dedupe/1` folds a phone listed more than once in a chunk into a single row, merging the field maps in CSV order. Postgres rejects an `ON CONFLICT DO UPDATE` that touches the same row twice.
- Collection labels are trimmed. `collection_label_check/2` split on `","` without trimming, so `"a, b"` created a group literally named `" b"`.
- Prefix language matching walks a list ordered by language id, so ties are deterministic. `get_language_by_label_or_locale/1` had no `order_by`.
- A missing active English language raises with an explanatory message rather than a bare `Map.fetch!` error.
- `build_fields/2` takes the chunk timestamp, so `fields.inserted_at` agrees with the history row for the same write.

## Behaviour changes worth a look

1. **Field labels are no longer rewritten.** Some organisations already have snake_cased `contacts_fields.name` values from the previous behaviour. Backfilling those is a separate decision.
2. **A phone listed twice in one CSV: the later row now wins**, consistently across import and move, per the ordering fix above.
3. **Language is resolved when the chunk runs, not when it is enqueued.** Only observable if a language is added mid-import.
4. **`move_contact` for a phone that does not exist** reports `"Contact <phone> was not found and hence not added"` rather than `"Contact not found."`.
5. **Left as is:** `cleanup_contact_data/3` drops only `phone`, `group`, `language`, `delete` and `opt_in`, so `name` and `collection` still land as contact *fields*. A test pins the current behaviour so a future change is visible.
6. **`move_contact` overwrites the contact name** when the CSV supplies a different one, and rejects the row outright when the name is blank. Both match the previous path; noting it because a move CSV with stale names will rename contacts.

**Not** a behaviour change: contact history keeps one row per field and its existing `event_meta` shape (`%{field: %{data, label, value, old_value, new_value}}`), because `contactHistory.tsx` renders `eventMeta.field.label`. An earlier revision of this PR collapsed it to one row per contact and blanked the history panel. That decision is what makes the trigger cost dominant — see #5695.

## Testing

`148 tests, 0 failures` across `test/glific/contacts`, `contacts_test.exs`, `contact_test.exs`, `contact_field_test.exs`.

`test/glific/contacts/bulk_import_test.exs` covers wide 15-field rows, per-field history rows in the shape the UI reads including `old_value` chaining, opt-in and `bsp_status`, collection membership and label trimming, field merging, blank cells not erasing stored values, `contact_type` on insert and its preservation on re-import, `last_communication_at`, blocked contacts staying blocked while their fields still update, profile field propagation, multi-chunk error accumulation, the delete flag, duplicate phones folding identically for import and move, `move_contact` updating without creating or altering opt-in, errors recorded for unknown phones, one bad row not stopping good rows in the same chunk, language by label / locale / unknown / blank, human label preservation, headers registered once, commas, quotes and 3000 character values, unicode phone normalisation, and two rollback tests — one failing the final write in the transaction, one confirming a rolled back chunk leaves its delete rows unapplied.

`contacts_test.exs` adds a test that runs a job built with the pre-deploy arg shape through the old worker.

Also exercised manually against a 10,000 row CSV plus reimport, move, blank-out and edge-case files, comparing every contact's field keys before and after each pass.

## Deploy notes

**`ImportWorker` and the `contact_import` queue must ship in this release and be removed together later.** `ImportWorker` is the only remaining consumer of `process_data/3`, and jobs already queued carry the old arg shape (`language_id` pre-resolved, `organization_id` nested inside `params`) and no partition key. Nothing enqueues it — it has no `make_job/4` — so it only ever drains what was already there.

Verified on a reset database, with pre-deploy jobs planted in all three states a real queue holds:

```
55  available  -> completed  attempt 1  partition_key NULL  234ms
56  scheduled  -> completed  attempt 1  partition_key NULL  233ms
57  retryable  -> completed  attempt 2  partition_key NULL  234ms

contact_import       ImportWorker      completed   3   null_partition_key 3
contact_import_bulk  BulkImportWorker  completed  20   null_partition_key 0
```

Both properties hold at once: legacy jobs run despite having no partition key, and every new job is partitioned. `UserJobWorker` marked the legacy user job `success 3/3`, so the report downloads rather than hanging.

Remove `ImportWorker` and the `contact_import` queue once this returns zero:

```sql
SELECT count(*) FROM global.oban_jobs
WHERE queue = 'contact_import' AND state IN ('available', 'scheduled', 'retryable');
```

## Follow-ups

- #5695 — move `contact_histories` pruning out of the per-insert trigger. With per-field history restored, `remove_old_history` is the dominant remaining cost of an import: identical statement count, 51ms vs 220ms on the same chunk.
- Remove `ImportWorker`, `process_data/3` and the `contact_import` queue once it drains.
- Re-tune `@contact_job_chunk_size` (100) and the `index * 2` stagger now that writes are batched. The stagger delays a 3 lakh import by about 100 minutes for roughly 130s of work, and `allowed: 5` on the partitioned queue now provides that throttling properly.
