### PR TITLE
fix: chat with the selected assistant version in Try It Out

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1182,10 +1182,7 @@ defmodule Glific.Assistants do
   end
 
   @doc """
-  Dispatches a chat message to the selected (or live, when none is given) Kaapi config
-  version of an assistant ("Try It Out" sandbox).
-  Kaapi just queues the job; the reply arrives via the `/kaapi/assistant_chat` callback and
-  is published over the `assistant_chat_response` subscription — no history is persisted here.
+  Queues a chat message on Kaapi for the selected (or live) config version of an assistant.
   """
   @spec send_message(map(), non_neg_integer(), non_neg_integer()) ::
           {:ok, map()} | {:error, any()}
@@ -1246,14 +1243,13 @@ defmodule Glific.Assistants do
     do: Repo.preload(assistant, :active_config_version).active_config_version
 
   defp fetch_config_version(assistant, config_version_id, organization_id) do
-    case Repo.fetch_by(AssistantConfigVersion, %{
-           id: config_version_id,
-           assistant_id: assistant.id,
-           organization_id: organization_id
-         }) do
-      {:ok, config_version} -> config_version
-      _ -> nil
-    end
+    AssistantConfigVersion
+    |> where(
+      [v],
+      v.id == ^config_version_id and v.assistant_id == ^assistant.id and
+        v.organization_id == ^organization_id and is_nil(v.deleted_at)
+    )
+    |> Repo.one()
   end
 
   @spec build_assistant_chat_payload(

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1182,7 +1182,8 @@ defmodule Glific.Assistants do
   end
 
   @doc """
-  Dispatches a chat message to an assistant's live Kaapi config ("Try It Out" sandbox).
+  Dispatches a chat message to the selected (or live, when none is given) Kaapi config
+  version of an assistant ("Try It Out" sandbox).
   Kaapi just queues the job; the reply arrives via the `/kaapi/assistant_chat` callback and
   is published over the `assistant_chat_response` subscription — no history is persisted here.
   """
@@ -1192,7 +1193,7 @@ defmodule Glific.Assistants do
     request_id = Ecto.UUID.generate()
 
     with {:ok, {kaapi_uuid, kaapi_version_number}} <-
-           fetch_live_kaapi_config(assistant_id, organization_id),
+           fetch_kaapi_config(assistant_id, params[:config_version_id], organization_id),
          payload =
            build_assistant_chat_payload(
              input,
@@ -1208,19 +1209,50 @@ defmodule Glific.Assistants do
     end
   end
 
-  @spec fetch_live_kaapi_config(non_neg_integer(), non_neg_integer()) ::
-          {:ok, {String.t(), non_neg_integer()}} | {:error, String.t()}
-  defp fetch_live_kaapi_config(assistant_id, organization_id) do
+  @spec fetch_kaapi_config(
+          non_neg_integer(),
+          non_neg_integer() | String.t() | nil,
+          non_neg_integer()
+        ) :: {:ok, {String.t(), non_neg_integer()}} | {:error, String.t()}
+  defp fetch_kaapi_config(assistant_id, config_version_id, organization_id) do
     with {:ok, assistant} <-
            Repo.fetch_by(Assistant, %{id: assistant_id, organization_id: organization_id}),
-         assistant <- Repo.preload(assistant, :active_config_version),
-         {kaapi_uuid, %AssistantConfigVersion{kaapi_version_number: kaapi_version_number}}
-         when not is_nil(kaapi_uuid) and not is_nil(kaapi_version_number) <-
-           {assistant.kaapi_uuid, assistant.active_config_version} do
+         %Assistant{kaapi_uuid: kaapi_uuid} when not is_nil(kaapi_uuid) <- assistant,
+         %AssistantConfigVersion{kaapi_version_number: kaapi_version_number}
+         when not is_nil(kaapi_version_number) <-
+           fetch_config_version(assistant, config_version_id, organization_id) do
       {:ok, {kaapi_uuid, kaapi_version_number}}
     else
-      {:error, _} -> {:error, "Assistant not found"}
-      _ -> {:error, "Assistant does not have a live config version yet"}
+      {:error, _} ->
+        {:error, "Assistant not found"}
+
+      %Assistant{} ->
+        {:error, "Assistant is not available on Kaapi yet"}
+
+      _ when is_nil(config_version_id) ->
+        {:error, "Assistant does not have a live config version yet"}
+
+      _ ->
+        {:error, "Selected assistant version is not available on Kaapi yet"}
+    end
+  end
+
+  @spec fetch_config_version(
+          Assistant.t(),
+          non_neg_integer() | String.t() | nil,
+          non_neg_integer()
+        ) :: AssistantConfigVersion.t() | nil
+  defp fetch_config_version(assistant, nil, _organization_id),
+    do: Repo.preload(assistant, :active_config_version).active_config_version
+
+  defp fetch_config_version(assistant, config_version_id, organization_id) do
+    case Repo.fetch_by(AssistantConfigVersion, %{
+           id: config_version_id,
+           assistant_id: assistant.id,
+           organization_id: organization_id
+         }) do
+      {:ok, config_version} -> config_version
+      _ -> nil
     end
   end
 

--- a/lib/glific_web/resolvers/assistant_chat.ex
+++ b/lib/glific_web/resolvers/assistant_chat.ex
@@ -1,6 +1,6 @@
 defmodule GlificWeb.Resolvers.AssistantChat do
   @moduledoc """
-  Resolver for sending a chat message to an assistant's live Kaapi config version
+  Resolver for sending a chat message to a selected (default: live) Kaapi config version of an assistant
   (the "Try It Out" sandbox). Dispatch is synchronous (Kaapi just queues the job);
   the reply arrives later via the `assistant_chat_response` subscription once Kaapi's
   callback fires.
@@ -9,7 +9,7 @@ defmodule GlificWeb.Resolvers.AssistantChat do
   alias Glific.Assistants
 
   @doc """
-  Dispatches a chat message to an assistant's live Kaapi config version.
+  Dispatches a chat message to the selected (or live) Kaapi config version of an assistant.
   """
   @spec send_message(Absinthe.Resolution.t(), %{input: map()}, %{context: map()}) ::
           {:ok, map()} | {:error, any()}
@@ -17,7 +17,8 @@ defmodule GlificWeb.Resolvers.AssistantChat do
     context_params = %{
       assistant_id: params.assistant_id,
       input: params.message,
-      conversation_id: params[:conversation_id]
+      conversation_id: params[:conversation_id],
+      config_version_id: params[:config_version_id]
     }
 
     Assistants.send_message(context_params, user.organization_id, user.id)

--- a/lib/glific_web/schema/assistant_chat_types.ex
+++ b/lib/glific_web/schema/assistant_chat_types.ex
@@ -1,7 +1,7 @@
 defmodule GlificWeb.Schema.AssistantChatTypes do
   @moduledoc """
-  GraphQL surface for sending a chat message to an assistant's live Kaapi config
-  version (the "Try It Out" sandbox) and receiving the async reply over a
+  GraphQL surface for sending a chat message to a selected (default: live) Kaapi config
+  version of an assistant (the "Try It Out" sandbox) and receiving the async reply over a
   subscription. Dispatch (`send_assistant_message`) just queues the job on Kaapi and
   returns immediately; the actual answer arrives later via `assistant_chat_response`
   once Kaapi calls back.
@@ -27,11 +27,15 @@ defmodule GlificWeb.Schema.AssistantChatTypes do
     field(:assistant_id, non_null(:id))
     field(:message, non_null(:string))
     field(:conversation_id, :string)
+
+    @desc "Config version to chat with. Defaults to the assistant's live version."
+    field(:config_version_id, :id)
   end
 
   object :assistant_chat_mutations do
-    @desc "Send a chat message to an assistant's live config version via Kaapi. Returns
-    a job_id immediately; the reply is delivered over the assistant_chat_response subscription."
+    @desc "Send a chat message to the selected (default: live) config version of an assistant
+    via Kaapi. Returns a job_id immediately; the reply is delivered over the
+    assistant_chat_response subscription."
     field :send_assistant_message, :assistant_chat_result do
       arg(:input, non_null(:assistant_chat_input))
       middleware(Authorize, :staff)

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -3118,6 +3118,59 @@ defmodule Glific.AssistantsTest do
                )
     end
 
+    test "dispatches the selected config version instead of the live one",
+         %{organization_id: organization_id} do
+      assistant = create_live_assistant(organization_id)
+
+      selected_version =
+        Fixtures.assistant_config_version_fixture(%{
+          assistant_id: assistant.id,
+          organization_id: organization_id,
+          kaapi_version_number: 7
+        })
+
+      mock(fn %Tesla.Env{method: :post, body: body} ->
+        decoded = Jason.decode!(body)
+        assert decoded["config"] == %{"id" => "kaapi_uuid_001", "version" => 7}
+        %Tesla.Env{status: 200, body: %{data: %{job_id: "job_chat_003"}}}
+      end)
+
+      assert {:ok, %{job_id: "job_chat_003"}} =
+               Assistants.send_message(
+                 %{
+                   assistant_id: assistant.id,
+                   input: "Hello",
+                   config_version_id: selected_version.id
+                 },
+                 organization_id,
+                 1
+               )
+    end
+
+    test "returns an error when the selected config version belongs to another assistant",
+         %{organization_id: organization_id} do
+      assistant = create_live_assistant(organization_id)
+      other_assistant = Fixtures.live_assistant_fixture(%{organization_id: organization_id})
+
+      other_version =
+        Fixtures.assistant_config_version_fixture(%{
+          assistant_id: other_assistant.id,
+          organization_id: organization_id,
+          kaapi_version_number: 9
+        })
+
+      assert {:error, _reason} =
+               Assistants.send_message(
+                 %{
+                   assistant_id: assistant.id,
+                   input: "Hello",
+                   config_version_id: other_version.id
+                 },
+                 organization_id,
+                 1
+               )
+    end
+
     test "returns an error when Kaapi dispatch fails",
          %{organization_id: organization_id} do
       assistant = create_live_assistant(organization_id)

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -3092,7 +3092,7 @@ defmodule Glific.AssistantsTest do
          %{organization_id: organization_id} do
       assistant = create_live_assistant(organization_id)
 
-      assert {:error, _reason} =
+      assert {:error, "Assistant not found"} =
                Assistants.send_message(
                  %{assistant_id: assistant.id, input: "Hello"},
                  organization_id + 1,
@@ -3100,7 +3100,7 @@ defmodule Glific.AssistantsTest do
                )
     end
 
-    test "returns an error when the assistant has no live config version yet",
+    test "returns an error when the assistant is not on Kaapi yet",
          %{organization_id: organization_id} do
       {:ok, assistant} =
         %Assistant{}
@@ -3110,7 +3110,23 @@ defmodule Glific.AssistantsTest do
         })
         |> Repo.insert()
 
