### PR TITLE
feat(web-channel): brand colours, a business profile, and an organisation-controlled switch

### DIFF
--- a/lib/glific/partners.ex
+++ b/lib/glific/partners.ex
@@ -46,6 +46,8 @@ defmodule Glific.Partners do
     Users.User
   }
 
+  alias GlificWeb.WebChannel.RoomChannel
+
   # We cache organization info under this id since when we want to retrieve
   # by shortcode we do not have an organization id to retrieve it from.
   @global_organization_id 0
@@ -1154,6 +1156,14 @@ defmodule Glific.Partners do
 
         {:error, "Failed to sync WhatsApp data to Glific. Please reach out to Glific Support"}
     end
+  end
+
+  # Switching the web channel off has to reach the browsers already in a conversation; they hold
+  # a token that stays valid and a socket that would otherwise keep serving messages.
+  defp credential_update_callback(organization, credential, "web_channel") do
+    if !credential.is_active, do: RoomChannel.close_all(organization.id)
+
+    {:ok, credential}
   end
 
   defp credential_update_callback(_organization, credential, _provider), do: {:ok, credential}

--- a/lib/glific/web_channel/branding.ex
+++ b/lib/glific/web_channel/branding.ex
@@ -18,8 +18,11 @@ defmodule Glific.WebChannel.Branding do
 
   @provider_code "web_channel"
 
-  @default_primary "#4c3bcf"
-  @default_secondary "#ff8a3d"
+  # Glific's own green and amber, so an organisation that has set nothing still looks deliberate
+  # rather than unstyled. Kept in step with FALLBACK_BRANDING in the widget's branding.ts, which
+  # is what a 404 or an empty payload falls back to there.
+  @default_primary "#119656"
+  @default_secondary "#eab308"
 
   # The two neutrals the widget's own palette is built from, so a computed foreground looks
   # like the rest of the surface rather than like pure #000/#fff dropped on top of it.

--- a/lib/glific/web_channel/branding.ex
+++ b/lib/glific/web_channel/branding.ex
@@ -1,61 +1,61 @@
 defmodule Glific.WebChannel.Branding do
   @moduledoc """
-  Per-organisation branding for the web channel — its theme, logo and display name.
-
-  "Theme" here means the colour palette only; branding is that plus the logo and the name.
+  Per-organisation branding for the web channel — its colours, logo, display name and the
+  business profile contacts can open from the chat menu.
 
   One deployment serves every organisation and the widget is a single build, so branding is
-  read at runtime from the organisation's `web` credential rather than baked in. An
-  organisation that has not filled the credential in yet still gets a usable theme built from
-  its own name.
+  read at runtime from the organisation's `web_channel` credential rather than baked in. An
+  organisation that has not filled the credential in yet still gets a usable surface built
+  from its own name and the default palette.
 
-  An organisation picks a named theme rather than a colour of its own. The widget holds the
-  matching palette, so the only thing that crosses this boundary is the name — which means an
-  organisation cannot produce an unreadable widget, and contrast is settled once here rather
-  than per organisation.
+  An organisation picks its own two colours. Only `primary` is ever painted behind text, and
+  the text colour over it is computed here rather than chosen by the admin — which is what
+  keeps an organisation from producing an unreadable widget. `secondary` is decorative and
+  never carries text, so it needs no such guarantee.
   """
 
   alias Glific.Partners.Organization
 
   @provider_code "web_channel"
 
-  # Kept in step with THEMES in glific-web-channel's src/services/themes.ts, which holds the
-  # palette each of these names resolves to. A name the widget does not recognise falls back
-  # there too, so the two lists drifting degrades rather than breaks.
-  #
-  # `swatch` is display only — it is the sRGB rendering of that theme's `--primary`, so the
-  # Settings dropdown can show the colour beside the name. The widget still owns the real
-  # values; `shade` names the Tailwind colour both sides were taken from.
-  @themes [
-    %{id: "violet", label: "Violet", shade: "violet-600", swatch: "#7f22fe"},
-    %{id: "blue", label: "Blue", shade: "blue-600", swatch: "#155dfc"},
-    %{id: "green", label: "Green", shade: "green-700", swatch: "#008236"},
-    %{id: "teal", label: "Teal", shade: "teal-700", swatch: "#00786f"},
-    %{id: "rose", label: "Rose", shade: "rose-600", swatch: "#ec003f"},
-    %{id: "orange", label: "Orange", shade: "orange-500", swatch: "#ff6900"},
-    %{id: "amber", label: "Amber", shade: "amber-400", swatch: "#ffb900"},
-    %{id: "zinc", label: "Zinc", shade: "zinc-900", swatch: "#18181b"}
-  ]
+  @default_primary "#4c3bcf"
+  @default_secondary "#ff8a3d"
 
-  @default_theme "zinc"
+  # The two neutrals the widget's own palette is built from, so a computed foreground looks
+  # like the rest of the surface rather than like pure #000/#fff dropped on top of it.
+  @on_dark "#fafafa"
+  @on_light "#18181b"
+
+  @about_fields ~w(description address website email hours)a
+
+  @type about() :: %{
+          description: String.t() | nil,
+          address: String.t() | nil,
+          website: String.t() | nil,
+          email: String.t() | nil,
+          hours: String.t() | nil
+        }
 
   @type t() :: %{
-          theme: String.t(),
+          display_name: String.t(),
           logo_url: String.t() | nil,
-          display_name: String.t()
+          primary_color: String.t(),
+          primary_foreground: String.t(),
+          secondary_color: String.t(),
+          about: about()
         }
 
   @doc """
-  The themes an organisation may choose between, as the Settings dropdown renders them.
+  The primary colour an organisation gets before it has chosen one.
   """
-  @spec themes() :: [%{id: String.t(), label: String.t(), shade: String.t(), swatch: String.t()}]
-  def themes, do: @themes
+  @spec default_primary() :: String.t()
+  def default_primary, do: @default_primary
 
   @doc """
-  The theme an organisation gets before it has chosen one.
+  The secondary colour an organisation gets before it has chosen one.
   """
