### PR TITLE
fix: clear error when downloading legacy knowledge base files

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1031,9 +1031,17 @@ defmodule Glific.Assistants do
 
   @doc """
   Get a knowledge base file's metadata and signed download URL from Kaapi.
+
+  Legacy knowledge bases store OpenAI file ids (`file-...`), which Kaapi has no
+  document for, so those downloads are rejected upfront.
   """
   @spec get_file(String.t(), non_neg_integer()) ::
           {:ok, map()} | {:error, String.t()}
+  def get_file("file-" <> _, _organization_id),
+    do:
+      {:error,
+       "This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded"}
+
   def get_file(file_id, organization_id) do
     case Kaapi.get_document(file_id, organization_id) do
       {:ok, document_data} ->

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1032,29 +1032,37 @@ defmodule Glific.Assistants do
   @doc """
   Get a knowledge base file's metadata and signed download URL from Kaapi.
 
-  Legacy knowledge bases store OpenAI file ids (`file-...`), which Kaapi has no
-  document for, so those downloads are rejected upfront.
+  A knowledge base version with no `kaapi_job_id` was synced straight from OpenAI
+  before the knowledge base rewrite, so Kaapi holds no document for its files and
+  those downloads are rejected upfront.
   """
   @spec get_file(String.t(), non_neg_integer()) ::
           {:ok, map()} | {:error, String.t()}
-  def get_file("file-" <> _, _organization_id),
-    do:
-      {:error,
-       "This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded"}
-
   def get_file(file_id, organization_id) do
-    case Kaapi.get_document(file_id, organization_id) do
-      {:ok, document_data} ->
-        {:ok,
-         %{
-           file_id: document_data[:id],
-           filename: document_data[:fname],
-           signed_url: document_data[:signed_url]
-         }}
+    with false <- legacy_file?(file_id, organization_id),
+         {:ok, document_data} <- Kaapi.get_document(file_id, organization_id) do
+      {:ok,
+       %{
+         file_id: document_data[:id],
+         filename: document_data[:fname],
+         signed_url: document_data[:signed_url]
+       }}
+    else
+      true ->
+        {:error,
+         "This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded"}
 
       {:error, reason} ->
         format_kaapi_file_error("File download", reason)
     end
+  end
+
+  @spec legacy_file?(String.t(), non_neg_integer()) :: boolean()
+  defp legacy_file?(file_id, organization_id) do
+    KnowledgeBaseVersion
+    |> where([kbv], is_nil(kbv.kaapi_job_id))
+    |> where([kbv], fragment("jsonb_exists(?, ?)", kbv.files, ^file_id))
+    |> Repo.exists?(organization_id: organization_id)
   end
 
   @spec format_kaapi_file_error(String.t(), map() | binary() | any()) :: {:error, String.t()}

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -441,14 +441,59 @@ defmodule Glific.Assistants.AssistantTest do
       assert signed_url == "https://kaapi-test.s3.amazonaws.com/test/biu-1.pdf"
     end
 
