### PR TITLE
feat(action): implement wait_for_time action handling and improve error management for WA groups

### DIFF
--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -794,13 +794,50 @@ defmodule Glific.Flows.Action do
     {:ok, updated_context, messages}
   end
 
+  def execute(%{type: type} = _action, context, [msg])
+      when type in @wait_for do
+    if msg.body != "No Response" do
+      Logger.info(
+        "Message #{msg.body} with context (#{context.id}) received while waiting for time"
+      )
+
+      {:error, "unexpected message received while waiting for time"}
+    else
+      {:ok, context, []}
+    end
+  end
+
+  @sleep_timeout 4 * 1000
+
+  def execute(%{type: type} = action, context, [])
+      when type in @wait_for do
+    if action.wait_time == @default_wait_time do
+      ## Ideally we should do it by async call
+      ## but this is fine as a sort term fix.
+      Process.sleep(@sleep_timeout)
+      {:ok, context, []}
+    else
+      {:ok, context} =
+        FlowContext.update_flow_context(
+          context,
+          %{
+            wakeup_at: DateTime.add(DateTime.utc_now(), action.wait_time),
+            is_background_flow: context.flow.is_background,
+            is_await_result: type == "wait_for_result"
+          }
+        )
+
+      {:wait, context, []}
+    end
+  end
+
   def execute(action, %{wa_group_id: wa_group_id} = context, messages)
       when wa_group_id != nil do
-    Logger.error(
-      "Unsupported action type: for flow_id #{Glific.SafeLog.safe_inspect(context.flow_id)} wa_group_id #{Glific.SafeLog.safe_inspect(context.wa_group_id)} and the message is #{Glific.SafeLog.safe_inspect(messages)}"
+    Glific.log_error(
+      "Unsupported action type #{action.type} for WA group: flow_id #{Glific.SafeLog.safe_inspect(context.flow_id)} wa_group_id #{Glific.SafeLog.safe_inspect(context.wa_group_id)} and the message is #{Glific.SafeLog.safe_inspect(messages)}"
     )
 
-    raise(UndefinedFunctionError, message: "Unsupported action type #{action.type} for WA group")
+    {:ok, context, messages}
   end
 
   def execute(%{type: "send_msg"} = action, context, messages) do
@@ -1055,43 +1092,6 @@ defmodule Glific.Flows.Action do
     end
 
     {:ok, context, messages}
-  end
-
-  def execute(%{type: type} = _action, context, [msg])
-      when type in @wait_for do
-    if msg.body != "No Response" do
-      Logger.info(
-        "Message #{msg.body} with context (#{context.id}) received while waiting for time"
-      )
-
-      {:error, "unexpected message received while waiting for time"}
-    else
-      {:ok, context, []}
-    end
-  end
-
-  @sleep_timeout 4 * 1000
-
-  def execute(%{type: type} = action, context, [])
-      when type in @wait_for do
-    if action.wait_time == @default_wait_time do
-      ## Ideally we should do it by async call
-      ## but this is fine as a sort term fix.
-      Process.sleep(@sleep_timeout)
-      {:ok, context, []}
-    else
-      {:ok, context} =
-        FlowContext.update_flow_context(
-          context,
-          %{
-            wakeup_at: DateTime.add(DateTime.utc_now(), action.wait_time),
-            is_background_flow: context.flow.is_background,
-            is_await_result: type == "wait_for_result"
-          }
-        )
-
-      {:wait, context, []}
-    end
   end
 
   def execute(action, context, messages) do

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -19,6 +19,7 @@ defmodule Glific.Flows.Action do
     Groups.Group,
     Messages,
     Messages.Message,
+    Notifications,
     Profiles,
     Repo,
     Sheets,
@@ -794,6 +795,17 @@ defmodule Glific.Flows.Action do
     {:ok, updated_context, messages}
   end
 
+  # wait_for_result parks the context for FlowContext.await_context/2, which looks a context up by
+  # contact_id. A WA group context has none, so a parked group flow could only ever be freed by its
+  # own wakeup timer -- silently degrading "await a result" into "sleep". Reject it instead.
+  def execute(
+        %{type: "wait_for_result"} = action,
+        %{wa_group_id: wa_group_id} = context,
+        messages
+      )
+      when wa_group_id != nil,
+      do: unsupported_for_wa_group(action, context, messages)
+
   def execute(%{type: type} = _action, context, [msg])
       when type in @wait_for do
     if msg.body != "No Response" do
@@ -813,7 +825,7 @@ defmodule Glific.Flows.Action do
       when type in @wait_for do
     if action.wait_time == @default_wait_time do
       ## Ideally we should do it by async call
-      ## but this is fine as a sort term fix.
+      ## but this is fine as a short term fix.
       Process.sleep(@sleep_timeout)
       {:ok, context, []}
     else
@@ -832,13 +844,8 @@ defmodule Glific.Flows.Action do
   end
 
   def execute(action, %{wa_group_id: wa_group_id} = context, messages)
-      when wa_group_id != nil do
-    Glific.log_error(
-      "Unsupported action type #{action.type} for WA group: flow_id #{Glific.SafeLog.safe_inspect(context.flow_id)} wa_group_id #{Glific.SafeLog.safe_inspect(context.wa_group_id)} and the message is #{Glific.SafeLog.safe_inspect(messages)}"
-    )
-
-    {:ok, context, messages}
-  end
+      when wa_group_id != nil,
+      do: unsupported_for_wa_group(action, context, messages)
 
   def execute(%{type: "send_msg"} = action, context, messages) do
     templating = Templating.execute(action.templating, context, messages)
@@ -1100,6 +1107,36 @@ defmodule Glific.Flows.Action do
     )
 
     raise(UndefinedFunctionError, message: "Unsupported action type #{action.type}")