-  @spec default_theme() :: String.t()
-  def default_theme, do: @default_theme
+  @spec default_secondary() :: String.t()
+  def default_secondary, do: @default_secondary
 
   @doc """
   The branding an organisation's web channel should render with.
@@ -63,12 +63,33 @@ defmodule Glific.WebChannel.Branding do
   @spec for_organization(Organization.t()) :: t()
   def for_organization(organization) do
     keys = branding_keys(organization)
+    primary = color(keys["primary_color"], @default_primary)
 
     %{
-      theme: theme(keys["theme"]),
+      display_name: display_name(keys["display_name"], organization),
       logo_url: logo_url(keys["logo_url"]),
-      display_name: display_name(keys["display_name"], organization)
+      primary_color: primary,
+      primary_foreground: readable_on(primary),
+      secondary_color: color(keys["secondary_color"], @default_secondary),
+      about: about(keys)
     }
+  end
+
+  @doc """
+  The text colour to use over `hex`, whichever of the two neutrals contrasts with it more.
+
+  Public because this is the guarantee the Settings page makes to an admin in words — that
+  header text flips to stay legible — and a guarantee stated in one place and implemented in
+  another is one that drifts.
+  """
+  @spec readable_on(String.t()) :: String.t()
+  def readable_on(hex) do
+    luminance = hex |> color(@default_primary) |> relative_luminance()
+
+    if contrast(luminance, relative_luminance(@on_light)) >=
+         contrast(luminance, relative_luminance(@on_dark)),
+       do: @on_light,
+       else: @on_dark
   end
 
   @spec branding_keys(Organization.t()) :: map()
@@ -79,13 +100,48 @@ defmodule Glific.WebChannel.Branding do
     end
   end
 
-  @spec theme(term()) :: String.t()
-  defp theme(name) when is_binary(name) do
-    name = name |> String.trim() |> String.downcase()
-    if Enum.any?(@themes, &(&1.id == name)), do: name, else: @default_theme
+  @spec about(map()) :: about()
+  defp about(keys),
+    do: Map.new(@about_fields, &{&1, about_value(&1, keys["about_#{&1}"])})
+
+  @spec about_value(atom(), term()) :: String.t() | nil
+  defp about_value(:website, value), do: value |> trimmed() |> with_scheme()
+  defp about_value(_field, value), do: trimmed(value)
+
+  @spec trimmed(term()) :: String.t() | nil
+  defp trimmed(value) when is_binary(value) do
+    case String.trim(value) do
+      "" -> nil
+      trimmed -> trimmed
+    end
   end
 
-  defp theme(_name), do: @default_theme
+  defp trimmed(_value), do: nil
+
+  # An admin types "example.org"; the widget renders it as a link, and a href without a scheme
+  # resolves against the widget's own host.
+  @spec with_scheme(String.t() | nil) :: String.t() | nil
+  defp with_scheme(nil), do: nil
+
+  defp with_scheme(url) do
+    if String.match?(url, ~r{^[a-z][a-z0-9+.-]*://}i), do: url, else: "https://#{url}"
+  end
+
+  @spec color(term(), String.t()) :: String.t()
+  defp color(value, fallback) when is_binary(value) do
+    case value |> String.trim() |> String.downcase() do
+      <<?#, r::binary-size(1), g::binary-size(1), b::binary-size(1)>> ->
+        color("##{r}#{r}#{g}#{g}#{b}#{b}", fallback)
+
+      <<?#, _rest::binary-size(6)>> = hex ->
+        if hex =~ ~r/^#[0-9a-f]{6}$/, do: hex, else: fallback
+
+      _malformed ->
+        fallback
+    end
+  end
+
+  defp color(_value, fallback), do: fallback
 
   @spec logo_url(term()) :: String.t() | nil
   defp logo_url(url) when is_binary(url) do
@@ -104,4 +160,20 @@ defmodule Glific.WebChannel.Branding do
   end
 
   defp display_name(_name, organization), do: organization.name
+
+  @spec contrast(float(), float()) :: float()
+  defp contrast(first, second),
+    do: (max(first, second) + 0.05) / (min(first, second) + 0.05)
+
+  @spec relative_luminance(String.t()) :: float()
+  defp relative_luminance(<<?#, r::binary-size(2), g::binary-size(2), b::binary-size(2)>>) do
+    [r, g, b] = Enum.map([r, g, b], &channel/1)
+    0.2126 * r + 0.7152 * g + 0.0722 * b
+  end
+
+  @spec channel(String.t()) :: float()
+  defp channel(hex) do
+    value = String.to_integer(hex, 16) / 255
+    if value <= 0.03928, do: value / 12.92, else: :math.pow((value + 0.055) / 1.055, 2.4)
+  end
 end

--- a/lib/glific/web_channel/branding.ex
+++ b/lib/glific/web_channel/branding.ex
@@ -40,12 +40,19 @@ defmodule Glific.WebChannel.Branding do
         }
 
   @type t() :: %{
+          enabled: true,
           display_name: String.t(),
           logo_url: String.t() | nil,
           primary_color: String.t(),
           primary_foreground: String.t(),
           secondary_color: String.t(),
           about: about()
+        }
+
+  @type disabled() :: %{
+          enabled: false,
+          display_name: String.t(),
+          whatsapp_number: String.t() | nil
         }
 
   @doc """
@@ -69,12 +76,30 @@ defmodule Glific.WebChannel.Branding do
     primary = color(keys["primary_color"], @default_primary)
 
     %{
+      enabled: true,
       display_name: display_name(keys["display_name"], organization),
       logo_url: logo_url(keys["logo_url"]),
       primary_color: primary,
       primary_foreground: readable_on(primary),
       secondary_color: color(keys["secondary_color"], @default_secondary),
       about: about(keys)
+    }
+  end
+
+  @doc """
+  What the widget renders for an organisation whose web channel is off.
+
+  A 200 rather than a 404, because there is still something to say: the organisation's name,
+  and the WhatsApp number a contact can reach them on instead. The name comes from the
+  organisation record rather than the credential — an organisation that has never configured
+  the channel has no credential to take a display name from.
+  """
+  @spec disabled_for_organization(Organization.t()) :: disabled()
+  def disabled_for_organization(organization) do
+    %{
+      enabled: false,
+      display_name: organization.name,
+      whatsapp_number: whatsapp_number(organization)
     }
   end
 
@@ -94,6 +119,10 @@ defmodule Glific.WebChannel.Branding do
        do: @on_light,
        else: @on_dark
   end
+
+  @spec whatsapp_number(Organization.t()) :: String.t() | nil
+  defp whatsapp_number(%{contact: %{phone: phone}}) when is_binary(phone), do: phone
+  defp whatsapp_number(_organization), do: nil
 
   @spec branding_keys(Organization.t()) :: map()
   defp branding_keys(organization) do

--- a/lib/glific_web/channels/web_channel/flag.ex
+++ b/lib/glific_web/channels/web_channel/flag.ex
@@ -1,7 +1,14 @@
 defmodule GlificWeb.WebChannel.Flag do
   @moduledoc """
-  Whether the web channel is switched on for an organization, for the surfaces that gate on it:
-  the OTP auth controller, the socket, and media upload.
+  Whether the web channel is switched on for an organization, for every surface that gates on
+  it: the branding endpoint, the OTP auth controller, the socket, and media upload.
+
+  Two switches, and both have to be on. `:web_channel_enabled` is Glific's — may this
+  organization have the feature at all — and a Glific admin flips it at `/feature-flags`. An
+  active `web_channel` credential is the organization's own, flipped by its admin on the
+  Settings page. Without the second, an organization granted the feature but configured with
+  nothing is already reachable in a browser, serving Glific's default branding under its own
+  domain to anyone who finds the address.
 
   `lib/glific/CLAUDE.md` says not to write a per-flag wrapper around
   `Glific.Flags.get_flag_enabled/2`, and to call it inline instead. This is the exception that
@@ -20,17 +27,29 @@ defmodule GlificWeb.WebChannel.Flag do
   back in.
   """
 
