### PR TITLE
 fix(router): log identifiers instead of the whole flow context on invalid results key

### DIFF
--- a/lib/glific/flows/router.ex
+++ b/lib/glific/flows/router.ex
@@ -341,7 +341,10 @@ defmodule Glific.Flows.Router do
   @spec update_context_results(FlowContext.t(), String.t(), Message.t(), {Category.t(), boolean}) ::
           FlowContext.t()
   defp update_context_results(context, key, _msg, _) when key in ["", nil] do
-    Logger.info("invalid results key for context: #{Glific.SafeLog.safe_inspect(context)}")
+    Logger.info(
+      "invalid results key for flow_context_id: #{context.id}, organization_id: #{context.organization_id}, flow_id: #{context.flow_id}"
+    )
+
     context
   end
 


### PR DESCRIPTION
## Summary
Router.update_context_results/4 logged the entire %FlowContext{} struct when a router had an empty results key.

Replaced the struct dump with the identifiers we actually need to debug:

Logger.info(
  "invalid results key for flow_context_id: #{context.id}, organization_id: #{context.organization_id}, flow_id: #{context.flow_id}"
)