### PR TITLE
fix(credo): make the SafeLog check actually fail the build

### DIFF
--- a/.credo/checks/no_raw_inspect.ex
+++ b/.credo/checks/no_raw_inspect.ex
@@ -19,7 +19,7 @@ defmodule GlificCredo.Checks.NoRawInspect do
   use Credo.Check,
     id: "GL1001",
     base_priority: :high,
-    category: :error,
+    category: :warning,
     param_defaults: [excluded_modules: ["Glific.SafeLog"]],
     explanations: [
       check: """

--- a/lib/glific/flows/expression.ex
+++ b/lib/glific/flows/expression.ex
@@ -1088,6 +1088,8 @@ defmodule Glific.Flows.Expression do
   defp kernel_call(:in, [a, b]) when is_list(b), do: Enum.member?(b, a)
   defp kernel_call(:in, _), do: reject("in requires a list")
   defp kernel_call(:to_string, [a]), do: to_string(a)
+  # Whitelisted expression function — the result is flow output, not a log line.
+  # credo:disable-for-next-line GlificCredo.Checks.NoRawInspect
   defp kernel_call(:inspect, [a]), do: inspect(a)
   defp kernel_call(:is_number, [a]), do: is_number(a)
   defp kernel_call(:is_binary, [a]), do: is_binary(a)


### PR DESCRIPTION
## Problem

The `NoRawInspect` check (GL1001) has never failed a build. It has been reporting its issue and being ignored since it landed in #5304 on 30 Jun.

Here is the `code-quality` job on master (run `34146297399`, commit `4fd3c307`):

```
[E] ↗ lib/glific/flows/expression.ex:1091:40 Use `Glific.SafeLog.safe_inspect/1` instead of raw `inspect/1` ...
 ✓ credo success in 0:29
```

It prints the violation, then reports success.

### Why

`.credo/checks/no_raw_inspect.ex` declared `category: :error`. Credo derives a check's exit status from its category using a fixed map in `Credo.Check`:

```elixir
@base_category_exit_status_map %{
  consistency: 1, design: 2, readability: 4, refactor: 8, warning: 16
}
```

`:error` is not in it. So `to_exit_status(:error)` looks up `nil`, `to_exit_status(nil)` returns `0`, and the issue contributes nothing to the exit status. `:error` is not a category Credo recognises anywhere else either — it has no colour mapping, and the `[E]` tag came from a generic first-letter fallback.

That is also how the violation in `expression.ex` got onto master with green CI in #5569: nothing was gating it.

## Fix

Switch the check to `category: :warning`, a real Credo category, which carries exit status 16. Using a valid category rather than pinning an explicit `exit_status` on an unknown one keeps the same trap from recurring.

The one existing violation is in the flow expression interpreter's whitelist table:

```elixir
defp kernel_call(:inspect, [a]), do: inspect(a)
```

`inspect` here is a function exposed to flow authors, and its result becomes flow output rather than a log line, so this is a false positive for a check about log leakage. It gets a scoped `credo:disable-for-next-line` rather than a swap to `safe_inspect`, which would change what flows using `inspect()` return. Happy to go the other way if reviewers prefer.

## Verification

Full-repo `mix credo --strict` on this branch exits `0`, with no GL1001 issues.

With a synthetic violation added, the check now bites:

```
[W] ↗ lib/glific/credo_canary.ex:4:38 Use `Glific.SafeLog.safe_inspect/1` instead of raw `inspect/1` ...
EXIT=16
```

Before this change, the same canary produced exit `0`.

## Note on master being red

This is unrelated to the credo output above, which is worth stating since the printed `[E]` line reads like the cause. The recent master failures are all in the `tests` job, with `code-quality` green in each, and a different test failing each time:

| Run | Commit | Failing test |
|---|---|---|
| 34146297399 | `4fd3c307` | `webhook_test.exs:627` — `assert 1 == length(jobs)`, got 2 |
| 34114134354 | `489d965d` | `ai_evaluations_test.exs`, many, timeout-shaped |
| 33780154045 | `a50fe8a2` | tests |

That flakiness needs its own fix and is not addressed here.