-  alias Glific.{Flags, Partners}
+  alias Glific.{Flags, Partners, Partners.Organization}
+
+  @provider_code "web_channel"
 
   @doc """
-  Whether `:web_channel_enabled` is on for `organization_id`, false for an organization that
-  does not exist.
+  Whether the web channel is on for an organization, false for one that does not exist.
+
+  Takes the id — which every caller reads from a JWT claim and so cannot trust — or an
+  organization already loaded, for a caller that has one and should not resolve it twice.
   """
-  @spec web_channel_enabled?(non_neg_integer()) :: boolean()
+  @spec web_channel_enabled?(non_neg_integer() | Organization.t()) :: boolean()
+  def web_channel_enabled?(%Organization{} = organization),
+    do: Flags.get_flag_enabled(:web_channel_enabled, organization) and configured?(organization)
+
   def web_channel_enabled?(organization_id) do
     case Partners.organization(organization_id) do
       {:error, _reason} -> false
-      organization -> Flags.get_flag_enabled(:web_channel_enabled, organization)
+      organization -> web_channel_enabled?(organization)
     end
   end
+
+  # `services` holds only ACTIVE credentials — `Partners.set_credentials/1` filters on
+  # `is_active` — so the key being present is the organization's own switch being on.
+  @spec configured?(Organization.t()) :: boolean()
+  defp configured?(organization), do: is_map(organization.services[@provider_code])
 end

--- a/lib/glific_web/channels/web_channel/room_channel.ex
+++ b/lib/glific_web/channels/web_channel/room_channel.ex
@@ -21,6 +21,29 @@ defmodule GlificWeb.WebChannel.RoomChannel do
 
   alias GlificWeb.WebChannel.{MessageSerializer, Presence, Token}
 
+  @doc """
+  Close every open room for an organization, because its admin has switched the web channel off.
+
+  A per-organization PubSub topic rather than Presence, which degrades to an empty list when its
+  tracker is not running — a room left open after the channel was switched off is the failure
+  this exists to prevent, so it must not depend on a display nicety being up.
+
+  The contact's token stays valid until it expires on its own; revoking it is #5768's job. What
+  this guarantees is that no room is still serving messages after the switch, and that every
+  open browser is told why rather than watching a chat go quiet.
+  """
+  @spec close_all(non_neg_integer()) :: :ok
+  def close_all(organization_id),
+    do:
+      Phoenix.PubSub.broadcast(
+        Glific.PubSub,
+        disabled_topic(organization_id),
+        :web_channel_disabled
+      )
+
+  @spec disabled_topic(non_neg_integer()) :: String.t()
+  defp disabled_topic(organization_id), do: "web_channel_disabled:#{organization_id}"
+
   @page_size 100
   @max_body_length 4_096
 
@@ -41,6 +64,7 @@ defmodule GlificWeb.WebChannel.RoomChannel do
       # Its own process, so org context has to be re-established, as in an Oban worker.
       Repo.put_process_state(socket.assigns.organization_id)
       schedule_sweep()
+      Phoenix.PubSub.subscribe(Glific.PubSub, disabled_topic(socket.assigns.organization_id))
 
       # The channel process, not the socket: presence lives under a per-organization topic, and
       # untracks when this process dies.
@@ -66,7 +90,7 @@ defmodule GlificWeb.WebChannel.RoomChannel do
   end
 
   @impl true
-  @spec handle_info(:sweep_token, Phoenix.Socket.t()) ::
+  @spec handle_info(:sweep_token | :web_channel_disabled | atom(), Phoenix.Socket.t()) ::
           {:noreply, Phoenix.Socket.t()} | {:stop, :normal, Phoenix.Socket.t()}
   def handle_info(:sweep_token, socket) do
     now = System.system_time(:second)
@@ -86,6 +110,11 @@ defmodule GlificWeb.WebChannel.RoomChannel do
         schedule_sweep()
         {:noreply, socket}
     end
+  end
+
+  def handle_info(:web_channel_disabled, socket) do
+    push(socket, "web_channel_disabled", %{})
+    {:stop, :normal, socket}
   end
 
   # ConsumerWorkerMock (test env) notifies its caller; swallow rather than crash the channel.

