### PR TITLE
fix(assistants): drop csv from knowledge base supported file extensions

### DIFF
--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -33,7 +33,6 @@ defmodule Glific.Assistants do
 
   # https://platform.openai.com/docs/assistants/tools/file-search#supported-files
   @assistant_supported_file_extensions [
-    "csv",
     "doc",
     "docx",
     "htm",

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -297,7 +297,7 @@ defmodule Glific.Assistants.AssistantTest do
           }
       end)
 
-      for extension <- ["csv", "doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"],
+      for extension <- ["doc", "docx", "htm", "html", "md", "markdown", "pdf", "txt"],
           cased_extension <- [extension, String.upcase(extension), String.capitalize(extension)] do
         upload = build_upload_for_extension(cased_extension)
 
@@ -307,10 +307,11 @@ defmodule Glific.Assistants.AssistantTest do
         assert filename == "sample.#{extension}"
       end
 
-      for cased_extension <- ["png", "PNG", "Png"] do
+      for cased_extension <- ["png", "PNG", "Png", "csv", "CSV", "Csv"] do
         unsupported_upload = build_upload_for_extension(cased_extension)
+        extension = String.downcase(cased_extension)
 
-        assert {:error, "Files with extension '.png' not supported in Assistants"} =
+        assert {:error, "Files with extension '.#{extension}' not supported in Assistants"} =
                  Assistants.upload_file(%{media: unsupported_upload}, organization_id)
       end
     end

--- a/test/glific/assistants/assistant_test.exs
+++ b/test/glific/assistants/assistant_test.exs
@@ -311,8 +311,10 @@ defmodule Glific.Assistants.AssistantTest do
         unsupported_upload = build_upload_for_extension(cased_extension)
         extension = String.downcase(cased_extension)
 
-        assert {:error, "Files with extension '.#{extension}' not supported in Assistants"} =
+        assert {:error, message} =
                  Assistants.upload_file(%{media: unsupported_upload}, organization_id)
+
+        assert message == "Files with extension '.#{extension}' not supported in Assistants"
       end
     end
 


### PR DESCRIPTION
## Description

### What

Removes `csv` from `@assistant_supported_file_extensions` in `Glific.Assistants`, so CSV files are rejected at upload time for assistants / knowledge bases.

### Why

OpenAI's file search does not support CSV files in knowledge bases. Allowing the upload let users add files that would never be indexed, failing silently later instead of at the point of upload.

### Changes

- `lib/glific/assistants.ex` — removed `"csv"` from the allowed extension list. Uploading  a `.csv` now returns `{:error, "Files with extension '.csv' not supported in Assistants"}`.
- `test/glific/assistants/assistant_test.exs` — moved `csv` from the supported-extension loop to the rejected-extension loop (all casings), with the expected message derived  from the extension.

### Testing

`mix test test/glific/assistants/assistant_test.exs`


### Testing ss
<img width="1079" height="104" alt="Screenshot 2026-09-11 at 2 38 58 PM" src="https://github.com/user-attachments/assets/744a09ca-91a3-437b-a49d-3c64c21f397b" />

