### PR TITLE
fix(assistants): normalize knowledge base file extension casing during upload validation

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1012,7 +1012,7 @@ defmodule Glific.Assistants do
   @spec upload_file(map(), non_neg_integer()) ::
           {:ok, map()} | {:error, String.t()}
   def upload_file(params, organization_id) do
-    with {:ok, filename} <- validate_file_format(params.media.filename),
+    with {:ok, filename} <- validate_and_normalize_file_extension(params.media.filename),
          document_params = %{
            path: params.media.path,
            filename: filename,
@@ -1094,8 +1094,9 @@ defmodule Glific.Assistants do
     end
   end
 
-  @spec validate_file_format(String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp validate_file_format(filename) do
+  @spec validate_and_normalize_file_extension(String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp validate_and_normalize_file_extension(filename) do
     raw_extension = String.split(filename, ".") |> List.last()
     extension = String.downcase(raw_extension)
 

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -1012,14 +1012,13 @@ defmodule Glific.Assistants do
   @spec upload_file(map(), non_neg_integer()) ::
           {:ok, map()} | {:error, String.t()}
   def upload_file(params, organization_id) do
-    document_params = %{
-      path: params.media.path,
-      filename: params.media.filename,
-      target_format: params[:target_format],
-      callback_url: params[:callback_url]
-    }
-
-    with {:ok, _} <- validate_file_format(params.media.filename),
+    with {:ok, filename} <- validate_file_format(params.media.filename),
+         document_params = %{
+           path: params.media.path,
+           filename: filename,
+           target_format: params[:target_format],
+           callback_url: params[:callback_url]
+         },
          {:ok, %{data: document_data}} <- Kaapi.upload_document(document_params, organization_id) do
       Metrics.increment("Assistant File Uploaded", organization_id)
 
@@ -1097,10 +1096,11 @@ defmodule Glific.Assistants do
 
   @spec validate_file_format(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defp validate_file_format(filename) do
-    extension = String.split(filename, ".") |> List.last()
+    raw_extension = String.split(filename, ".") |> List.last()
+    extension = String.downcase(raw_extension)
 
     if extension in @assistant_supported_file_extensions do
-      {:ok, filename}
+      {:ok, String.replace_suffix(filename, raw_extension, extension)}
     else
       {:error, "Files with extension '.#{extension}' not supported in Assistants"}
     end

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -298,8 +298,8 @@ defmodule Glific.Assistants.AssistantTest do
       end)
 
       for extension <- ["csv", "doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"],
-          cased <- [extension, String.upcase(extension), String.capitalize(extension)] do
-        upload = build_upload_for_extension(cased)
+          cased_extension <- [extension, String.upcase(extension), String.capitalize(extension)] do
+        upload = build_upload_for_extension(cased_extension)
 
         assert {:ok, %{filename: filename}} =
                  Assistants.upload_file(%{media: upload}, organization_id)
@@ -307,12 +307,11 @@ defmodule Glific.Assistants.AssistantTest do
         assert filename == "sample.#{extension}"
       end
 
-      for cased <- ["png", "PNG", "Png"] do
+      for cased_extension <- ["png", "PNG", "Png"] do
+        unsupported_upload = build_upload_for_extension(cased_extension)
+
         assert {:error, "Files with extension '.png' not supported in Assistants"} =
-                 Assistants.upload_file(
-                   %{media: build_upload_for_extension(cased)},
-                   organization_id
-                 )
+                 Assistants.upload_file(%{media: unsupported_upload}, organization_id)
       end
     end
 
@@ -576,9 +575,6 @@ defmodule Glific.Assistants.AssistantTest do
     end
   end
 
-  defp multipart_filename(%Tesla.Multipart{parts: parts}),
-    do: Enum.find_value(parts, fn part -> part.dispositions[:filename] end)
-
   defp build_upload_for_extension(extension) do
     tmp_path =
       Path.join(
@@ -607,4 +603,7 @@ defmodule Glific.Assistants.AssistantTest do
         is_active: true
       })
   end
+
+  defp multipart_filename(%Tesla.Multipart{parts: parts}),
+    do: Enum.find_value(parts, fn part -> part.dispositions[:filename] end)
 end

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -281,13 +281,13 @@ defmodule Glific.Assistants.AssistantTest do
   describe "upload_file/2" do
     test "validates assistant-supported file extensions", %{organization_id: organization_id} do
       Tesla.Mock.mock(fn
-        %{method: :post, url: "This is not a secret/api/v1/documents/"} ->
+        %{method: :post, url: "This is not a secret/api/v1/documents/", body: multipart} ->
           %Tesla.Env{
             status: 200,
             body: %{
               success: true,
               data: %{
-                fname: "uploaded",
+                fname: multipart_filename(multipart),
                 id: "d33539f6-2196-477c-a127-0f17f04ef133",
                 inserted_at: "2026-01-30T10:51:16.872363"
               },
@@ -297,15 +297,23 @@ defmodule Glific.Assistants.AssistantTest do
           }
       end)
 
-      for extension <- ["csv", "doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"] do
-        upload = build_upload_for_extension(extension)
-        assert {:ok, _} = Assistants.upload_file(%{media: upload}, organization_id)
+      for extension <- ["csv", "doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"],
+          cased <- [extension, String.upcase(extension), String.capitalize(extension)] do
+        upload = build_upload_for_extension(cased)
+
+        assert {:ok, %{filename: filename}} =
+                 Assistants.upload_file(%{media: upload}, organization_id)
+
+        assert filename == "sample.#{extension}"
       end
 
-      unsupported_upload = build_upload_for_extension("png")
-
-      assert {:error, "Files with extension '.png' not supported in Assistants"} =
-               Assistants.upload_file(%{media: unsupported_upload}, organization_id)
+      for cased <- ["png", "PNG", "Png"] do
+        assert {:error, "Files with extension '.png' not supported in Assistants"} =
+                 Assistants.upload_file(
+                   %{media: build_upload_for_extension(cased)},
+                   organization_id
+                 )
+      end
     end
 
     test "uploads the file successfully to Kaapi", %{
@@ -567,6 +575,9 @@ defmodule Glific.Assistants.AssistantTest do
       assert refreshed.updated_at == original_updated_at
     end
   end
+
+  defp multipart_filename(%Tesla.Multipart{parts: parts}),
+    do: Enum.find_value(parts, fn part -> part.dispositions[:filename] end)
 
   defp build_upload_for_extension(extension) do
     tmp_path =


### PR DESCRIPTION
## Summary
Closes #5546

Uploading a knowledge base file with an uppercase or mixed-case extension (e.g. `test.PDF`,
`Report.Csv`) was rejected with `Files with extension '.PDF' not supported in Assistants`.

`Glific.Assistants.validate_file_format/1` compared the raw extension against
`@assistant_supported_file_extensions`, which is all lowercase, so anything but a lowercase
extension failed the whitelist check.

This PR downcases the extension before the check **and** sends the normalised filename on to Kaapi,
so `test.PDF` becomes `test.pdf`. Kaapi normalises on its side too — this keeps Glific consistent
instead of depending on that, so it doubles as a safety check.