+  end
+
+  # Skipping rather than raising is deliberate: this runs inside the webhook Oban job, where an
+  # exception retries the job and repeats an already-sent message. AppSignal is suppressed because
+  # a group flow fans out per wa_group and re-runs on every trigger; the org-visible notification
+  # is the durable signal instead. `messages` passes through untouched, so a pending message is
+  # consumed by the next action rather than aborting the flow.
+  @spec unsupported_for_wa_group(Action.t(), FlowContext.t(), [Message.t()]) ::
+          {:ok, FlowContext.t(), [Message.t()]}
+  defp unsupported_for_wa_group(action, context, messages) do
+    Glific.log_error(
+      "Unsupported action type #{action.type} for WA group: flow_id #{Glific.SafeLog.safe_inspect(context.flow_id)} wa_group_id #{Glific.SafeLog.safe_inspect(context.wa_group_id)} and the message is #{Glific.SafeLog.safe_inspect(messages)}",
+      false
+    )
+
+    Notifications.create_notification(%{
+      category: "Flow",
+      message: "Action #{action.type} is not supported in WhatsApp group flows and was skipped",
+      severity: Notifications.types().warning,
+      organization_id: context.organization_id,
+      entity: %{
+        flow_id: context.flow_id,
+        flow_uuid: context.flow_uuid,
+        node_uuid: context.node_uuid,
+        wa_group_id: context.wa_group_id,
+        action_type: action.type
+      }
+    })
+
+    {:ok, context, messages}
   end
 
   @spec add_flow_label(FlowContext.t(), String.t()) :: nil

--- a/lib/glific/flows/action.ex
+++ b/lib/glific/flows/action.ex
@@ -795,9 +795,8 @@ defmodule Glific.Flows.Action do
     {:ok, updated_context, messages}
   end
 