-      assert {:error, _reason} =
+      assert {:error, "Assistant is not available on Kaapi yet"} =
+               Assistants.send_message(
+                 %{assistant_id: assistant.id, input: "Hello"},
+                 organization_id,
+                 1
+               )
+    end
+
+    test "returns an error when the assistant has no live config version yet",
+         %{organization_id: organization_id} do
+      assistant =
+        Fixtures.assistant_fixture(%{
+          organization_id: organization_id,
+          kaapi_uuid: "kaapi_uuid_002"
+        })
+
+      assert {:error, "Assistant does not have a live config version yet"} =
                Assistants.send_message(
                  %{assistant_id: assistant.id, input: "Hello"},
                  organization_id,
@@ -3159,7 +3175,7 @@ defmodule Glific.AssistantsTest do
           kaapi_version_number: 9
         })
 
-      assert {:error, _reason} =
+      assert {:error, "Selected assistant version is not available on Kaapi yet"} =
                Assistants.send_message(
                  %{
                    assistant_id: assistant.id,

--- a/test/glific_web/schema/assistant_chat_test.exs
+++ b/test/glific_web/schema/assistant_chat_test.exs
@@ -50,6 +50,41 @@ defmodule GlificWeb.Schema.AssistantChatTest do
       assert response["errors"] in [nil, []]
     end
 
+    test "dispatches the selected config version when configVersionId is given",
+         %{staff: user, organization_id: organization_id} do
+      assistant = Fixtures.live_assistant_fixture(%{organization_id: organization_id})
+
+      selected_version =
+        Fixtures.assistant_config_version_fixture(%{
+          assistant_id: assistant.id,
+          organization_id: organization_id,
+          kaapi_version_number: 5
+        })
+
+      mock(fn %Tesla.Env{method: :post, body: body} ->
+        assert Jason.decode!(body)["config"]["version"] == 5
+
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{job_id: "job_gql_002", conversation: %{id: "conv_gql_002"}}}
+        }
+      end)
+
+      result =
+        auth_query_gql_by(:send_message, user,
+          variables: %{
+            "input" => %{
+              "assistantId" => assistant.id,
+              "message" => "Hello",
+              "configVersionId" => selected_version.id
+            }
+          }
+        )
+
+      assert {:ok, query_data} = result
+      assert get_in(query_data, [:data, "sendAssistantMessage", "jobId"]) == "job_gql_002"
+    end
+
     test "returns an error for an assistant belonging to another organization",
          %{staff: user} do
       other_organization = Fixtures.organization_fixture()


