### PR TITLE
fix(assistants): resolve versionLabel on the config version subscription

### DIFF
--- a/assets/gql/assistants/subscribe.gql
+++ b/assets/gql/assistants/subscribe.gql
@@ -1,12 +1,11 @@
 subscription assistantConfigVersionUpdated {
   assistantConfigVersionUpdated {
     id
-    versionNumber
+    versionLabel
     model
     prompt
     settings
     status
-    isLive
     description
     insertedAt
     updatedAt

--- a/assets/gql/assistants/subscribe.gql
+++ b/assets/gql/assistants/subscribe.gql
@@ -7,6 +7,13 @@ subscription assistantConfigVersionUpdated {
     settings
     status
     description
+    vectorStore {
+      id
+      knowledgeBaseVersionId
+      vectorStoreId
+      name
+      status
+    }
     insertedAt
     updatedAt
   }

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -94,7 +94,6 @@ defmodule Glific.Assistants do
            id: version.id,
            major_version: version.major_version,
            minor_version: version.minor_version,
-           version_label: AssistantConfigVersion.version_label(version),
            model: version.model,
            prompt: version.prompt,
            settings: version.settings,

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -461,16 +461,15 @@ defmodule Glific.Assistants do
   @spec publish_config_version_update(AssistantConfigVersion.t()) :: :ok
   defp publish_config_version_update(%{status: status} = config_version)
        when status in [:ready, :failed] do
-    config_version = Repo.preload(config_version, knowledge_base_versions: :knowledge_base)
-
-    config =
+    config_version =
       config_version
+      |> Repo.preload(knowledge_base_versions: :knowledge_base)
       |> Map.from_struct()
       |> Map.put(:vector_store_data, build_vector_store_data(config_version))
 
     Absinthe.Subscription.publish(
       GlificWeb.Endpoint,
-      config,
+      config_version,
       [{:assistant_config_version_updated, "#{config_version.organization_id}"}]
     )
 

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -461,15 +461,16 @@ defmodule Glific.Assistants do
   @spec publish_config_version_update(AssistantConfigVersion.t()) :: :ok
   defp publish_config_version_update(%{status: status} = config_version)
        when status in [:ready, :failed] do
-    config_version =
+    config_version = Repo.preload(config_version, knowledge_base_versions: :knowledge_base)
+
+    payload =
       config_version
-      |> Repo.preload(knowledge_base_versions: :knowledge_base)
       |> Map.from_struct()
       |> Map.put(:vector_store_data, build_vector_store_data(config_version))
 
     Absinthe.Subscription.publish(
       GlificWeb.Endpoint,
-      config_version,
+      payload,
       [{:assistant_config_version_updated, "#{config_version.organization_id}"}]
     )
 

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -461,9 +461,16 @@ defmodule Glific.Assistants do
   @spec publish_config_version_update(AssistantConfigVersion.t()) :: :ok
   defp publish_config_version_update(%{status: status} = config_version)
        when status in [:ready, :failed] do
+    config_version = Repo.preload(config_version, knowledge_base_versions: :knowledge_base)
+
+    config =
+      config_version
+      |> Map.from_struct()
+      |> Map.put(:vector_store_data, build_vector_store_data(config_version))
+
     Absinthe.Subscription.publish(
       GlificWeb.Endpoint,
-      config_version,
+      config,
       [{:assistant_config_version_updated, "#{config_version.organization_id}"}]
     )
 

--- a/lib/glific/assistants/assistant_config_version.ex
+++ b/lib/glific/assistants/assistant_config_version.ex
@@ -103,7 +103,10 @@ defmodule Glific.Assistants.AssistantConfigVersion do
   end
 
   @doc "Display label for a config version, e.g. `\"1.3\"`."
-  @spec version_label(t()) :: String.t()
-  def version_label(%__MODULE__{major_version: major, minor_version: minor}),
-    do: "#{major}.#{minor}"
+  @spec version_label(map()) :: String.t() | nil
+  def version_label(%{major_version: major, minor_version: minor})
+      when not is_nil(major) and not is_nil(minor),
+      do: "#{major}.#{minor}"
+
+  def version_label(_config_version), do: nil
 end

--- a/lib/glific_web/resolvers/assistants.ex
+++ b/lib/glific_web/resolvers/assistants.ex
@@ -5,6 +5,7 @@ defmodule GlificWeb.Resolvers.Assistants do
   """
 
   alias Glific.Assistants
+  alias Glific.Assistants.AssistantConfigVersion
 
   require Logger
 
@@ -195,6 +196,13 @@ defmodule GlificWeb.Resolvers.Assistants do
   def resolve_vector_store(_parent, _args, _context) do
     {:ok, nil}
   end
+
+  @doc """
+  Display label for a config version, e.g. `"1.3"`.
+  """
+  @spec version_label(map(), map(), map()) :: {:ok, String.t() | nil}
+  def version_label(config_version, _args, _context),
+    do: {:ok, AssistantConfigVersion.version_label(config_version)}
 
   @doc """
   Calculate the total file size linked to the VectorStore.

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -75,7 +75,11 @@ defmodule GlificWeb.Schema.AssistantTypes do
     field :id, :id
     field :major_version, :integer
     field :minor_version, :integer
-    field :version_label, :string
+
+    field :version_label, :string do
+      resolve(&Resolvers.Assistants.version_label/3)
+    end
+
     field :model, :string
     field :prompt, :string
     field :settings, :json


### PR DESCRIPTION
## Summary
`versionLabel` came back `nil` on the `assistantConfigVersionUpdated` subscription, so the frontend was concatenating `major.minor` itself.

`version_label` is not a column — it is `"#{major_version}.#{minor_version}"`, computed by `AssistantConfigVersion.version_label/1`. Only the query path filled it in (`Assistants.list_assistant_config_versions/1` built it into each map); the subscription published the raw Ecto struct, which has no such key, so Absinthe's default resolver returned `nil`. Any future producer of `:assistant_config_version` would have hit the same thing.

Changes:
- `object :assistant_config_version` now resolves `version_label` through `Resolvers.Assistants.version_label/3`, so the field derives itself from `major_version`/`minor_version` — both of which every producer already carries (struct and map alike). No caller sets the key any more: dropped from the query map in `list_assistant_config_versions/1`, and the subscription publishes the plain struct like every other subscription in the codebase (`Glific.AIEvaluations`, `assistants.ex` KB publish)
- `AssistantConfigVersion.version_label/1` matches on `%{major_version: major, minor_version: minor}` instead of `%__MODULE__{}` so it serves both shapes, guarded with `when not is_nil(...)` plus a `nil` fallback clause — the same pattern as `resolve_optional_knowledge_base/1` and `build_settings/1` in this module. Without the fallback the resolver raises a `FunctionClauseError` on the assistant-not-found path, where Absinthe hands the field an error map instead of a config version
- `assets/gql/assistants/subscribe.gql` selected `versionNumber` on `assistantConfigVersionUpdated`, which is not a field on `:assistant_config_version` at all — a single invalid selection is enough for the client to drop the whole payload. Replaced with `versionLabel`
- Same document also selected `isLive`. That field is computed against `assistant.active_config_version_id`, so it is only meaningful on the query path; the frontend derives live-ness from its cached `activeConfigVersionId`, so the selection is removed rather than pushing an extra assistant lookup into every publish. `field :is_live` stays on the object for the version-list query

`field :live_version_label` on `:assistant` / `:live_version_assistant` is untouched — different objects, whose parents are server-built maps holding a *different* version's label.

## Checklist
- [ ] Ran `mix setup` in the repository root and test. — skipped, it resets the dev DB; ran `MIX_ENV=test mix check` instead
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed.

## Test plan
- [x] `mix test test/glific/assistants_test.exs test/glific/assistants/assistant_config_version_test.exs test/glific_web/resolvers/assistants_test.exs test/glific_web/schema/assistant_test.exs test/glific/third_party/kaapi/assistant_clone_worker_test.exs` — 161 tests, 0 failures
- [x] `test/glific_web/resolvers/assistants_test.exs:521` exercises the new resolver end to end: it asserts `["2.0", "1.1", "1.0"]` off a real `assistantVersions` document. The subscription hits the same object and same field resolver, only the parent differs (struct vs map)
- [x] Confirmed the `FunctionClauseError` on the not-found path is real — with `assistant_id: 0`, `test/glific_web/resolvers/assistants_test.exs:638` fails without the fallback clause and passes with it
- [x] `MIX_ENV=test mix check` — compiler, credo, doctor, ex_doc, format, unused_deps pass. Dialyzer reports one warning in `lib/glific_web/endpoint.ex:1`, a file this branch does not touch

## Notes
`knowledgeBaseVersionUpdated` was reported alongside this as "`knowledgeBaseId` not arriving", but no backend defect was found: `knowledge_base_id` is a real column, listed in `KnowledgeBaseVersion`'s `@required_fields`, the published struct carries it, and `object :knowledge_base_version_update` declares it. That subscription is unchanged here — if the field is still missing on the client, the cause is on the frontend document / Apollo cache side, the same class of problem as the bogus `versionNumber` above.

Delivery over the websocket has no automated coverage — the repo has no subscription-over-socket test — so the fix is verified through the shared field resolver rather than through a live channel.