-  # wait_for_result parks the context for FlowContext.await_context/2, which looks a context up by
-  # contact_id. A WA group context has none, so a parked group flow could only ever be freed by its
-  # own wakeup timer -- silently degrading "await a result" into "sleep". Reject it instead.
+  # await_context/2 finds parked contexts by contact_id, which a WA group context does not have,
+  # so a group parked here could never be resumed by a result.
   def execute(
         %{type: "wait_for_result"} = action,
         %{wa_group_id: wa_group_id} = context,
@@ -1109,11 +1108,6 @@ defmodule Glific.Flows.Action do
     raise(UndefinedFunctionError, message: "Unsupported action type #{action.type}")
   end
 
-  # Skipping rather than raising is deliberate: this runs inside the webhook Oban job, where an
-  # exception retries the job and repeats an already-sent message. AppSignal is suppressed because
-  # a group flow fans out per wa_group and re-runs on every trigger; the org-visible notification
-  # is the durable signal instead. `messages` passes through untouched, so a pending message is
-  # consumed by the next action rather than aborting the flow.
   @spec unsupported_for_wa_group(Action.t(), FlowContext.t(), [Message.t()]) ::
           {:ok, FlowContext.t(), [Message.t()]}
   defp unsupported_for_wa_group(action, context, messages) do

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -10,6 +10,7 @@ defmodule Glific.Flows.ActionTest do
     Flows.ContactField,
     Groups,
     Groups.ContactGroup,
+    Notifications,
     Partners,
     Profiles,
     Seeds.SeedsDev,
@@ -938,6 +939,36 @@ defmodule Glific.Flows.ActionTest do
     assert resumed.is_await_result == false
   end
 
+  test "execute a wait_for_result action for a contact still parks and awaits a result", attrs do
+    contact = Repo.get_by(Contact, %{name: "Default receiver"})
+
+    {:ok, context} =
+      FlowContext.create_flow_context(%{
+        contact_id: contact.id,
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        organization_id: attrs.organization_id
+      })
+
+    context = Repo.preload(context, [:contact, :flow])
+
+    action = %Action{
+      uuid: "UUID 1",
+      node_uuid: "Test UUID",
+      type: "wait_for_result",
+      wait_time: 900
+    }
+
+    # the WA-group rejection clause must not capture contacts: await_context/2 finds these by
+    # contact_id, so is_await_result has to stay true here
+    assert {:wait, waiting_context, []} = Action.execute(action, context, [])
+    assert waiting_context.is_await_result == true
+
+    assert_in_delta DateTime.diff(waiting_context.wakeup_at, DateTime.utc_now()),
+                    action.wait_time,
+                    5
+  end
+
   test "execute a wait_for_result action for a WA Group is rejected, not parked", attrs do
     [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
     [flow | _tail] = Flows.list_flows(%{filter: attrs})
@@ -1716,6 +1747,36 @@ defmodule Glific.Flows.ActionTest do
 
     # raising here retried the enclosing webhook job and duplicated an already-sent message
     assert {:ok, ^context, ^message_stream} = Action.execute(action, context, message_stream)
+  end
+
+  test "execute a wa group unsupported action raises an org notification", attrs do
+    [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
+
+    context =
+      %FlowContext{
+        wa_group_id: wa_group.id,
+        flow_id: 1,
+        flow_uuid: Ecto.UUID.generate(),
+        node_uuid: Ecto.UUID.generate(),
+        organization_id: attrs.organization_id
+      }
+      |> Repo.preload([:wa_group, :flow])
+
+    action = %Action{type: "add_contact_groups", value: ["1"]}
+
+    assert {:ok, _context, []} = Action.execute(action, context, [])
+
+    # AppSignal is suppressed on this path, so the notification is the only durable signal
+    [notification] =
+      Notifications.list_notifications(%{
+        filter: %{message: "add_contact_groups", category: "Flow"}
+      })
+
+    assert notification.severity == Notifications.types().warning
+    assert notification.organization_id == attrs.organization_id
+    assert notification.entity["action_type"] == "add_contact_groups"
+    assert notification.entity["wa_group_id"] == wa_group.id
+    assert notification.entity["node_uuid"] == context.node_uuid
   end
 
   test "execute a wa group unsupported action passes the message stream through untouched",

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -893,11 +893,76 @@ defmodule Glific.Flows.ActionTest do
     # before the wait clauses were moved above the WA group catch-all this raised
     # UndefinedFunctionError instead of arming the timer
     assert {:wait, %FlowContext{} = waiting_context, []} = Action.execute(action, context, [])
+
+    # a regression that armed wakeup_at at "now" would pass a mere non-nil assertion
+    assert_in_delta DateTime.diff(waiting_context.wakeup_at, DateTime.utc_now()),
+                    action.wait_time,
+                    5
+
+    assert waiting_context.is_await_result == false
+
+    no_response = Messages.create_temp_message(attrs.organization_id, "No Response")
+    assert {:ok, %FlowContext{}, []} = Action.execute(action, context, [no_response])
+  end
+
+  test "a WA Group context parked by wait_for_time is resumed by wakeup_one/1",
+       %{organization_id: organization_id} = _attrs do
+    flow = Flow.get_loaded_flow(organization_id, "published", %{keyword: "help"})
+    [node | _tail] = flow.nodes
+
+    context =
+      Fixtures.wa_flow_context_fixture(%{
+        node_uuid: node.uuid,
+        flow_uuid: flow.uuid,
+        flow_id: flow.id,
+        organization_id: organization_id
+      })
+      |> Repo.preload([:flow, :wa_group])
+
+    action = %Action{
+      uuid: "UUID 1",
+      node_uuid: node.uuid,
+      type: "wait_for_time",
+      wait_time: 900
+    }
+
+    assert {:wait, waiting_context, []} = Action.execute(action, context, [])
     assert waiting_context.wakeup_at != nil
 
-    # woken by its own timeout, the wait proceeds along the normal path
-    assert {:ok, %FlowContext{}, []} =
-             Action.execute(action, context, [%{body: "No Response"}])
+    # wakeup_one/1 (no message) is the path a wait timer actually takes: mark_flows_complete and
+    # handle_nil_message must both tolerate a context with contact_id: nil
+    assert {:ok, _context, []} = FlowContext.wakeup_one(waiting_context)
+
+    resumed = Repo.get!(FlowContext, waiting_context.id)
+    assert resumed.wakeup_at == nil
+    assert resumed.is_await_result == false
+  end
+
+  test "execute a wait_for_result action for a WA Group is rejected, not parked", attrs do
+    [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
+    [flow | _tail] = Flows.list_flows(%{filter: attrs})
+
+    {:ok, context} =
+      FlowContext.create_flow_context(%{
+        flow_id: flow.id,
+        flow_uuid: Ecto.UUID.generate(),
+        wa_group_id: wa_group.id,
+        organization_id: attrs.organization_id
+      })
+
+    context = Repo.preload(context, [:flow, :wa_group])
+
+    action = %Action{
+      uuid: "UUID 1",
+      node_uuid: "Test UUID",
+      type: "wait_for_result",
+      wait_time: 900
+    }
+
+    # await_context/2 filters on contact_id, so a parked group context is unresumable by a result
+    assert {:ok, skipped_context, []} = Action.execute(action, context, [])
+    assert skipped_context.wakeup_at == nil
+    assert skipped_context.is_await_result == false
   end
 
   test "execute an action for WA Group when type is set_run_result", attrs do
@@ -1630,11 +1695,16 @@ defmodule Glific.Flows.ActionTest do
   end
 
   test "execute a wa group unsupported action skips the node instead of raising",
-       _attrs do
+       attrs do
     [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
 
     context =
-      %FlowContext{wa_group_id: wa_group.id, flow_id: 1, results: %{"test_result" => "field1"}}
+      %FlowContext{
+        wa_group_id: wa_group.id,
+        flow_id: 1,
+        organization_id: attrs.organization_id,
+        results: %{"test_result" => "field1"}
+      }
       |> Repo.preload([:wa_group, :flow])
 
     action = %Action{

--- a/test/glific/flows/action_test.exs
+++ b/test/glific/flows/action_test.exs
@@ -869,6 +869,37 @@ defmodule Glific.Flows.ActionTest do
     assert updated_context.results["video_code"]["value"] == "shyness"
   end
 
+  test "execute a wait_for_time action for a WA Group arms the timer instead of raising", attrs do
+    [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
+    [flow | _tail] = Flows.list_flows(%{filter: attrs})
+
+    {:ok, context} =
+      FlowContext.create_flow_context(%{
+        flow_id: flow.id,
+        flow_uuid: Ecto.UUID.generate(),
+        wa_group_id: wa_group.id,
+        organization_id: attrs.organization_id
+      })
+
+    context = Repo.preload(context, [:flow, :wa_group])
+
+    action = %Action{
+      uuid: "UUID 1",
+      node_uuid: "Test UUID",
+      type: "wait_for_time",
+      wait_time: 900
+    }
+
+    # before the wait clauses were moved above the WA group catch-all this raised
+    # UndefinedFunctionError instead of arming the timer
+    assert {:wait, %FlowContext{} = waiting_context, []} = Action.execute(action, context, [])
+    assert waiting_context.wakeup_at != nil
+
+    # woken by its own timeout, the wait proceeds along the normal path
+    assert {:ok, %FlowContext{}, []} =
+             Action.execute(action, context, [%{body: "No Response"}])
+  end
+
   test "execute an action for WA Group when type is set_run_result", attrs do
     [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
     [flow | _tail] = Flows.list_flows(%{filter: attrs})
@@ -1598,7 +1629,7 @@ defmodule Glific.Flows.ActionTest do
     assert_raise(UndefinedFunctionError, fn -> Action.execute(action, context, message_stream) end)
   end
 
-  test "execute a wa group unsupported action",
+  test "execute a wa group unsupported action skips the node instead of raising",
        _attrs do
     [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
 
@@ -1613,7 +1644,26 @@ defmodule Glific.Flows.ActionTest do
 
     message_stream = []
 
-    assert_raise(UndefinedFunctionError, fn -> Action.execute(action, context, message_stream) end)
+    # raising here retried the enclosing webhook job and duplicated an already-sent message
+    assert {:ok, ^context, ^message_stream} = Action.execute(action, context, message_stream)
+  end
+
+  test "execute a wa group unsupported action passes the message stream through untouched",
+       attrs do
+    [wa_group | _] = WAGroups.list_wa_groups(%{filter: %{limit: 1}})
+
+    context =
+      %FlowContext{
+        wa_group_id: wa_group.id,
+        flow_id: 1,
+        organization_id: attrs.organization_id
+      }
+      |> Repo.preload([:wa_group, :flow])
+
+    action = %Action{type: "set_contact_name", value: "New Name"}
+    message_stream = [Messages.create_temp_message(attrs.organization_id, "Success")]
+
+    assert {:ok, ^context, ^message_stream} = Action.execute(action, context, message_stream)
   end
 
   describe "call_webhook await state (park_async_webhook)" do

--- a/test/glific/flows/node_test.exs
+++ b/test/glific/flows/node_test.exs
@@ -24,6 +24,39 @@ defmodule Glific.Flows.NodeTest do
     :ok
   end
 
+  test "a WA group flow takes the exit past an unsupported action instead of stalling", attrs do
+    flow = %Flow{id: 1, uuid: "Flow UUID 1"}
+    exit_uuid = Ecto.UUID.generate()
+
+    json = %{
+      "uuid" => Ecto.UUID.generate(),
+      "actions" => [
+        %{
+          "uuid" => Ecto.UUID.generate(),
+          "type" => "set_contact_name",
+          "name" => "Contact Name"
+        }
+      ],
+      "exits" => [
+        %{"uuid" => exit_uuid, "destination_uuid" => nil}
+      ]
+    }
+
+    {node, uuid_map} = Node.process(json, %{}, flow)
+
+    context =
+      Fixtures.wa_flow_context_fixture(%{
+        organization_id: attrs.organization_id,
+        flow_id: 1,
+        uuid_map: uuid_map
+      })
+
+    # set_contact_name is contact-only, so it hits the WA group clause. A nil destination_uuid
+    # means the exit resets the context, so {:ok, nil, []} proves the exit was taken rather
+    # than the node raising or the flow stopping at the action.
+    assert {:ok, nil, []} = Node.execute(node, context, [])
+  end
+
   test "process extracts the right values from json" do
     flow = %Flow{uuid: "Flow UUID 1"}
 


### PR DESCRIPTION
Fixes #5754

## Production symptom

ngo reported an hourly-triggered poll delivered **twice within the same minute** to a WA group, and the 15-minute follow-up message never sent. Reproduced A/B in prod: the same trigger against a flow *with* a `wait for time` node duplicated the poll (group 11936), the flow *without* one behaved correctly (group 12452).

## Root cause

`Action.execute/3` dispatches on clause order. The WA group catch-all

```elixir
def execute(action, %{wa_group_id: wa_group_id} = context, messages)
    when wa_group_id != nil do
```

was declared at line 797, and both `@wait_for` clauses at ~1051/1075 — *below* it. Elixir matches top-down, so a `wait_for_time` node in a group flow never reached its own clause and hit the catch-all, which raised `UndefinedFunctionError`.

That raise happens inside the webhook Oban job, **after** the send has already gone out:

```
action.ex:803       Action.execute/3          <- raise
node.ex:338         Node.execute_node_actions/3
flow_context.ex:908 FlowContext.step_forward/2
flow_context.ex:980 FlowContext.wakeup_one/2
webhook.ex:412      Glific.Flows.Webhook.handle/3
```

`Webhook.perform/1` sends first (`do_action`) and advances the flow second, in one job with `max_attempts: 2`. Oban cannot know the external call already succeeded, so it re-ran `perform/1` from the top — resending the poll — then raised identically and discarded the job, stranding the context (`wakeup_at NULL, completed_at NULL`) so nothing after the wait ever fired. Two symptoms, one cause.

Confirmed from `oban_jobs` on a local repro: job 16945 discarded at attempt 2/2, both errors `UndefinedFunctionError action.ex:803`; **one** `webhook_logs` row against **two** `wa_messages` polls 18s apart, matching Oban's first-retry backoff (`attempt^4 + 15 + rand(0..10)`).

## Changes

**1. Move the `@wait_for` clauses above the catch-all.** Position in the clause list is the enable switch for WA groups — same pattern #4227 used for `set_run_result`. This is what makes `wait_for_time` work for groups.

**2. Reject `wait_for_result` for groups explicitly.** `@wait_for` covers both types, and the clause sets `is_await_result: type == "wait_for_result"`. The only consumer of that flag is `await_context/2` (`flow_context.ex:988`), which filters `fc.contact_id == ^contact_id` — a group context has `contact_id: nil`, which matches nothing in SQL. Enabling it would ship a second, silently broken feature: "await a result" degraded to "sleep until the timer". A new clause above the shared ones routes it to the unsupported handler instead.

**3. The catch-all skips instead of raising.** A raise here is the mechanism that duplicates the send, so an unsupported node now logs and continues to its exit rather than killing the job. `messages` passes through unchanged, so a pending message is consumed by the next action rather than aborting the flow.

AppSignal reporting is suppressed (`Glific.log_error/2` with `send_appsignal?: false`) and replaced with a `Notifications.create_notification` for the org. A group flow fans out per `wa_group` via `Broadcast.broadcast_wa_groups/2` and now re-runs on every trigger instead of stopping at the first failure — one unsupported node in a flow used by 300 groups would be 300 exception reports per trigger. The notification is the org-visible signal; the log line keeps the detail.