--- a/lib/glific_web/controllers/api/v1/web_channel_controller.ex
+++ b/lib/glific_web/controllers/api/v1/web_channel_controller.ex
@@ -15,26 +15,30 @@ defmodule GlificWeb.API.V1.WebChannelController do
 
   @doc """
   Returns the branding the widget should paint itself with, before its first render.
+
+  200 either way. An organisation with the channel switched off still has a name and a WhatsApp
+  number to send a contact to, and a 404 would leave the widget guessing at both — every other
+  web channel endpoint refuses, but this one is what tells the visitor why.
   """
   @spec branding(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def branding(%Plug.Conn{assigns: %{organization_id: organization_id}} = conn, _params) do
     # organization/1 returns {:error, reason} on a cache or lookup failure, and everything
-    # downstream reads organization.id — so an unlucky lookup would raise on a public endpoint.
+    # downstream reads the organization — so an unlucky lookup would raise on a public endpoint.
     case Partners.organization(organization_id) do
       {:error, _reason} ->
-        not_enabled(conn)
+        not_found(conn)
 
       organization ->
         if Flag.web_channel_enabled?(organization),
           do: json(conn, %{data: Branding.for_organization(organization)}),
-          else: not_enabled(conn)
+          else: json(conn, %{data: Branding.disabled_for_organization(organization)})
     end
   end
 
-  @spec not_enabled(Plug.Conn.t()) :: Plug.Conn.t()
-  defp not_enabled(conn) do
+  @spec not_found(Plug.Conn.t()) :: Plug.Conn.t()
+  defp not_found(conn) do
     conn
     |> put_status(:not_found)
-    |> json(%{error: %{status: 404, message: "Web channel is not enabled."}})
+    |> json(%{error: %{status: 404, message: "Organization not found."}})
   end
 end

--- a/lib/glific_web/controllers/api/v1/web_channel_controller.ex
+++ b/lib/glific_web/controllers/api/v1/web_channel_controller.ex
@@ -10,7 +10,8 @@ defmodule GlificWeb.API.V1.WebChannelController do
 
   use GlificWeb, :controller
 
-  alias Glific.{Flags, Partners, WebChannel.Branding}
+  alias Glific.{Partners, WebChannel.Branding}
+  alias GlificWeb.WebChannel.Flag
 
   @doc """
   Returns the branding the widget should paint itself with, before its first render.
@@ -24,7 +25,7 @@ defmodule GlificWeb.API.V1.WebChannelController do
         not_enabled(conn)
 
       organization ->
-        if Flags.get_flag_enabled(:web_channel_enabled, organization),
+        if Flag.web_channel_enabled?(organization),
           do: json(conn, %{data: Branding.for_organization(organization)}),
           else: not_enabled(conn)
     end

--- a/priv/repo/seeds/20260901120000_add_web_channel_provider.exs
+++ b/priv/repo/seeds/20260901120000_add_web_channel_provider.exs
@@ -10,8 +10,7 @@ defmodule Glific.Repo.Seeds.AddWebChannelProvider do
 
   alias Glific.{
     Partners.Provider,
-    Repo,
-    WebChannel.Branding
+    Repo
   }
 
   envs([:dev, :test, :prod])
@@ -40,7 +39,7 @@ defmodule Glific.Repo.Seeds.AddWebChannelProvider do
           group: nil,
           is_required: false,
           # `position` drives field order on the Settings page; jsonb hands the keys back
-          # sorted by length, which would otherwise put Theme first.
+          # sorted by length, which bears no relation to the order an admin reads them in.
           keys: %{
             display_name: %{
               type: :string,
@@ -60,14 +59,6 @@ defmodule Glific.Repo.Seeds.AddWebChannelProvider do
               accept: "image/png,image/jpeg,image/webp,image/svg+xml",
               helper_text:
                 "Upload a PNG, JPEG, WEBP or SVG up to 200KB, or paste an https URL you host. Landscape works best."
-            },
-            theme: %{
-              type: :select,
-              label: "Theme",
-              default: Branding.default_theme(),
-              view_only: false,
-              position: 3,
-              options: Branding.themes()
             }
           },
           secrets: %{}

--- a/priv/repo/seeds/20260911120000_update_web_channel_provider_branding.exs
+++ b/priv/repo/seeds/20260911120000_update_web_channel_provider_branding.exs
@@ -1,0 +1,112 @@
+defmodule Glific.Repo.Seeds.UpdateWebChannelProviderBranding do
+  @moduledoc """
+  Replaces the web channel provider's named-theme key with the two brand colours the Settings
+  page now asks for, and adds the business profile contacts open from the chat menu.
+  """
+
+  use Glific.Seeds.Seed
+
+  alias Glific.{
+    Partners.Provider,
+    Repo,
+    WebChannel.Branding
+  }
+
+  envs([:dev, :test, :prod])
+
+  tags([:web_channel])
+
+  @doc """
+  Rewrites the web channel provider's keys.
+  """
+  @spec up(Ecto.Repo.t(), Keyword.t()) :: any()
+  def up(_repo, _opts) do
+    case Repo.fetch_by(Provider, %{shortcode: "web_channel"}) do
+      {:ok, provider} ->
+        provider
+        |> Ecto.Changeset.change(%{keys: keys()})
+        |> Repo.update!()
+
+      _not_seeded ->
+        :ok
+    end
+  end
+
+  # `position` drives field order on the Settings page; jsonb hands the keys back sorted by
+  # length, which bears no relation to the order an admin reads them in.
+  @spec keys() :: map()
+  defp keys do
+    %{
+      logo_url: %{
+        type: :upload,
+        label: "Display picture",
+        default: nil,
+        view_only: false,
+        position: 1,
+        max_size_kb: 2048,
+        upload_folder: "org_logo",
+        accept: "image/png,image/jpeg",
+        helper_text:
+          "PNG or JPG, square (1:1) and shown as a circle. 512x512 recommended, 128x128 minimum, 2MB maximum."
+      },
+      display_name: %{
+        type: :string,
+        label: "Display name",
+        default: nil,
+        view_only: false,
+        position: 2,
+        helper_text:
+          "The organisation name contacts see in the chat header and on the sign-in page."
+      },
+      primary_color: %{
+        type: :color,
+        label: "Primary",
+        default: Branding.default_primary(),
+        view_only: false,
+        position: 3
+      },
+      secondary_color: %{
+        type: :color,
+        label: "Secondary",
+        default: Branding.default_secondary(),
+        view_only: false,
+        position: 4
+      },
+      about_description: %{
+        type: :text,
+        label: "Description",
+        default: nil,
+        view_only: false,
+        position: 5
+      },
+      about_address: %{
+        type: :string,
+        label: "Address",
+        default: nil,
+        view_only: false,
+        position: 6
+      },
+      about_website: %{
+        type: :string,
+        label: "Website",
+        default: nil,
+        view_only: false,
+        position: 7
+      },
+      about_email: %{
+        type: :string,
+        label: "Contact email",
+        default: nil,
+        view_only: false,
+        position: 8
+      },
+      about_hours: %{
+        type: :string,
+        label: "Hours",
+        default: nil,
+        view_only: false,
+        position: 9
+      }
+    }
+  end
+end

--- a/test/glific/web_channel/branding_test.exs
+++ b/test/glific/web_channel/branding_test.exs
@@ -45,6 +45,7 @@ defmodule Glific.WebChannel.BrandingTest do
         |> Branding.for_organization()
 
       assert branding == %{
+               enabled: true,
                display_name: "Example NGO",
                logo_url: "https://cdn.example.org/logo.png",
                primary_color: "#4c3bcf",
@@ -134,5 +135,30 @@ defmodule Glific.WebChannel.BrandingTest do
       end)
 
     0.2126 * r + 0.7152 * g + 0.0722 * b
+  end
+
+  describe "disabled_for_organization/1" do
+    test "answers with the name and number a contact can reach the organization on instead" do
+      organization = %Organization{
+        name: "NGO Name",
+        contact: %Glific.Contacts.Contact{phone: "919876543210"},
+        services: %{}
+      }
+
+      assert Branding.disabled_for_organization(organization) == %{
+               enabled: false,
+               display_name: "NGO Name",
+               whatsapp_number: "919876543210"
+             }
+    end
+
+    # `contact` is preloaded on the cached organization, but a caller holding a bare struct is
+    # not a reason for a public endpoint to raise.
+    test "leaves the number out rather than raising when the contact is not loaded" do
+      branding = %Organization{name: "NGO Name"} |> Branding.disabled_for_organization()
+
+      assert branding.whatsapp_number == nil
+      assert branding.display_name == "NGO Name"
+    end
   end
 end

--- a/test/glific/web_channel/branding_test.exs
+++ b/test/glific/web_channel/branding_test.exs
@@ -9,95 +9,130 @@ defmodule Glific.WebChannel.BrandingTest do
   defp organization(keys),
     do: %Organization{name: "NGO Name", services: %{"web_channel" => %{keys: keys, secrets: %{}}}}
 
-  describe "themes/0" do
-    test "every theme has an id and a label the Settings dropdown can render" do
-      for theme <- Branding.themes() do
-        assert is_binary(theme.id) and theme.id != ""
-        assert is_binary(theme.label) and theme.label != ""
+  describe "readable_on/1" do
+    test "flips to dark text on a light primary and light text on a dark one" do
+      assert Branding.readable_on("#ffffff") == Branding.readable_on("#ffb900")
+      refute Branding.readable_on("#ffffff") == Branding.readable_on("#18181b")
+    end
+
+    test "clears WCAG AA against the colour it was chosen for" do
+      for primary <- ["#ffffff", "#000000", "#4c3bcf", "#ffb900", "#ff6900", "#008236"] do
+        assert contrast(primary, Branding.readable_on(primary)) >= 4.5,
+               "#{primary} is unreadable under #{Branding.readable_on(primary)}"
       end
     end
 
-    test "every theme carries a swatch the Settings dropdown can render" do
-      for theme <- Branding.themes() do
-        # Display only — the widget owns the real palette — but it must be a colour the
-        # browser will accept, or the picker silently shows nothing.
-        assert theme.swatch =~ ~r/^#[0-9a-f]{6}$/
-        assert is_binary(theme.shade) and theme.shade != ""
-      end
-    end
-
-    test "swatches are distinct, so two themes never look the same in the picker" do
-      swatches = Enum.map(Branding.themes(), & &1.swatch)
-      assert swatches == Enum.uniq(swatches)
-    end
-
-    test "ids are unique, so a choice resolves to exactly one palette" do
-      ids = Enum.map(Branding.themes(), & &1.id)
-      assert ids == Enum.uniq(ids)
-    end
-
-    test "the default is one of the offered themes" do
-      assert Enum.any?(Branding.themes(), &(&1.id == Branding.default_theme()))
+    test "falls back rather than raising on a colour it cannot parse" do
+      assert Branding.readable_on("not a colour") ==
+               Branding.readable_on(Branding.default_primary())
     end
   end
 
   describe "for_organization/1" do
-    test "reads the organization's branding off its web credential" do
-      theme =
+    test "reads the organization's branding off its web channel credential" do
+      branding =
         organization(%{
-          "theme" => "violet",
-          "logo_url" => "https://cdn.example.org/logo.svg",
-          "display_name" => "Example NGO"
+          "display_name" => "Example NGO",
+          "logo_url" => "https://cdn.example.org/logo.png",
+          "primary_color" => "#4C3BCF",
+          "secondary_color" => "#FF8A3D",
+          "about_description" => "We run skill-building journeys.",
+          "about_address" => "Mumbai, Maharashtra",
+          "about_website" => "example.org",
+          "about_email" => "support@example.org",
+          "about_hours" => "Mon-Sat, 9am-7pm IST"
         })
         |> Branding.for_organization()
 
-      assert theme == %{
-               theme: "violet",
-               logo_url: "https://cdn.example.org/logo.svg",
-               display_name: "Example NGO"
+      assert branding == %{
+               display_name: "Example NGO",
+               logo_url: "https://cdn.example.org/logo.png",
+               primary_color: "#4c3bcf",
+               primary_foreground: Branding.readable_on("#4c3bcf"),
+               secondary_color: "#ff8a3d",
+               about: %{
+                 description: "We run skill-building journeys.",
+                 address: "Mumbai, Maharashtra",
+                 website: "https://example.org",
+                 email: "support@example.org",
+                 hours: "Mon-Sat, 9am-7pm IST"
+               }
              }
     end
 
-    test "every offered theme survives a round trip" do
-      for %{id: id} <- Branding.themes() do
-        assert %{theme: ^id} = Branding.for_organization(organization(%{"theme" => id}))
-      end
+    test "falls back to the organization's own name and the default palette" do
+      branding = %{} |> organization() |> Branding.for_organization()
+
+      assert branding.display_name == "NGO Name"
+      assert branding.logo_url == nil
+      assert branding.primary_color == Branding.default_primary()
+      assert branding.secondary_color == Branding.default_secondary()
+
+      assert branding.about == %{
+               description: nil,
+               address: nil,
+               website: nil,
+               email: nil,
+               hours: nil
+             }
     end
 
-    test "falls back to the organization name when there is no credential" do
-      theme = Branding.for_organization(%Organization{name: "NGO Name", services: %{}})
+    test "falls back when the organization has no web channel credential at all" do
+      branding = %Organization{name: "NGO Name", services: %{}} |> Branding.for_organization()
 
-      assert theme == %{theme: Branding.default_theme(), logo_url: nil, display_name: "NGO Name"}
+      assert branding.display_name == "NGO Name"
+      assert branding.primary_color == Branding.default_primary()
     end
 
-    test "falls back to the organization name when the display name is blank" do
-      assert %{display_name: "NGO Name"} =
-               Branding.for_organization(organization(%{"display_name" => "   "}))
-    end
-
-    test "falls back to the default theme when the name is not one we offer" do
-      for name <- ["chartreuse", "#ffe600", "", nil, 42] do
-        assert %{theme: "zinc"} = Branding.for_organization(organization(%{"theme" => name}))
-      end
-    end
-
-    test "accepts a theme name whatever its casing or padding" do
-      assert %{theme: "violet"} =
-               Branding.for_organization(organization(%{"theme" => "  Violet  "}))
-    end
-
-    test "drops a logo url that is not served over https" do
-      for url <- ["http://cdn.example.org/logo.svg", "javascript:alert(1)", "logo.svg", nil] do
-        assert %{logo_url: nil} = Branding.for_organization(organization(%{"logo_url" => url}))
-      end
-    end
-
-    test "trims surrounding whitespace before validating" do
-      theme =
-        organization(%{"logo_url" => "  https://cdn.example.org/logo.svg  "})
+    test "expands a three digit colour and ignores one it cannot parse" do
+      branding =
+        organization(%{"primary_color" => "#ABC", "secondary_color" => "rebeccapurple"})
         |> Branding.for_organization()
 
-      assert theme.logo_url == "https://cdn.example.org/logo.svg"
+      assert branding.primary_color == "#aabbcc"
+      assert branding.secondary_color == Branding.default_secondary()
     end
+
+    test "treats whitespace-only values as unset" do
+      branding =
+        organization(%{"display_name" => "   ", "about_address" => "  "})
+        |> Branding.for_organization()
+
+      assert branding.display_name == "NGO Name"
+      assert branding.about.address == nil
+    end
+
+    test "leaves a website that already carries a scheme alone" do
+      branding =
+        organization(%{"about_website" => "http://example.org/about"})
+        |> Branding.for_organization()
+
+      assert branding.about.website == "http://example.org/about"
+    end
+
+    test "refuses a logo that is not served over https" do
+      branding =
+        organization(%{"logo_url" => "http://cdn.example.org/logo.png"})
+        |> Branding.for_organization()
+
+      assert branding.logo_url == nil
+    end
+  end
+
+  @spec contrast(String.t(), String.t()) :: float()
+  defp contrast(first, second) do
+    [first, second] = Enum.map([first, second], &luminance/1)
+    (max(first, second) + 0.05) / (min(first, second) + 0.05)
+  end
+
+  @spec luminance(String.t()) :: float()
+  defp luminance(<<?#, r::binary-size(2), g::binary-size(2), b::binary-size(2)>>) do
+    [r, g, b] =
+      Enum.map([r, g, b], fn hex ->
+        value = String.to_integer(hex, 16) / 255
+        if value <= 0.03928, do: value / 12.92, else: :math.pow((value + 0.055) / 1.055, 2.4)
+      end)
+
+    0.2126 * r + 0.7152 * g + 0.0722 * b
   end
 end

--- a/test/glific/web_channel/branding_test.exs
+++ b/test/glific/web_channel/branding_test.exs
@@ -16,7 +16,7 @@ defmodule Glific.WebChannel.BrandingTest do
     end
 
     test "clears WCAG AA against the colour it was chosen for" do
-      for primary <- ["#ffffff", "#000000", "#4c3bcf", "#ffb900", "#ff6900", "#008236"] do
+      for primary <- ["#ffffff", "#000000", "#119656", "#eab308", "#ff6900", "#4c3bcf"] do
         assert contrast(primary, Branding.readable_on(primary)) >= 4.5,
                "#{primary} is unreadable under #{Branding.readable_on(primary)}"
       end

--- a/test/glific_web/channels/web_channel/room_channel_test.exs
+++ b/test/glific_web/channels/web_channel/room_channel_test.exs
@@ -7,6 +7,7 @@ defmodule GlificWeb.WebChannel.RoomChannelTest do
     Fixtures,
     GcsFixtures,
     Messages.Message,
+    Partners,
     Repo,
     WebChannelFixtures
   }
@@ -115,6 +116,42 @@ defmodule GlificWeb.WebChannel.RoomChannelTest do
 
         assert {:error, %{reason: "unauthorized"}} =
                  WebChannelFixtures.join_web_channel(expired_socket, contact)
+      end)
+    end
+  end
+
+  describe "switching the web channel off" do
+    test "closes an open room and tells the browser why", %{contact: contact} do
+      with_web_channel_enabled(fn ->
+        {:ok, ws_socket} = WebChannelFixtures.web_channel_socket_fixture(contact)
+        {:ok, _reply, socket} = WebChannelFixtures.join_web_channel(ws_socket, contact)
+        monitor = Process.monitor(socket.channel_pid)
+
+        {:ok, credential} =
+          Partners.get_credential(%{
+            organization_id: contact.organization_id,
+            shortcode: "web_channel"
+          })
+
+        Partners.update_credential(credential, %{is_active: false})
+
+        # The message first, so an open browser is told why rather than watching the chat go
+        # quiet, and only then the room.
+        assert_push("web_channel_disabled", %{})
+        assert_receive {:DOWN, ^monitor, :process, _pid, :normal}
+      end)
+    end
+
+    test "leaves an organization's rooms alone when another one switches off", %{
+      contact: contact
+    } do
+      with_web_channel_enabled(fn ->
+        {:ok, ws_socket} = WebChannelFixtures.web_channel_socket_fixture(contact)
+        {:ok, _reply, _socket} = WebChannelFixtures.join_web_channel(ws_socket, contact)
+
+        RoomChannel.close_all(contact.organization_id + 1)
+
+        refute_push("web_channel_disabled", %{})
       end)
     end
   end

--- a/test/glific_web/channels/web_channel_socket_test.exs
+++ b/test/glific_web/channels/web_channel_socket_test.exs
@@ -77,6 +77,10 @@ defmodule GlificWeb.WebChannelSocketTest do
          %{contact: contact} do
       organization_id = contact.organization_id
 
+      # The organization's own half of the switch is already on and cached; this test is about
+      # the flag alone.
+      Glific.WebChannelFlagHelpers.activate_web_channel(organization_id)
+
       # Confirm the cached field really is stale before proving the socket ignores it.
       cached = Partners.organization(organization_id)
       assert cached.web_channel_enabled == false

--- a/test/glific_web/controllers/api/v1/web_channel_auth_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/web_channel_auth_controller_test.exs
@@ -238,7 +238,9 @@ defmodule GlificWeb.API.V1.WebChannelAuthControllerTest do
 
     test "takes effect without refilling the organization cache", %{conn: conn} do
       # Not using with_web_channel_enabled/1: it refills the cache, the step being asserted as
-      # unnecessary.
+      # unnecessary. The organization's own half of the switch is on and cached already; this
+      # test is about the flag alone.
+      Glific.WebChannelFlagHelpers.activate_web_channel(1)
       Partners.organization(1) |> Partners.fill_cache()
       assert Partners.organization(1).web_channel_enabled == false
 

--- a/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
@@ -43,16 +43,21 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
       enable_web_channel(organization_id)
 
       add_branding(organization_id, %{
-        theme: "violet",
-        logo_url: "https://cdn.example.org/logo.svg",
-        display_name: "Example NGO"
+        primary_color: "#4C3BCF",
+        secondary_color: "#FF8A3D",
+        logo_url: "https://cdn.example.org/logo.png",
+        display_name: "Example NGO",
+        about_website: "example.org"
       })
 
       assert %{
                "data" => %{
-                 "theme" => "violet",
-                 "logo_url" => "https://cdn.example.org/logo.svg",
-                 "display_name" => "Example NGO"
+                 "primary_color" => "#4c3bcf",
+                 "primary_foreground" => _foreground,
+                 "secondary_color" => "#ff8a3d",
+                 "logo_url" => "https://cdn.example.org/logo.png",
+                 "display_name" => "Example NGO",
+                 "about" => %{"website" => "https://example.org"}
                }
              } = conn |> get(@branding_path) |> json_response(200)
     end
@@ -66,9 +71,18 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
 
       assert %{
                "data" => %{
-                 "theme" => Branding.default_theme(),
+                 "primary_color" => Branding.default_primary(),
+                 "primary_foreground" => Branding.readable_on(Branding.default_primary()),
+                 "secondary_color" => Branding.default_secondary(),
                  "logo_url" => nil,
-                 "display_name" => organization.name
+                 "display_name" => organization.name,
+                 "about" => %{
+                   "description" => nil,
+                   "address" => nil,
+                   "website" => nil,
+                   "email" => nil,
+                   "hours" => nil
+                 }
                }
              } == conn |> get(@branding_path) |> json_response(200)
     end
@@ -80,12 +94,14 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
       enable_web_channel(organization_id)
 
       add_branding(organization_id, %{
-        theme: "red; background: url(evil)",
-        logo_url: "http://cdn.example.org/logo.svg"
+        primary_color: "red; background: url(evil)",
+        logo_url: "http://cdn.example.org/logo.png"
       })
 
-      assert %{"data" => %{"theme" => "zinc", "logo_url" => nil}} =
+      assert %{"data" => %{"primary_color" => primary, "logo_url" => nil}} =
                conn |> get(@branding_path) |> json_response(200)
+
+      assert primary == Branding.default_primary()
     end
 
     test "returns 404 rather than raising when the organization cannot be loaded", %{conn: conn} do
@@ -104,16 +120,16 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
 
     test "resolves the organization from the request host", %{organization_id: organization_id} do
       enable_web_channel(organization_id)
-      add_branding(organization_id, %{theme: "violet", display_name: "First NGO"})
+      add_branding(organization_id, %{primary_color: "#4c3bcf", display_name: "First NGO"})
 
       other = Fixtures.organization_fixture(%{shortcode: "other_ngo", name: "Second NGO"})
       enable_web_channel(other.id)
-      add_branding(other.id, %{theme: "amber", display_name: "Second NGO"})
+      add_branding(other.id, %{primary_color: "#ffb900", display_name: "Second NGO"})
 
-      assert %{"data" => %{"theme" => "violet", "display_name" => "First NGO"}} =
+      assert %{"data" => %{"primary_color" => "#4c3bcf", "display_name" => "First NGO"}} =
                "glific.glific.test" |> branding_for_host() |> json_response(200)
 
-      assert %{"data" => %{"theme" => "amber", "display_name" => "Second NGO"}} =
+      assert %{"data" => %{"primary_color" => "#ffb900", "display_name" => "Second NGO"}} =
                "other_ngo.glific.test" |> branding_for_host() |> json_response(200)
     end
   end

--- a/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
@@ -73,6 +73,7 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
 
       assert %{
                "data" => %{
+                 "enabled" => true,
                  "primary_color" => Branding.default_primary(),
                  "primary_foreground" => Branding.readable_on(Branding.default_primary()),
                  "secondary_color" => Branding.default_secondary(),
@@ -108,31 +109,48 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
 
     test "returns 404 rather than raising when the organization cannot be loaded", %{conn: conn} do
       # organization/1 returns {:error, _} on a cache or lookup failure, and everything
-      # downstream reads organization.id. This is a public endpoint, so it must not 500.
+      # downstream reads the organization. This is a public endpoint, so it must not 500.
       with_mock Partners, [:passthrough], organization: fn _id -> {:error, "cache miss"} end do
         assert %{"error" => %{"status" => 404}} =
                  conn |> get(@branding_path) |> json_response(404)
       end
     end
 
-    test "returns 404 for an organization without the feature flag", %{conn: conn} do
-      assert %{"error" => %{"status" => 404, "message" => "Web channel is not enabled."}} =
-               conn |> get(@branding_path) |> json_response(404)
+    # 200, not 404: the widget still has a page to render, and it needs the organization's name
+    # and WhatsApp number to render it.
+    test "answers with the organization's name and WhatsApp number when the flag is off", %{
+      conn: conn,
+      organization_id: organization_id
+    } do
+      organization = Partners.organization(organization_id)
+
+      assert %{
+               "data" => %{
+                 "enabled" => false,
+                 "display_name" => display_name,
+                 "whatsapp_number" => whatsapp_number
+               }
+             } = conn |> get(@branding_path) |> json_response(200)
+
+      assert display_name == organization.name
+      assert whatsapp_number == organization.contact.phone
     end
 
     # The flag is Glific's half of the switch. An organization that has been granted the feature
-    # and then switched it off in Settings must be just as unreachable.
-    test "returns 404 once the organization switches the channel off", %{
+    # and then switched it off in Settings must read as just as off.
+    test "reports the channel as off once the organization switches it off", %{
       conn: conn,
       organization_id: organization_id
     } do
       enable_web_channel(organization_id)
-      assert %{"data" => _branding} = conn |> get(@branding_path) |> json_response(200)
+      assert %{"data" => %{"enabled" => true}} = conn |> get(@branding_path) |> json_response(200)
 
       deactivate_web_channel(organization_id)
 
-      assert %{"error" => %{"status" => 404, "message" => "Web channel is not enabled."}} =
-               conn |> get(@branding_path) |> json_response(404)
+      assert %{"data" => %{"enabled" => false, "whatsapp_number" => number}} =
+               conn |> get(@branding_path) |> json_response(200)
+
+      assert is_binary(number)
     end
 
     test "resolves the organization from the request host", %{organization_id: organization_id} do

--- a/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
+++ b/test/glific_web/controllers/api/v1/web_channel_controller_test.exs
@@ -8,6 +8,8 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
   alias FunWithFlags.Store.Cache, as: FlagCache
   alias Glific.{Fixtures, Partners, WebChannel.Branding}
 
+  import Glific.WebChannelFlagHelpers, only: [activate_web_channel: 1, activate_web_channel: 2]
+
   @branding_path "/api/v1/web_channel/branding"
 
   # FunWithFlags persists through Ecto but reads through a 15-minute cache, and only the Ecto
@@ -18,20 +20,20 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
     :ok
   end
 
-  defp enable_web_channel(organization_id),
-    do: FunWithFlags.enable(:web_channel_enabled, for_actor: %{organization_id: organization_id})
+  # Both halves of the switch: the Glific flag, and the organization's own active credential.
+  defp enable_web_channel(organization_id) do
+    FunWithFlags.enable(:web_channel_enabled, for_actor: %{organization_id: organization_id})
+    activate_web_channel(organization_id)
+  end
 
-  defp add_branding(organization_id, keys) do
-    {:ok, _credential} =
-      Partners.create_credential(%{
-        organization_id: organization_id,
-        shortcode: "web_channel",
-        keys: keys,
-        secrets: %{},
-        is_active: true
-      })
+  defp add_branding(organization_id, keys), do: activate_web_channel(organization_id, keys)
 
-    organization_id |> Partners.get_organization!() |> Partners.fill_cache()
+  defp deactivate_web_channel(organization_id) do
+    {:ok, credential} =
+      Partners.get_credential(%{organization_id: organization_id, shortcode: "web_channel"})
+
+    Partners.update_credential(credential, %{is_active: false})
+    organization_id |> Partners.organization() |> Partners.fill_cache()
     :ok
   end
 
@@ -114,6 +116,21 @@ defmodule GlificWeb.API.V1.WebChannelControllerTest do
     end
 
     test "returns 404 for an organization without the feature flag", %{conn: conn} do
+      assert %{"error" => %{"status" => 404, "message" => "Web channel is not enabled."}} =
+               conn |> get(@branding_path) |> json_response(404)
+    end
+
+    # The flag is Glific's half of the switch. An organization that has been granted the feature
+    # and then switched it off in Settings must be just as unreachable.
+    test "returns 404 once the organization switches the channel off", %{
+      conn: conn,
+      organization_id: organization_id
+    } do
+      enable_web_channel(organization_id)
+      assert %{"data" => _branding} = conn |> get(@branding_path) |> json_response(200)
+
+      deactivate_web_channel(organization_id)
+
       assert %{"error" => %{"status" => 404, "message" => "Web channel is not enabled."}} =
                conn |> get(@branding_path) |> json_response(404)
     end

--- a/test/support/web_channel_flag_helpers.ex
+++ b/test/support/web_channel_flag_helpers.ex
@@ -10,6 +10,8 @@ defmodule Glific.WebChannelFlagHelpers do
   alias FunWithFlags.Store.Cache
   alias Glific.Partners
 
+  @shortcode "web_channel"
+
   @doc """
   Disables `:web_channel_enabled` for `organization_id` and refills the org cache.
   """
@@ -21,6 +23,31 @@ defmodule Glific.WebChannelFlagHelpers do
     :ok
   end
 
+  @doc """
+  Gives the organization an active `web_channel` credential, the organization's own half of the
+  switch — without it the channel is off however the flag is set. Upserts, so a test may call it
+  again to set the branding keys.
+  """
+  @spec activate_web_channel(non_neg_integer(), map()) :: :ok
+  def activate_web_channel(organization_id \\ 1, keys \\ %{}) do
+    case Partners.get_credential(%{organization_id: organization_id, shortcode: @shortcode}) do
+      {:ok, credential} ->
+        Partners.update_credential(credential, %{keys: keys, is_active: true})
+
+      _not_yet ->
+        Partners.create_credential(%{
+          organization_id: organization_id,
+          shortcode: @shortcode,
+          keys: keys,
+          secrets: %{},
+          is_active: true
+        })
+    end
+
+    organization_id |> Partners.organization() |> Partners.fill_cache()
+    :ok
+  end
+
   # try/after rather than on_exit: the flag write needs the process owning this test's sandbox
   # connection, and on_exit runs after that process has gone.
   @doc """
@@ -28,6 +55,7 @@ defmodule Glific.WebChannelFlagHelpers do
   """
   @spec with_web_channel_enabled(non_neg_integer(), (-> any())) :: any()
   def with_web_channel_enabled(organization_id \\ 1, fun) do
+    activate_web_channel(organization_id)
     FunWithFlags.enable(:web_channel_enabled, for_actor: %{organization_id: organization_id})
     organization_id |> Partners.organization() |> Partners.fill_cache()
 


### PR DESCRIPTION
Part of #5711. The backend half: what an organisation configures for its web channel, and what
switching it off actually does.

## Branding is two colours, not a named theme

#5711's design lets an organisation pick its own primary and secondary colour, replacing the
named-theme dropdown. Named themes existed to guarantee the widget stayed readable — an
organisation chose a name and the widget owned the palette, so nobody could put grey text on a
yellow header. Free colours keep that guarantee by **computing** it instead of constraining it:
`Branding.readable_on/1` takes the primary's WCAG relative luminance and returns whichever of the
widget's two neutrals contrasts with it more, and the test asserts the pair clears AA (4.5:1) at
both extremes. That is the same promise the Settings form makes to the admin in words, which is
why it lives in one place rather than two.

Everything an admin types is normalised rather than trusted: colours lower-cased, three-digit hex
expanded, anything unparseable falls back to the default rather than reaching a browser as a CSS
value, and a website typed without a scheme gets `https://` so the widget's link does not resolve
against its own host.

The business profile — description, address, website, contact email, hours — is the web
equivalent of a WhatsApp business profile, and rides the same credential.

## Two switches, and both have to be on

`GlificWeb.WebChannel.Flag` is now the one place both are read, for every surface: branding, the
three OTP endpoints, the socket and media upload.

- **`:web_channel_enabled`** is Glific's — may this organisation have the feature at all. A Glific
  admin flips it at `/feature-flags`.
- **An active `web_channel` credential** is the organisation's own, flipped on the Settings page.

Only the first was checked before, so an organisation granted the feature but configured with
nothing was already reachable in a browser, serving Glific's default branding under its own domain
to anyone who found the address. The branding endpoint was also reading the flag directly; it goes
through `Flag` like everything else, so there is one answer to "is the web channel on" rather than
two that can drift.

⚠️ **This changes behaviour for existing environments.** Any organisation with the flag on that has
never saved the Settings page now has no web channel — that includes staging. One save each fixes
it. Say the word if you would rather have a `Glific.Scripts.*` backfill that activates a credential
for every organisation already carrying the flag, which would make the deploy a no-op.

## Switching it off reaches open browsers

A contact already in a conversation holds a valid token and a socket that would otherwise keep
serving messages. Every room subscribes to a per-organisation topic at join, and
`RoomChannel.close_all/1` — called from the credential update callback — pushes
`web_channel_disabled` and stops the room. The push comes first, so an open browser is told why
rather than watching the chat go quiet.

A per-organisation PubSub topic rather than `Presence`, whose own moduledoc says it degrades to an
empty list when its tracker is down: a room still serving messages after the switch is the exact
failure this prevents.

The contact's token stays valid until it expires on its own — expiring it on deactivation is its
own ticket. What this guarantees is that nothing reconnects and no room keeps serving.

## Branding answers 200 either way

A 404 left the widget with nothing to say. An organisation with the channel off still has a name
and a WhatsApp number to send a contact to, so branding carries `enabled` and returns 200 in both
cases. Every other web channel endpoint still refuses — this is the one that exists to tell the
visitor why. The name comes from the organisation record rather than the credential, because an
organisation that never configured the channel has no credential to take a display name from. The
only remaining 404 is a genuine lookup failure, and it says so.

## Notes for the reviewer

- The provider row's keys are rewritten by a **new seed** rather than by editing the one that
  created it, since that seed has already run.
- Defaults are Glific's own green and amber, kept in step with `FALLBACK_BRANDING` in the widget.
- The test helper grew `activate_web_channel/2`, since "the web channel is on" now means both
  halves. The two #5662 tests that prove the flag is read live rather than off the cached
  organisation activate the credential first, so they still test only the flag.

**Out of scope, deliberately:** the per-org signing key, the favicon, the media bucket and the live
preview — all #5711, none of them in the design mock this was built from.

## Companion PRs

- glific-frontend: the Settings page
- glific-web-channel: the contact-facing screens

## Tests

`mix test test/glific/web_channel test/glific_web/channels test/glific_web/controllers/api/v1` —
142 tests, 0 failures. Credo `--strict` and `mix format --check-formatted` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015JqHf9PqoGCW27fcNbQnnT