### PR DESCRIPTION
## Summary

In the evaluation "Try It Out" sandbox, chatting always used the assistant's **live** config version, even when the user had a different version selected. Root cause: `Assistants.send_message/3` resolved the Kaapi config via `assistant.active_config_version` only — the frontend had no way to say which version it was chatting with.

`sendAssistantMessage` now accepts an optional `configVersionId` and dispatches that version's Kaapi config (`config: %{id:, version:}`). With no `configVersionId`, behaviour is unchanged (live version), so this is backward compatible.

The selected version is looked up scoped by `id + assistant_id + organization_id`, so a version from another assistant or another org is rejected. A version that has not been published to Kaapi yet (`kaapi_version_number` nil) is rejected with its own message, separate from "assistant not on Kaapi yet".

The eval-run path already keys off `assistant_config_version_id`, and the production flow webhook (`Flows.Webhooks.Kaapi`) intentionally uses the live version — both left as-is.

**Frontend follow-up:** the FE must send `configVersionId` in the chat input; the version `id` is already exposed on `assistantConfigVersions`.

### Changes

- `lib/glific/assistants.ex` — `fetch_live_kaapi_config/2` → `fetch_kaapi_config/3`; new `fetch_config_version/3` resolves the selected version, falling back to the live one
- `lib/glific_web/schema/assistant_chat_types.ex` — optional `config_version_id` on `assistant_chat_input`
- `lib/glific_web/resolvers/assistant_chat.ex` — passes it through

## Checklist

- [x] Ran `mix setup` in the repository root and test.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that. (no new endpoint — existing mutation gained an optional field)
- [x] Coding standard and conventions are followed.

## Notes

Tests added: selected version wins over live, cross-assistant version rejected (context level), and a GraphQL-level test asserting the Kaapi payload carries the selected `config.version`. `MIX_ENV=test mix check` passes (compiler, credo, dialyzer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