-    test "returns a clear error for legacy OpenAI file ids", %{
-      organization_id: organization_id
+    test "returns a clear error for files of a knowledge base version with no kaapi_job_id", %{
+      organization_id: organization_id,
+      knowledge_base: kb
     } do
+      {:ok, _legacy_version} =
+        Assistants.create_knowledge_base_version(%{
+          knowledge_base_id: kb.id,
+          llm_service_id: "vs_legacy_123",
+          status: :completed,
+          organization_id: organization_id,
+          files: %{"file-abc123" => %{"name" => "legacy.pdf", "size" => 10}},
+          size: 10
+        })
+
       assert {:error, error_message} =
-               Assistants.get_file("file-1r7VpWeTW4CThvnsjvBRp4", organization_id)
+               Assistants.get_file("file-abc123", organization_id)
 
       assert error_message ==
                "This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded"
+    end
+
+    test "fetches from Kaapi when the knowledge base version has a kaapi_job_id", %{
+      organization_id: organization_id,
+      knowledge_base: kb
+    } do
+      {:ok, _version} =
+        Assistants.create_knowledge_base_version(%{
+          knowledge_base_id: kb.id,
+          llm_service_id: "vs_synced_123",
+          kaapi_job_id: "job_123",
+          status: :completed,
+          organization_id: organization_id,
+          files: %{"file-abc123" => %{"name" => "synced.pdf", "size" => 10}},
+          size: 10
+        })
+
+      Tesla.Mock.mock(fn
+        %{method: :get, url: "This is not a secret/api/v1/documents/file-abc123"} ->
+          %Tesla.Env{
+            status: 200,
+            body: %{
+              success: true,
+              data: %{
+                id: "file-abc123",
+                fname: "synced.pdf",
+                signed_url: "https://kaapi-test.s3.amazonaws.com/test/synced.pdf"
+              }
+            }
+          }
+      end)
+
+      assert {:ok, %{filename: "synced.pdf"}} =
+               Assistants.get_file("file-abc123", organization_id)
     end
 
     test "returns an error when Kaapi fails", %{organization_id: organization_id} do

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -441,6 +441,16 @@ defmodule Glific.Assistants.AssistantTest do
       assert signed_url == "https://kaapi-test.s3.amazonaws.com/test/biu-1.pdf"
     end
 
+    test "returns a clear error for legacy OpenAI file ids", %{
+      organization_id: organization_id
+    } do
+      assert {:error, error_message} =
+               Assistants.get_file("file-1r7VpWeTW4CThvnsjvBRp4", organization_id)
+
+      assert error_message ==
+               "This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded"
+    end
+
     test "returns an error when Kaapi fails", %{organization_id: organization_id} do
       Tesla.Mock.mock(fn
         %{method: :get, url: "This is not a secret/api/v1/documents/doc_123"} ->


### PR DESCRIPTION
## Summary
Target issue is #5693

Downloading a knowledge base file from a **legacy** assistant (created before the knowledge base
rewrite) failed with a raw Kaapi error the user could do nothing with:

> File download failed (status 422): Validation failed

Legacy knowledge base versions were synced straight from OpenAI, so Kaapi holds no document for
their files. `getFile` still passed those ids to `GET /api/v1/documents/:document_id`; Kaapi
answered 422, and `format_kaapi_file_error/2` forwarded it verbatim to the UI.

Those files are genuinely unretrievable — they were never registered with Kaapi, and there is no
OpenAI file-retrieval path in the codebase. So the fix is to fail clearly rather than pretend.

### Changes

**`lib/glific/assistants.ex`** — `get_file/2` now checks whether the file belongs to a legacy
knowledge base version before making any Kaapi call. Legacy is the same marker already used
elsewhere in this module: a `knowledge_base_versions` row with no `kaapi_job_id`.

```elixir
defp legacy_file?(file_id, organization_id) do
  KnowledgeBaseVersion
  |> where([kbv], is_nil(kbv.kaapi_job_id))
  |> where([kbv], fragment("jsonb_exists(?, ?)", kbv.files, ^file_id))
  |> Repo.exists?(organization_id: organization_id)
end
```

On a hit, `get_file/2` returns:

> This file belongs to a legacy knowledge base created before the knowledge base rewrite and cannot be downloaded

The lookup is org-scoped through `Repo.exists?(organization_id: ...)`, so there is no cross-org
read. `files` is a real `jsonb` column keyed by file id on both the legacy sync path and the
current Kaapi path, so the key lookup matches in both cases.

This replaces an earlier version of the fix that matched on the `"file-"` id prefix — that was
guessing at the id shape rather than asking the data which knowledge base the file came from.

**`test/glific/assistants/assistant_test.exs`** — two tests:
- a legacy version (no `kaapi_job_id`) asserts the exact message, deliberately with no `Tesla.Mock`
  set up, so the test fails if the guard is removed and the call reaches Kaapi
- a version *with* a `kaapi_job_id` still goes to Kaapi and returns the file, so the guard cannot
  silently swallow live downloads

Non-legacy downloads are untouched.

## Checklist
- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Notes
Frontend follow-up: the download button should be hidden/disabled for legacy knowledge bases
entirely. The backend already exposes `legacy` (`is_nil(knowledge_base_version.kaapi_job_id)`) on
both `vector_store` and `assistant`, so no further backend change is needed for that. This PR only
makes the failure legible.
