### PR TITLE
feat(evaluationv2): download knowledge base documents directly 

### DIFF
--- a/lib/glific/third_party/kaapi/api_client.ex
+++ b/lib/glific/third_party/kaapi/api_client.ex
@@ -329,7 +329,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClient do
     org_api_key
     |> client()
     |> Tesla.get("/api/v1/documents/:document_id",
-      query: [include_url: "true"],
+      query: [include_url: "true", download: "true"],
       opts: [path_params: [document_id: document_id]]
     )
     |> parse_kaapi_response()

--- a/test/glific/third_party/kaapi/api_client_test.exs
+++ b/test/glific/third_party/kaapi/api_client_test.exs
@@ -313,6 +313,7 @@ defmodule Glific.ThirdParty.Kaapi.ApiClientTest do
     test "returns document data with signed_url" do
       mock(fn %Tesla.Env{method: :get, query: query} ->
         assert query[:include_url] == "true"
+        assert query[:download] == "true"
 
         %Tesla.Env{
           status: 200,


### PR DESCRIPTION
## Summary
- Kaapi's document API now supports a `download=true` query param for direct file download.
- Pass `download=true` alongside `include_url=true` when calling `ApiClient.get_document/2`, so users get the file downloaded directly instead of opening it in a new tab and downloading from there — saves a step.

Fixes #5761

## Test plan
- [x] Updated `test/glific/third_party/kaapi/api_client_test.exs` to assert `download=true` is sent
- [x] `mix test test/glific/third_party/kaapi/api_client_test.exs` passes