### PR TITLE
feat(evaluationv2): show original item count as totalItems on datasets

### DIFF
--- a/assets/gql/ai_evaluations/create_golden_qa.gql
+++ b/assets/gql/ai_evaluations/create_golden_qa.gql
@@ -3,7 +3,6 @@ mutation CreateGoldenQa($input: GoldenQaInput!) {
     goldenQa {
       id
       name
-      duplicationFactor
       fileName
       totalItems
     }

--- a/assets/gql/ai_evaluations/create_golden_qa.gql
+++ b/assets/gql/ai_evaluations/create_golden_qa.gql
@@ -1,10 +1,14 @@
-#import "./golden_qa_fields.frag.gql"
-
-mutation CreateGoldenQA($input: GoldenQaInput!) {
-  createGoldenQA(input: $input) {
-    goldenQA {
+mutation CreateGoldenQa($input: GoldenQaInput!) {
+  createGoldenQa(input: $input) {
+    goldenQa {
+      id
       name
+      duplicationFactor
+      fileName
+      totalItems
     }
-    ...ErrorFields
+    errors {
+      message
+    }
   }
 }

--- a/assets/gql/ai_evaluations/get_golden_qa_dataset.gql
+++ b/assets/gql/ai_evaluations/get_golden_qa_dataset.gql
@@ -1,13 +1,18 @@
-#import "./golden_qa_fields.frag.gql"
-
 query GetGoldenQa($id: ID!, $includeSignedUrl: Boolean) {
-  goldenQA(id: $id, includeSignedUrl: $includeSignedUrl) {
-    id
-    name
-    duplicationFactor
-    fileName
-    signedUrl
-    insertedAt
-    updatedAt
+  goldenQa(id: $id, includeSignedUrl: $includeSignedUrl) {
+    goldenQa {
+      id
+      name
+      datasetId
+      duplicationFactor
+      fileName
+      signedUrl
+      totalItems
+      insertedAt
+      updatedAt
+    }
+    errors {
+      message
+    }
   }
 }

--- a/assets/gql/ai_evaluations/list_golden_qas.gql
+++ b/assets/gql/ai_evaluations/list_golden_qas.gql
@@ -2,7 +2,6 @@ query GoldenQas($filter: GoldenQaFilter, $opts: Opts) {
   goldenQas(filter: $filter, opts: $opts) {
     id
     name
-    goldenQaId
     fileName
     totalItems
     insertedAt

--- a/assets/gql/ai_evaluations/list_golden_qas.gql
+++ b/assets/gql/ai_evaluations/list_golden_qas.gql
@@ -3,7 +3,6 @@ query GoldenQas($filter: GoldenQaFilter, $opts: Opts) {
     id
     name
     goldenQaId
-    duplicationFactor
     fileName
     totalItems
     insertedAt

--- a/assets/gql/ai_evaluations/list_golden_qas.gql
+++ b/assets/gql/ai_evaluations/list_golden_qas.gql
@@ -1,0 +1,12 @@
+query GoldenQas($filter: GoldenQaFilter, $opts: Opts) {
+  goldenQas(filter: $filter, opts: $opts) {
+    id
+    name
+    goldenQaId
+    duplicationFactor
+    fileName
+    totalItems
+    insertedAt
+    updatedAt
+  }
+}

--- a/lib/glific/third_party/kaapi.ex
+++ b/lib/glific/third_party/kaapi.ex
@@ -1060,10 +1060,10 @@ defmodule Glific.ThirdParty.Kaapi do
           non_neg_integer()
         ) :: {:ok, map()} | {:error, map() | binary()}
   defp handle_evaluation_dataset_v2_response(
-         {:ok, %{data: %{dataset_id: dataset_id, total_items: total_items}}},
+         {:ok, %{data: %{dataset_id: dataset_id, original_items: original_items}}},
          _organization_id
        ) do
-    {:ok, %{dataset_id: dataset_id, total_items: total_items}}
+    {:ok, %{dataset_id: dataset_id, original_items: original_items}}
   end
 
   defp handle_evaluation_dataset_v2_response({:error, reason}, organization_id) do

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -322,7 +322,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
   def get_golden_qa(_, %{id: golden_qa_id, include_signed_url: include_signed_url}, %{
         context: %{current_user: user}
       }) do
-    with {:ok, golden_qa} <- Repo.fetch(Glific.AIEvaluations.GoldenQA, golden_qa_id),
+    with {:ok, golden_qa} <-
+           Repo.fetch_by(GoldenQA, %{id: golden_qa_id, organization_id: user.organization_id}),
          {:ok, kaapi_data} <- fetch_kaapi_dataset(golden_qa, user, include_signed_url) do
       golden_qa_map =
         golden_qa

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -325,15 +325,8 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     with {:ok, golden_qa} <- Repo.fetch(Glific.AIEvaluations.GoldenQA, golden_qa_id),
          {:ok, kaapi_data} <- fetch_kaapi_dataset(golden_qa, user, include_signed_url) do
       golden_qa_map =
-        %{
-          id: golden_qa.id,
-          name: golden_qa.name,
-          duplication_factor: golden_qa.duplication_factor,
-          file_name: golden_qa.file_name,
-          total_items: golden_qa.total_items,
-          inserted_at: golden_qa.inserted_at,
-          updated_at: golden_qa.updated_at
-        }
+        golden_qa
+        |> Map.from_struct()
         |> maybe_put_signed_url(kaapi_data)
 
       if include_signed_url, do: Metrics.increment("Golden QA Downloaded", user.organization_id)

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -121,7 +121,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
          {:ok, row_count} <- validate_csv_structure(file),
          :ok <- validate_golden_qa_question_limit(row_count),
          {:ok, kaapi_dataset} <- upload_dataset(dataset, user.organization_id) do
-      create_golden_qa_record(kaapi_dataset, name, file, factor, user)
+      create_golden_qa_record(kaapi_dataset, name, file, factor, row_count, user)
     else
       {:error, :timeout} ->
         {:ok, %{errors: [%{message: "Timeout occurred, please try again."}]}}
@@ -162,16 +162,23 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
     end
   end
 
-  @spec create_golden_qa_record(map(), String.t(), Plug.Upload.t(), integer(), map()) ::
+  @spec create_golden_qa_record(
+          map(),
+          String.t(),
+          Plug.Upload.t(),
+          integer(),
+          non_neg_integer(),
+          map()
+        ) ::
           {:ok, %{golden_qa: GoldenQA.t()}} | {:ok, %{errors: [%{message: String.t()}]}}
-  defp create_golden_qa_record(kaapi_dataset, name, file, factor, user) do
+  defp create_golden_qa_record(kaapi_dataset, name, file, factor, row_count, user) do
     case AIEvaluations.create_golden_qa(%{
            name: name,
            dataset_id: kaapi_dataset.dataset_id,
            duplication_factor: factor,
            file_name: file.filename,
            organization_id: user.organization_id,
-           total_items: Map.get(kaapi_dataset, :total_items, 0)
+           total_items: row_count
          }) do
       {:ok, golden_qa} ->
         {:ok, %{golden_qa: golden_qa}}

--- a/lib/glific_web/resolvers/ai_evaluations.ex
+++ b/lib/glific_web/resolvers/ai_evaluations.ex
@@ -178,7 +178,7 @@ defmodule GlificWeb.Resolvers.AIEvaluations do
            duplication_factor: factor,
            file_name: file.filename,
            organization_id: user.organization_id,
-           total_items: row_count
+           total_items: Map.get(kaapi_dataset, :original_items, row_count)
          }) do
       {:ok, golden_qa} ->
         {:ok, %{golden_qa: golden_qa}}

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -42,17 +42,6 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :updated_at, :datetime
   end
 
-  object :golden_qa_item do
-    field :id, :id
-    field :name, :string
-    field :golden_qa_id, :id
-    field :duplication_factor, :integer
-    field :file_name, :string
-    field :total_items, :integer
-    field :inserted_at, :datetime
-    field :updated_at, :datetime
-  end
-
   input_object :ai_evaluation_filter do
     field :name, :string
     field :golden_qa_id, :id
@@ -154,7 +143,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     end
 
     @desc "List Golden QAs"
-    field :golden_qas, list_of(:golden_qa_item) do
+    field :golden_qas, list_of(:golden_qa) do
       arg(:filter, :golden_qa_filter)
       arg(:opts, :opts)
       middleware(Authorize, :staff)

--- a/lib/glific_web/schema/ai_evaluation_types.ex
+++ b/lib/glific_web/schema/ai_evaluation_types.ex
@@ -48,6 +48,7 @@ defmodule GlificWeb.Schema.AIEvaluationTypes do
     field :golden_qa_id, :id
     field :duplication_factor, :integer
     field :file_name, :string
+    field :total_items, :integer
     field :inserted_at, :datetime
     field :updated_at, :datetime
   end

--- a/test/glific/third_party/kaapi_test.exs
+++ b/test/glific/third_party/kaapi_test.exs
@@ -57,26 +57,29 @@ defmodule Glific.ThirdParty.KaapiTest do
   describe "upload_evaluation_dataset_v2/2" do
     setup [:enable_kaapi_credential, :create_dataset_upload_params]
 
-    test "extracts dataset_id and total_items from a well-shaped v2 response", %{
+    test "extracts dataset_id and the pre-duplication original_items from a v2 response", %{
       organization_id: organization_id,
       dataset_params: dataset_params
     } do
       mock(fn %Tesla.Env{method: :post, url: url} ->
         assert url =~ "/api/v2/evaluations/datasets"
 
-        %Tesla.Env{status: 200, body: %{data: %{dataset_id: "99002", total_items: 55}}}
+        %Tesla.Env{
+          status: 200,
+          body: %{data: %{dataset_id: "99002", total_items: 55, original_items: 11}}
+        }
       end)
 
-      assert {:ok, %{dataset_id: "99002", total_items: 55}} =
+      assert {:ok, %{dataset_id: "99002", original_items: 11}} =
                Kaapi.upload_evaluation_dataset_v2(dataset_params, organization_id)
     end
 
-    test "returns a generic error and does not crash when total_items is missing", %{
+    test "returns a generic error and does not crash when original_items is missing", %{
       organization_id: organization_id,
       dataset_params: dataset_params
     } do
       mock(fn %Tesla.Env{method: :post} ->
-        %Tesla.Env{status: 200, body: %{data: %{dataset_id: "99003"}}}
+        %Tesla.Env{status: 200, body: %{data: %{dataset_id: "99003", total_items: 55}}}
       end)
 
       assert {:error, "An unknown error occurred, please contact Glific support."} =

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -902,15 +902,31 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert golden_qa.name == "dataset_2024_v1"
     end
 
-    test "v1 path: uploads to the v1 endpoint and stores the CSV row count as total_items",
-         %{staff: user, upload: upload} do
+    test "v1 path: falls back to the CSV row count, since the v1 wrapper drops the item counts",
+         %{staff: user} do
+      csv_path = create_csv_with_rows(7)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "golden_qa.csv"
+      }
+
       Tesla.Mock.mock(fn
         %{method: :post, url: url} ->
           assert url =~ "/api/v1/evaluations/datasets"
 
           %Tesla.Env{
             status: 200,
-            body: %{data: %{dataset_name: "v1_regression_dataset", dataset_id: "88003"}}
+            body: %{
+              data: %{
+                dataset_name: "v1_regression_dataset",
+                dataset_id: "88003",
+                total_items: 129,
+                original_items: 43
+              }
+            }
           }
       end)
 
@@ -929,18 +945,27 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       assert golden_qa.name == "v1_regression_dataset"
       assert golden_qa.dataset_id == 88_003
-      assert golden_qa.total_items == 1
+      assert golden_qa.total_items == 7
     end
   end
 
   describe "create_golden_qa/3 v2 (is_ai_evaluation_enabled)" do
     setup [:enable_kaapi, :create_upload_file]
 
-    test "v2 path: hits the v2 endpoint and ignores Kaapi's duplicated total_items",
-         %{staff: user, upload: upload} do
+    test "v2 path: stores Kaapi's original_items, not the post-duplication total_items",
+         %{staff: user} do
       FunWithFlags.enable(:is_ai_evaluation_enabled,
         for_actor: %{organization_id: user.organization_id}
       )
+
+      csv_path = create_csv_with_rows(7)
+      on_exit(fn -> File.rm(csv_path) end)
+
+      upload = %Plug.Upload{
+        path: csv_path,
+        content_type: "text/csv",
+        filename: "golden_qa.csv"
+      }
 
       Tesla.Mock.mock(fn
         %{method: :post, url: url} ->
@@ -948,7 +973,14 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
           %Tesla.Env{
             status: 200,
-            body: %{data: %{dataset_id: "88004", total_items: 120}}
+            body: %{
+              data: %{
+                dataset_id: "88004",
+                total_items: 129,
+                original_items: 43,
+                duplication_factor: 3
+              }
+            }
           }
       end)
 
@@ -968,7 +1000,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
         assert golden_qa.name == "valid_dataset_v2"
         assert golden_qa.dataset_id == 88_004
-        assert golden_qa.total_items == 1
+        assert golden_qa.total_items == 43
 
         assert called(
                  Glific.Metrics.increment(
@@ -983,7 +1015,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       )
     end
 
-    test "v2 path: returns a generic error when the Kaapi response is missing total_items", %{
+    test "v2 path: returns a generic error when the Kaapi response is missing original_items", %{
       staff: user,
       upload: upload
     } do

--- a/test/glific_web/resolvers/ai_evaluations_test.exs
+++ b/test/glific_web/resolvers/ai_evaluations_test.exs
@@ -641,6 +641,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
                AIEvaluations.create_golden_qa(nil, args, resolution)
 
       assert golden_qa.name == "valid_name"
+      assert golden_qa.total_items == 5
     end
 
     test "succeeds when CSV has only a header row (0 questions)", %{staff: user} do
@@ -901,7 +902,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
       assert golden_qa.name == "dataset_2024_v1"
     end
 
-    test "v1 path: uploads to the v1 endpoint and leaves total_items at default when the flag is off",
+    test "v1 path: uploads to the v1 endpoint and stores the CSV row count as total_items",
          %{staff: user, upload: upload} do
       Tesla.Mock.mock(fn
         %{method: :post, url: url} ->
@@ -928,14 +929,14 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
       assert golden_qa.name == "v1_regression_dataset"
       assert golden_qa.dataset_id == 88_003
-      assert golden_qa.total_items == 0
+      assert golden_qa.total_items == 1
     end
   end
 
   describe "create_golden_qa/3 v2 (is_ai_evaluation_enabled)" do
     setup [:enable_kaapi, :create_upload_file]
 
-    test "v2 path: returns golden_qa with total_items and hits the v2 endpoint when is_ai_evaluation_enabled is on",
+    test "v2 path: hits the v2 endpoint and ignores Kaapi's duplicated total_items",
          %{staff: user, upload: upload} do
       FunWithFlags.enable(:is_ai_evaluation_enabled,
         for_actor: %{organization_id: user.organization_id}
@@ -967,7 +968,7 @@ defmodule GlificWeb.Resolvers.AIEvaluationsTest do
 
         assert golden_qa.name == "valid_dataset_v2"
         assert golden_qa.dataset_id == 88_004
-        assert golden_qa.total_items == 120
+        assert golden_qa.total_items == 1
 
         assert called(
                  Glific.Metrics.increment(

--- a/test/glific_web/schema/golden_qa_test.exs
+++ b/test/glific_web/schema/golden_qa_test.exs
@@ -1,0 +1,42 @@
+defmodule GlificWeb.Schema.GoldenQATest do
+  @moduledoc """
+  GraphQL integration tests for the Golden QA dataset list.
+  """
+
+  use GlificWeb.ConnCase
+  use Wormwood.GQLCase
+
+  alias Glific.Fixtures
+
+  load_gql(
+    :list,
+    GlificWeb.Schema,
+    "assets/gql/ai_evaluations/list_golden_qas.gql"
+  )
+
+  setup %{organization_id: org_id} do
+    FunWithFlags.enable(:ai_evaluations, for_actor: %{organization_id: org_id})
+    :ok
+  end
+
+  test "goldenQas returns totalItems for each dataset", %{
+    staff: user,
+    organization_id: organization_id
+  } do
+    golden_qa =
+      Fixtures.golden_qa_fixture(%{
+        name: "dataset_with_items",
+        dataset_id: 4242,
+        total_items: 7,
+        organization_id: organization_id
+      })
+
+    result = auth_query_gql_by(:list, user, variables: %{})
+
+    assert {:ok, query_data} = result
+    datasets = get_in(query_data, [:data, "goldenQas"])
+
+    assert %{"totalItems" => 7} =
+             Enum.find(datasets, &(&1["id"] == to_string(golden_qa.id)))
+  end
+end

--- a/test/glific_web/schema/golden_qa_test.exs
+++ b/test/glific_web/schema/golden_qa_test.exs
@@ -14,6 +14,12 @@ defmodule GlificWeb.Schema.GoldenQATest do
     "assets/gql/ai_evaluations/list_golden_qas.gql"
   )
 
+  load_gql(
+    :by_id,
+    GlificWeb.Schema,
+    "assets/gql/ai_evaluations/get_golden_qa_dataset.gql"
+  )
+
   setup %{organization_id: org_id} do
     FunWithFlags.enable(:ai_evaluations, for_actor: %{organization_id: org_id})
     :ok
@@ -38,5 +44,29 @@ defmodule GlificWeb.Schema.GoldenQATest do
 
     assert %{"totalItems" => 7} =
              Enum.find(datasets, &(&1["id"] == to_string(golden_qa.id)))
+  end
+
+  test "goldenQa returns every declared field off the record", %{
+    staff: user,
+    organization_id: organization_id
+  } do
+    golden_qa =
+      Fixtures.golden_qa_fixture(%{
+        name: "dataset_by_id",
+        dataset_id: 4243,
+        total_items: 11,
+        file_name: "golden.csv",
+        organization_id: organization_id
+      })
+
+    result = auth_query_gql_by(:by_id, user, variables: %{"id" => golden_qa.id})
+
+    assert {:ok, query_data} = result
+    dataset = get_in(query_data, [:data, "goldenQa", "goldenQa"])
+
+    assert dataset["datasetId"] == 4243
+    assert dataset["totalItems"] == 11
+    assert dataset["fileName"] == "golden.csv"
+    assert dataset["signedUrl"] == nil
   end
 end


### PR DESCRIPTION
## Summary
`golden_qas.total_items` is now the **pre-duplication** item count, and it is exposed on the dataset list query so the frontend can render it.

Kaapi's `DatasetUploadResponse` returns both counts, and its own OpenAPI spec is explicit about which is which:

| field | Kaapi's description |
|---|---|
| `total_items` | "Total number of items uploaded (after duplication)" |
| `original_items` | "Number of original items before duplication" |

We want the second one. `duplication_factor` is applied when an evaluation *runs*, so a dataset's own item count should be the un-multiplied figure — that is also what the file itself contains.

Previously the column was populated with Kaapi's `total_items`, i.e. `original_items × duplication_factor` (Kaapi returns `total_items: 300, original_items: 100, duplication_factor: 3` for a 100-row file uploaded with factor 3). On the v1 path it stayed `0`.

### Changes

**`total_items` now comes from Kaapi's `original_items`**
- `Kaapi.handle_evaluation_dataset_v2_response/2` destructured `total_items` out of the response and returned it — but the resolver never read it, so the wrapper required a field it discarded, and `original_items` appeared nowhere in `lib/`. It now reads and returns `original_items`.
- `create_golden_qa_record/6` persists `Map.get(kaapi_dataset, :original_items, row_count)`. The fallback covers the v1 wrapper, which returns only `%{name:, dataset_id:}` — v1 keeps the locally computed CSV row count, which is the same number for a well-formed file.
- `row_count` (from `validate_csv_structure/1`) still drives the pre-upload `validate_golden_qa_question_limit/1` check; it just is not the persisted value on the v2 path.

**`goldenQas` returned a phantom type**
- `object :golden_qa_item` was a near-duplicate of `object :golden_qa`, exposing a `golden_qa_id` field that `Glific.AIEvaluations.GoldenQA` does not have — so `goldenQaId` always resolved to `nil` — and missing `total_items` entirely. Deleted; `goldenQas` now resolves against `:golden_qa`, which already declares every field the record has.

**`get_golden_qa/3` hardening**
- The by-id lookup used `Repo.fetch/2` and leaned on `Repo.prepare_query/3` auto-scoping for a client-supplied id. Now `Repo.fetch_by(GoldenQA, %{id: ..., organization_id: user.organization_id})`, per `lib/glific_web/CLAUDE.md` and the pattern already used elsewhere in this module. *(Raised by CodeRabbit.)*
- The response was a hand-enumerated map of every `GoldenQA` field — the reason `total_items` had to be added there by hand, while the list query needed no change. Now built with `Map.from_struct/1`, the pattern used in `Glific.Contacts`, `Glific.Partners` and `Glific.Messages`. Absinthe reads only the fields declared on `:golden_qa`, so extra struct keys are inert. This also fixes a latent bug: `:golden_qa` declares `dataset_id`, but the hand-built map never set it, so `datasetId` always resolved to `nil`.

**`.gql` assets**
- `create_golden_qa.gql` and `get_golden_qa_dataset.gql` did not validate against the schema: both imported a `golden_qa_fields.frag.gql` that does not exist, used `goldenQA` / `createGoldenQA` instead of the real `goldenQa` / `createGoldenQa`, and `get_golden_qa_dataset.gql` selected fields directly off the result wrapper instead of its `goldenQa` sub-object. Both rewritten.
- New `list_golden_qas.gql`.
- Selections omit `duplicationFactor`; `get_golden_qa_dataset.gql` keeps it, since it selected it before this branch.

## Checklist
- [ ] Ran `mix setup` in the repository root and test. — skipped, it resets the dev DB; ran `MIX_ENV=test mix check` instead
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Test plan
- [x] `MIX_ENV=test mix check` — compiler, credo `--strict`, dialyzer, doctor, ex_doc, format, unused_deps all pass
- [x] `mix test test/glific_web/resolvers/ test/glific/third_party/ test/glific_web/schema/golden_qa_test.exs test/glific/ai_evaluations_test.exs` — 279 tests, 0 failures

**The existing `total_items` tests could not catch this bug.** The shared `create_upload_file` fixture writes a one-data-row CSV, so every assertion was `total_items == 1` — the local row count, `original_items`, and a hardcoded `1` were indistinguishable. The v2 mock returned `total_items: 120` and no `original_items` at all, and the test was named "ignores Kaapi's duplicated total_items", encoding the wrong intent.

Rewritten so exactly one source can pass:
- [x] v2 path: 7-row CSV, mock returns `original_items: 43, total_items: 129, duplication_factor: 3`, asserts `43`. `7` would mean the local count was used, `129` the duplicated figure. Mutation-checked — reverting the resolver line to `row_count` fails this test.
- [x] v1 path: 7-row CSV, mock carries counts it must ignore, asserts `7` (the fallback).
- [x] `Kaapi.upload_evaluation_dataset_v2/2` unit tests assert `original_items` is extracted, and that a response missing it still errors without crashing.
- [x] New `test/glific_web/schema/golden_qa_test.exs` — `totalItems` comes back through `list_golden_qas.gql`, and the by-id query returns `datasetId` / `totalItems` / `fileName` off the record. Verified the by-id test fails (`datasetId` is `nil`) against the pre-refactor hand-built map.

## Notes
**Existing rows are not backfilled.** Rows created by the current v2 path still hold `original × duplication_factor` and will read high until re-uploaded; v1 / pre-migration rows stay at `0`. A backfill has to run **before** this ships — afterwards nothing on a row distinguishes an old inflated value from a new correct one. Either divide by `duplication_factor`, or refetch `original_items` from Kaapi's `GET /api/v1/evaluations/datasets` (no client function for that endpoint exists today).

Frontend should select `totalItems` in the `goldenQas` query to render the column.

Two follow-ups, deliberately out of scope here:
- The v1 upload returns the same `DatasetUploadResponse` schema, so `Kaapi.upload_evaluation_dataset/2` is also dropping `original_items` and could use it instead of the CSV-count fallback.
- `fetch_kaapi_dataset/3` only pulls `signed_url`, so `total_items` is never refreshed on read — a dataset changed server-side keeps its stale value.
