### PR TITLE
feat(web-channel): Omnichannel schema foundation: channel columns on messages, flow_contexts, flows and message_broadcasts

### DIFF
--- a/lib/glific/enums/constants/enums.ex
+++ b/lib/glific/enums/constants/enums.ex
@@ -67,6 +67,9 @@ defmodule Glific.Enums.Constants do
         :whatsapp_form_response
       ]
 
+      # the channel a message was sent or received on
+      @message_channel_const [:whatsapp, :web]
+
       # the different possible types of interactive message
       @interactive_message_type_const [:list, :quick_reply, :location_request_message]
 

--- a/lib/glific/enums/ecto_enums.ex
+++ b/lib/glific/enums/ecto_enums.ex
@@ -70,6 +70,12 @@ defenum(
 )
 
 defenum(
+  Glific.Enums.MessageChannel,
+  :message_channel_enum,
+  Glific.Enums.message_channel_const()
+)
+
+defenum(
   Glific.Enums.QuestionType,
   :question_type_enum,
   Glific.Enums.question_type_const()

--- a/lib/glific/enums/enums.ex
+++ b/lib/glific/enums/enums.ex
@@ -170,6 +170,9 @@ defmodule Glific.Enums do
   defmacro message_type_const,
     do: Macro.expand(@message_type_const, __CALLER__)
 
+  defmacro message_channel_const,
+    do: Macro.expand(@message_channel_const, __CALLER__)
+
   defmacro question_type_const,
     do: Macro.expand(@question_type_const, __CALLER__)
 

--- a/priv/repo/migrations/20260902120000_add_channel_to_messages_and_flow_contexts.exs
+++ b/priv/repo/migrations/20260902120000_add_channel_to_messages_and_flow_contexts.exs
@@ -1,0 +1,39 @@
+defmodule Glific.Repo.Migrations.AddChannelToMessagesAndFlowContexts do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    CREATE TYPE message_channel_enum AS ENUM (
+      'whatsapp',
+      'web'
+    )
+    """)
+
+    alter table(:messages) do
+      add :channel, :message_channel_enum,
+        default: "whatsapp",
+        null: false,
+        comment: "The channel a message was sent or received on."
+    end
+
+    alter table(:flow_contexts) do
+      add :channel, :message_channel_enum,
+        default: "whatsapp",
+        null: false,
+        comment:
+          "The channel of the message that triggered this flow context; propagated into the flow's outbound sends so replies route back over the originating channel."
+    end
+  end
+
+  def down do
+    alter table(:messages) do
+      remove :channel
+    end
+
+    alter table(:flow_contexts) do
+      remove :channel
+    end
+
+    execute("DROP TYPE IF EXISTS message_channel_enum")
+  end
+end

--- a/priv/repo/migrations/20260902120001_add_channels_to_flows_and_message_broadcasts.exs
+++ b/priv/repo/migrations/20260902120001_add_channels_to_flows_and_message_broadcasts.exs
@@ -1,0 +1,31 @@
+defmodule Glific.Repo.Migrations.AddChannelsToFlowsAndMessageBroadcasts do
+  use Ecto.Migration
+
+  def up do
+    alter table(:flows) do
+      add :channels, {:array, :message_channel_enum},
+        default: ["whatsapp"],
+        null: false,
+        comment:
+          "The set of channels this flow can reach. Derived from the flow definition on every save, never authored. The default is whatsapp alone because it represents the un-derived state, not a narrowing: every existing flow demonstrably works on whatsapp today, and web is earned once the derivation has run and found every node compatible."
+    end
+
+    alter table(:message_broadcasts) do
+      add :channel, :message_channel_enum,
+        default: "whatsapp",
+        null: false,
+        comment:
+          "The channel a scheduled or group-initiated flow start runs on. Persisted rather than passed in opts because the broadcast worker rebuilds its opts from this row in a later process."
+    end
+  end
+
+  def down do
+    alter table(:flows) do
+      remove :channels
+    end
+
+    alter table(:message_broadcasts) do
+      remove :channel
+    end
+  end
+end


### PR DESCRIPTION
Adds every schema change the omnichannel work needs, in one migration set, so the feature tickets
that follow add **code** rather than migrations.

Design: [`plans/web-channel/tech-design.md`](https://github.com/glific/glific/tree/web-channel-tech-design/plans/web-channel) §2.2 and §2.3.

## What lands

| Table | Column | Type | Why |
|---|---|---|---|
| `messages` | `channel` | `message_channel_enum` | Which route a message took — nothing records it today |
| `flow_contexts` | `channel` | `message_channel_enum` | Carries the reply channel through a flow run, so a flow answers on the channel it was triggered from |
| `flows` | `channels` | `message_channel_enum[]` | Which channels a flow can reach. Derived from the definition on save, never authored |
| `message_broadcasts` | `channel` | `message_channel_enum` | The channel a scheduled or group-initiated flow start runs on (#5706) |

Plus `message_channel_enum` itself (`whatsapp`, `web`).

**`flow_type` is deliberately untouched.** An earlier revision of this PR added `web_message` to
`flow_type_enum`. It is a single-valued vestigial column inherited from RapidPro that nothing in
`lib/` branches on — the frontend does not even read it, hardcoding `flowType: 'messaging'`. The
web-only signal belongs in `flows.channels` rather than being split across two columns, one of which
is not named for channels.

**All four columns are catalog-only adds with defaults.** On PG 11+ `ADD COLUMN ... DEFAULT` stores the
value once in `pg_attribute.attmissingval`; no table is rewritten and no existing row is touched. This
matters — `messages` is ~10M rows. There is no long-running DDL anywhere in this PR.

## Decisions worth reviewing

**A native PG enum, not a varchar.** `messages` already carries four enum-typed columns and the schema
has 20 enum types, so a bare varchar discriminator would be the outlier. More concretely, the enum
enforces the domain in the database, which a changeset `validate_inclusion` cannot — nothing otherwise
stops an Oban worker or a `Repo.update_all` writing `"Web"`. Measured on a synthetic 5M-row table:
varchar and enum are **identical on disk** (+7.8 B/row once row alignment is accounted for), their
index sizes are byte-identical, and lookup times are indistinguishable. The tradeoff accepted is that
enum values are permanent, which is why **only the two channels in use ship** — the prototype's
`:telegram, :rcs, :sms, :fb_messenger, :instagram` deliberately do not.

**`flows.channels` defaults to `{whatsapp}` alone**, which is the un-derived state rather than a
narrowing. Every existing flow demonstrably works on WhatsApp today; **web is earned** once the flow
has been edited and the derivation has found every node compatible. Defaulting to `{whatsapp,web}`
would advertise thousands of never-inspected flows as web-capable, which is the wrong direction to be
wrong in. No backfill — the default *is* the backfill. It is an enum array rather than a string array
both for consistency and because `users.roles` is the existing precedent for that shape.

**`message_broadcasts.channel` is not derivable from the flow it references.** The obvious objection
is that the row already has a `flow_id`, and flows now carry `channels` — three reasons it does not
answer the question:

1. An omnichannel flow's `channels` is `{whatsapp,web}`. That says what the flow *can* reach, not
   which channel *this run* should use. Only a single-element set would determine it.
2. **`flow_id` is nullable.** `broadcast_message_to_group/4` (`broadcast.ex:126`) creates rows with a
   `message_id`, `type: "message"` and no flow at all — a raw message broadcast has no flow to consult.
3. `flows.channels` is recomputed on every flow save, so a broadcast enqueued now and drained minutes
   later could read a different value than it was created with.

Separately, opts cannot carry it either: `broadcast_flow_to_group/4` only enqueues, and the worker
rebuilds its opts from the persisted row in a *later process*. `default_results` is the exact
precedent — an `init_context` opt persisted for the same reason.

**No index is added.** The previously proposed `(contact_id, channel)` index does not match the query
it was meant to serve, and `messages_contact_id_index` already narrows to a few hundred rows per
contact. The index the conversation read actually needs belongs with fixing its pagination — #5708.

**The Ecto schemas deliberately do not declare these fields yet.** Ecto selects and inserts only
declared fields, so the columns are invisible to the running app and inserts fall through to the
database defaults. Schema fields, changeset wiring and reply-channel propagation land with the feature
tickets.

## Verification

- Rollback removes all four columns and drops `message_channel_enum`, leaving the schema
  byte-identical to master. **The PR is now fully reversible** — dropping `flow_type` left no
  irreversible step.
- The 19 seeded flows read `{whatsapp}` with no `UPDATE`.
- The database rejects an out-of-domain value in **both** the scalar and the array —
  `invalid input value for enum message_channel_enum: "telegram"`.
- 41 doctests and 148 tests pass. The 5 `Glific.MessagesTest` Gupshup HSM failures are **pre-existing**
  — confirmed by an identical control run on a clean `origin/master` checkout with a freshly rebuilt
  database.
- `mix compile --warnings-as-errors` clean; Credo's single finding and the one `mix format` failure are
  both in `lib/glific/flows/expression.ex` and pre-date this branch.

## Reviewer checklist

- [ ] The two enum value names ship permanently. Read `whatsapp` / `web` as a naming decision.
- [ ] Satisfy yourself that `message_broadcasts.channel` is warranted rather than derivable from
      `flow_id` — the three reasons above are the argument.
- [ ] Confirm no migration here rewrites a table — every one should complete in milliseconds.
- [ ] Confirm no index migration crept back in.

Refs #5660, #5706, #5707

🤖 Generated with [Claude Code](https://claude.com/claude-code)
