### PR TITLE
fix: persist and expose assistant config failure reasons

### DIFF
--- a/assets/gql/assistants/assistant_versions.gql
+++ b/assets/gql/assistants/assistant_versions.gql
@@ -8,6 +8,7 @@ query AssistantVersions($assistant_id: ID!) {
     prompt
     settings
     status
+    failure_reason
     is_live
     description
     vector_store {

--- a/assets/gql/assistants/subscribe.gql
+++ b/assets/gql/assistants/subscribe.gql
@@ -6,6 +6,7 @@ subscription assistantConfigVersionUpdated {
     prompt
     settings
     status
+    failureReason
     description
     vectorStore {
       id

--- a/lib/glific/assistants.ex
+++ b/lib/glific/assistants.ex
@@ -97,6 +97,7 @@ defmodule Glific.Assistants do
            prompt: version.prompt,
            settings: version.settings,
            status: version.status,
+           failure_reason: version.failure_reason,
            is_live: version.id == assistant.active_config_version_id,
            description: version.description,
            vector_store_data: build_vector_store_data(version),
@@ -523,7 +524,14 @@ defmodule Glific.Assistants do
         {:ok, %{assistant: updated_assistant, config_version: updated_config_version}}
 
       {:error, error} ->
-        update_config_version_status(config_version, %{status: :failed})
+        update_config_version_status(config_version, %{
+          status: :failed,
+          failure_reason:
+            normalize_failure_reason(
+              error,
+              "Assistant configuration could not be created. Please contact support."
+            )
+        })
 
         Glific.log_exception(%Error{
           message:
@@ -977,6 +985,11 @@ defmodule Glific.Assistants do
       provider: "openai",
       settings: kaapi_config.settings,
       status: status,
+      failure_reason:
+        if(status == :failed,
+          do:
+            "The linked knowledge base failed to process. Please check its files before creating another version."
+        ),
       organization_id: kaapi_config.organization_id
     })
   end
@@ -984,6 +997,16 @@ defmodule Glific.Assistants do
   @spec kaapi_error_message(map() | any()) :: String.t()
   defp kaapi_error_message(%{body: %{error: message}}) when is_binary(message), do: message
   defp kaapi_error_message(_value), do: "Unknown error occurred, please retry again."
+
+  @spec normalize_failure_reason(any(), String.t()) :: String.t()
+  defp normalize_failure_reason(%{body: %{error: message}}, fallback),
+    do: normalize_failure_reason(message, fallback)
+
+  defp normalize_failure_reason(message, fallback) when is_binary(message) do
+    if String.trim(message) == "", do: fallback, else: message
+  end
+
+  defp normalize_failure_reason(_message, fallback), do: fallback
 
   @spec generate_assistant_name(String.t() | nil) :: String.t()
   defp generate_assistant_name(name) when name in [nil, ""] do
@@ -1410,7 +1433,11 @@ defmodule Glific.Assistants do
         assistant_config_versions: :assistant
       ])
 
-    failure_reason = error_message || "Knowledge base creation failed with status #{status}"
+    failure_reason =
+      normalize_failure_reason(
+        error_message,
+        "Knowledge base creation failed with status #{status}"
+      )
 
     case knowledge_base_version.assistant_config_versions do
       [config_version] ->

--- a/lib/glific_web/schema/assistant_types.ex
+++ b/lib/glific_web/schema/assistant_types.ex
@@ -85,6 +85,7 @@ defmodule GlificWeb.Schema.AssistantTypes do
     field :settings, :json
     field :status, :string
     field :is_live, :boolean
+    field :failure_reason, :string
     field :description, :string
 
     field :vector_store, :vector_store do

--- a/test/glific/assistants_test.exs
+++ b/test/glific/assistants_test.exs
@@ -1234,6 +1234,36 @@ defmodule Glific.AssistantsTest do
   end
 
   describe "create_assistant/1" do
+    test "persists initial Kaapi failure reasons without changing the error return",
+         %{organization_id: organization_id} do
+      enable_kaapi(%{organization_id: organization_id})
+      fallback = "Assistant configuration could not be created. Please contact support."
+
+      for {body, expected_reason} <- [
+            {%{error: "Invalid model requested"}, "Invalid model requested"},
+            {%{}, fallback},
+            {%{error: nil}, fallback},
+            {%{error: ""}, fallback},
+            {%{error: " \n\t"}, fallback},
+            {%{error: %{code: "invalid_config"}}, fallback}
+          ] do
+        Tesla.Mock.mock(fn %{method: :post} ->
+          %Tesla.Env{status: 400, body: body}
+        end)
+
+        name = "Failed Assistant #{Ecto.UUID.generate()}"
+
+        assert Assistants.create_assistant(%{name: name, organization_id: organization_id}) ==
+                 {:error,
+                  "Kaapi config creation failed for assistant, Reason: #{Glific.SafeLog.safe_inspect(%{status: 400, body: body})}"}
+
+        assistant = Repo.get_by!(Assistant, name: name)
+        config_version = Repo.get!(AssistantConfigVersion, assistant.active_config_version_id)
+        assert config_version.status == :failed
+        assert config_version.failure_reason == expected_reason
+      end
+    end
+
     test "creates assistant and config version with nil kaapi_uuid",
          %{organization_id: organization_id} do
       {:ok, kb} =
@@ -1328,6 +1358,7 @@ defmodule Glific.AssistantsTest do
 
       assert assistant.name == "No KB Assistant"
       assert config_version.status == :ready
+      assert is_nil(config_version.failure_reason)
     end
 
     test "uses default values when optional params are missing",
@@ -2381,6 +2412,52 @@ defmodule Glific.AssistantsTest do
   describe "end-to-end: create assistant — failure cases" do
     setup [:enable_kaapi]
 
+    test "FAILED KB callbacks use the same nonblank reason in storage and notifications",
+         %{organization_id: organization_id} do
+      Tesla.Mock.mock(fn _request -> flunk("Failed KB must not register with Kaapi") end)
+      fallback = "Knowledge base creation failed with status FAILED"
+
+      for {error_fields, expected_reason} <- [
+            {%{"error_message" => "Invalid documents: unsupported format"},
+             "Invalid documents: unsupported format"},
+            {%{}, fallback},
+            {%{"error_message" => nil}, fallback},
+            {%{"error_message" => ""}, fallback},
+            {%{"error_message" => " \n\t"}, fallback}
+          ] do
+        job_id = Ecto.UUID.generate()
+
+        {_knowledge_base, knowledge_base_version} =
+          create_knowledge_base_version(organization_id, :in_progress, job_id, [])
+
+        {:ok, %{assistant: assistant, config_version: config_version}} =
+          Assistants.create_assistant(%{
+            knowledge_base_version_id: knowledge_base_version.id,
+            organization_id: organization_id
+          })
+
+        assert is_nil(config_version.failure_reason)
+
+        Assistants.handle_knowledge_base_callback(%{
+          "data" => Map.merge(%{"job_id" => job_id, "status" => "FAILED"}, error_fields)
+        })
+
+        config_version = Repo.get!(AssistantConfigVersion, config_version.id)
+        assert config_version.status == :failed
+        assert config_version.failure_reason == expected_reason
+
+        notification =
+          Notification
+          |> Repo.all()
+          |> Enum.find(&(&1.entity["config_version_id"] == config_version.id))
+
+        assert notification.entity["failure_reason"] == expected_reason
+
+        assert notification.message ==
+                 "Knowledge Base creation failed for assistant \"#{assistant.name}\". Reason: #{expected_reason}. Please try again."
+      end
+    end
+
     test "create assistant -> FAILED KB callback -> config version marked as failed with real error",
          %{organization_id: organization_id} do
       Tesla.Mock.mock(fn
@@ -2570,8 +2647,10 @@ defmodule Glific.AssistantsTest do
   describe "end-to-end: callback arrives before save — failure cases" do
     setup [:enable_kaapi]
 
-    test "FAILED KB callback first, then assistant creation -> config stays in_progress with failed KB",
+    test "FAILED KB callback first, then assistant creation -> config fails with a dependency reason",
          %{organization_id: organization_id} do
+      Tesla.Mock.mock(fn _request -> flunk("Failed KB must not register with Kaapi") end)
+
       {:ok, kb} =
         Assistants.create_knowledge_base(%{
           name: "Test KB",
@@ -2616,7 +2695,13 @@ defmodule Glific.AssistantsTest do
 
       # No Kaapi registration since KB failed — kaapi_uuid stays nil
       assert is_nil(assistant.kaapi_uuid)
+      config_version = Repo.get!(AssistantConfigVersion, config_version.id)
       assert config_version.status == :failed
+
+      assert config_version.failure_reason ==
+               "The linked knowledge base failed to process. Please check its files before creating another version."
+
+      refute config_version.failure_reason =~ "Document parsing failed"
     end
 
     test "SUCCESSFUL KB callback first, then assistant creation fails to register with Kaapi",
@@ -2669,6 +2754,39 @@ defmodule Glific.AssistantsTest do
 
   describe "end-to-end: update assistant" do
     setup [:enable_kaapi, :setup_assistant_with_kb]
+
+    test "updating with an already-failed KB explains the new version and retains the live version",
+         %{
+           organization_id: organization_id,
+           assistant: assistant,
+           config_version: original_config_version
+         } do
+      Tesla.Mock.mock(fn _request -> flunk("Failed KB must not register with Kaapi") end)
+
+      {_knowledge_base, knowledge_base_version} =
+        create_knowledge_base_version(organization_id, :failed, "failed_before_update", [])
+
+      assert {:ok, _result} =
+               Assistants.update_assistant(assistant.id, %{
+                 name: assistant.name,
+                 knowledge_base_version_id: knowledge_base_version.id,
+                 organization_id: organization_id
+               })
+
+      new_config_version =
+        AssistantConfigVersion
+        |> where([version], version.assistant_id == ^assistant.id)
+        |> where([version], version.id != ^original_config_version.id)
+        |> Repo.one!()
+
+      assert new_config_version.status == :failed
+
+      assert new_config_version.failure_reason ==
+               "The linked knowledge base failed to process. Please check its files before creating another version."
+
+      assert Repo.get!(Assistant, assistant.id).active_config_version_id ==
+               original_config_version.id
+    end
 
     test "update assistant with same KB -> new config version registered with Kaapi",
          %{

--- a/test/glific_web/resolvers/assistants_test.exs
+++ b/test/glific_web/resolvers/assistants_test.exs
@@ -34,6 +34,12 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
   )
 
   load_gql(
+    :config_subscription,
+    GlificWeb.Schema,
+    "assets/gql/assistants/subscribe.gql"
+  )
+
+  load_gql(
     :set_live_version,
     GlificWeb.Schema,
     "assets/gql/assistants/set_live_version.gql"
@@ -501,8 +507,22 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
           model: "gpt-4o",
           prompt: "Prompt v3",
           settings: %{},
-          status: :ready,
+          status: :failed,
+          failure_reason: "Invalid documents: unsupported format",
           bump_type: :major
+        })
+        |> Repo.insert()
+
+      {:ok, _legacy_version} =
+        %AssistantConfigVersion{}
+        |> AssistantConfigVersion.changeset(%{
+          assistant_id: assistant.id,
+          organization_id: organization_id,
+          provider: "openai",
+          model: "gpt-4o",
+          prompt: "Legacy failed version",
+          settings: %{},
+          status: :failed
         })
         |> Repo.insert()
 
@@ -515,10 +535,16 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
         auth_query_gql_by(:assistant_versions, user, variables: %{"assistant_id" => assistant.id})
 
       versions = query_data.data["assistantVersions"]
-      assert length(versions) == 3
+      assert length(versions) == 4
 
       # Ordered newest first by major, then minor
-      assert Enum.map(versions, & &1["version_label"]) == ["2.0", "1.1", "1.0"]
+      assert Enum.map(versions, & &1["version_label"]) == ["2.1", "2.0", "1.1", "1.0"]
+      assert Enum.map(versions, & &1["status"]) == ["failed", "failed", "in_progress", "ready"]
+
+      assert Enum.map(versions, & &1["failure_reason"]) ==
+               [nil, "Invalid documents: unsupported format", nil, nil]
+
+      assert Enum.map(versions, & &1["is_live"]) == [false, false, false, true]
 
       # is_live reflects active_config_version_id
       live_version = Enum.find(versions, & &1["is_live"])
@@ -526,6 +552,24 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
 
       # versions without a linked knowledge base have no vector_store
       assert Enum.all?(versions, fn v -> is_nil(v["vector_store"]) end)
+
+      other_organization = Glific.Fixtures.organization_fixture()
+      Repo.put_organization_id(other_organization.id)
+
+      other_user =
+        Glific.Fixtures.user_fixture(%{
+          organization_id: other_organization.id,
+          roles: ["manager"]
+        })
+
+      {:ok, other_query_data} =
+        auth_query_gql_by(:assistant_versions, other_user,
+          variables: %{"assistant_id" => assistant.id}
+        )
+
+      other_versions = other_query_data.data["assistantVersions"]
+      assert other_versions == [] or Enum.all?(other_versions, &is_nil(&1["id"]))
+      assert Enum.all?(other_versions, &is_nil(&1["failure_reason"]))
     end
 
     test "concurrent inserts for the same assistant get unique, sequential version numbers", %{
@@ -640,6 +684,51 @@ defmodule GlificWeb.Resolvers.AssistantsTest do
       versions = query_data.data["assistantVersions"]
       # Absinthe returns a list with nil entries or an empty list when the resolver errors
       assert versions == [] or Enum.all?(versions, &is_nil(&1["id"]))
+    end
+  end
+
+  describe "assistantConfigVersionUpdated subscription" do
+    setup :enable_kaapi
+
+    test "publishes the persisted terminal failure to the organization's subscriber", %{
+      manager: user,
+      organization_id: organization_id
+    } do
+      assert {:ok, %{"subscribed" => subscription_id}} =
+               auth_query_gql_by(:config_subscription, user,
+                 operation_name: "assistantConfigVersionUpdated",
+                 context: %{current_user: user, pubsub: GlificWeb.Endpoint}
+               )
+
+      :ok = GlificWeb.Endpoint.subscribe(subscription_id)
+
+      failure_reason = "Invalid model requested"
+
+      Tesla.Mock.mock(fn %{method: :post} ->
+        %Tesla.Env{status: 400, body: %{error: failure_reason}}
+      end)
+
+      assert {:error, _reason} =
+               Assistants.create_assistant(%{
+                 name: "Subscription failure",
+                 organization_id: organization_id
+               })
+
+      assistant = Repo.get_by!(Assistant, name: "Subscription failure")
+      config_version = Repo.get!(AssistantConfigVersion, assistant.active_config_version_id)
+      assert config_version.status == :failed
+      assert config_version.failure_reason == failure_reason
+
+      assert_receive %Phoenix.Socket.Broadcast{
+                       topic: ^subscription_id,
+                       event: "subscription:data",
+                       payload: %{result: %{data: %{"assistantConfigVersionUpdated" => payload}}}
+                     },
+                     1_000
+
+      assert payload["id"] == to_string(config_version.id)
+      assert payload["status"] == "failed"
+      assert payload["failureReason"] == config_version.failure_reason
     end
   end
 


### PR DESCRIPTION
## Summary

In `lib/glific/assistants.ex`, persist a nonblank, contextual reason in `create_config_without_knowledge_base/3` when Kaapi returns an error, preserving an available provider message and using an honest fallback when no message exists. In `build_config_version_changeset/3`, attach a reason identifying the already-failed linked knowledge base when the initial config status is failed; the KB schema does not retain its earlier callback error, so do not claim to recover that original detail. In `update_linked_config_version/3`, treat nil, empty, and whitespace-only error messages as absent and use the existing contextual fallback for both the saved reason and notification, preserving useful provider text.

Issue #5752 reports failed assistant versions that cannot be evaluated or made live, with missing explanations and no usable recovery path. The report counts 352 failed production versions and 48 staging versions; the September 10 thread reproduces a knowledge-base failure and distinguishes historical deferred-config failures from current defects. This checkout already filters the evaluation picker to ready versions, but initial config creation can still persist a failed version without its available Kaapi error, and creating against an already-failed knowledge base copies the status without a reason. Version history also drops `failure_reason` from its response map, while its GraphQL type omits the field altogether.

Fixes #5752

## Checklist

Before submitting a pull request, please ensure that you mark these task.

- [ ] Ran `mix setup` in the repository root and test.
  Not run: no test command resolved in this workspace, so nothing was executed to pass.
- [x] If you've fixed a bug or added code that is tested and has test cases.
- [ ] In the case of adding a new API, you added a **postman** request for that.
- [x] Coding standard and conventions are followed. https://docs.google.com/document/d/1rfU33IjS-ioiIH0TBWpxoLsdyyYdI1tDrqr5HCRIb98/edit?usp=sharing

## Notes

Nothing beyond what is described above.
